### PR TITLE
feat: Enable Automatic Releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   # Job 1: Detect changed crates and create release PRs
   detect-and-release:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -24,6 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          lfs: false
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -34,9 +35,6 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-workspaces
-        run: cargo install cargo-workspaces
 
       - name: Detect changed crates
         id: detect-changes
@@ -52,68 +50,43 @@ jobs:
           
           for crate_toml in $CRATES; do
             CRATE_DIR=$(dirname "$crate_toml")
-            CRATE_NAME=$(cargo metadata --no-deps --manifest-path "$crate_toml" --format-version 1 | jq -r '.packages[0].name')
+            CRATE_NAME=$(
+              cargo metadata --format-version 1 --no-deps | jq -r \
+                 --arg path "$(realpath $crate_toml)" \
+                 '.packages[] | select(.manifest_path | startswith($path)) | .name'
+            )
           
             # Check if there are changes in this crate since last tag
             if [ -z "$LAST_TAG" ] || git diff --name-only "$LAST_TAG"..HEAD | grep -q "^${CRATE_DIR#./}"; then
               echo "Changes detected in crate: $CRATE_NAME at $CRATE_DIR"
           
-              # Create git-cliff config for this specific crate
-              cat > "$CRATE_DIR/cliff.toml" << 'EOF'
-          [changelog]
-          header = """
-          # Changelog
-          All notable changes to this project will be documented in this file.
-          """
-          body = """
-          {% if version %}\
-              ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
-          {% else %}\
-              ## [unreleased]
-          {% endif %}\
-          {% for group, commits in commits | group_by(attribute="group") %}
-              ### {{ group | striptags | trim | upper_first }}
-              {% for commit in commits %}
-                  - {% if commit.scope %}**{{commit.scope}}**: {% endif %}{{ commit.message | upper_first }}\
-              {% endfor %}
-          {% endfor %}\n
-          """
-          trim = true
-          
-          [git]
-          conventional_commits = true
-          filter_unconventional = true
-          commit_parsers = [
-              { message = "^feat", group = "Features" },
-              { message = "^fix", group = "Bug Fixes" },
-              { message = "^doc", group = "Documentation" },
-              { message = "^perf", group = "Performance" },
-              { message = "^refactor", group = "Refactor" },
-              { message = "^style", group = "Styling" },
-              { message = "^test", group = "Testing" },
-              { message = "^chore\\(release\\): prepare for", skip = true },
-              { message = "^chore", group = "Miscellaneous Tasks" },
-              { body = ".*security", group = "Security" },
-          ]
-          tag_pattern = "${CRATE_NAME}-v[0-9]*"
-          EOF
-          
               # Get next version for this crate
               cd "$CRATE_DIR"
-              NEXT_VERSION=$(git-cliff --bumped-version 2>/dev/null || echo "0.1.0")
-              cd - > /dev/null
+              CLIFF_VERSION=$(git-cliff --bumped-version 2>/dev/null)
+              SUGGESTED_NEXT_VERSION="${CLIFF_VERSION##*-v}"
+              NEXT_VERSION="${SUGGESTED_NEXT_VERSION:-0.1.0}"
           
+              cd - > /dev/null
               CHANGED_CRATES+=("{\"name\":\"$CRATE_NAME\",\"path\":\"$CRATE_DIR\",\"version\":\"$NEXT_VERSION\"}")
             fi
           done
           
           # Create JSON matrix for parallel processing
           if [ ${#CHANGED_CRATES[@]} -gt 0 ]; then
-            MATRIX_JSON=$(printf '%s\n' "${CHANGED_CRATES[@]}" | jq -s '{"include": .}')
+            # Debug: log the raw crate objects
+            echo "DEBUG: Raw crate objects:"
+            printf '%s\n' "${CHANGED_CRATES[@]}"
+          
+            # Create the matrix JSON by combining all crate objects into an array
+            printf '%s\n' "${CHANGED_CRATES[@]}" | jq -s . > /tmp/crates.json
+          
+            MATRIX_JSON=$(jq -c '{"include": .}' /tmp/crates.json)
+            echo "$MATRIX_JSON"
+          
             echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
             echo "Found ${#CHANGED_CRATES[@]} crates with changes"
           else
-            echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
+            echo 'matrix={"include":[]}' >> $GITHUB_OUTPUT
             echo "No crates with changes found"
           fi
 
@@ -125,6 +98,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     strategy:
       matrix: ${{ fromJson(needs.detect-and-release.outputs.matrix) }}
       fail-fast: false
@@ -132,6 +106,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          lfs: false
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -147,8 +122,8 @@ jobs:
         working-directory: ${{ matrix.path }}
         run: |
           # Generate changelog
-          git-cliff --tag "${{ matrix.name }}-v${{ matrix.version }}" > CHANGELOG.md
-          git-cliff --unreleased --strip header > UNRELEASED.md
+          git-cliff --unreleased --bump --tag "${{ matrix.name }}-v${{ matrix.version }}" --prepend CHANGELOG.md
+          git-cliff --unreleased --strip all > UNRELEASED.md
           
           # Update Cargo.toml version
           sed -i 's/^version = ".*"/version = "${{ matrix.version }}"/' Cargo.toml
@@ -159,47 +134,60 @@ jobs:
 
       - name: Dry run crates.io publish
         working-directory: ${{ matrix.path }}
-        run: cargo publish --dry-run
+        run: cargo publish --dry-run --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Create release branch and commit
         run: |
+          # Set branch name
           BRANCH_NAME="release/${{ matrix.name }}-v${{ matrix.version }}"
+          
+          # Configure Bot User
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH_NAME"
+          
+          # Add modifications
           git add "${{ matrix.path }}/Cargo.toml" "${{ matrix.path }}/CHANGELOG.md"
           git commit -m "chore(${{ matrix.name }}): release v${{ matrix.version }}"
-          git push origin "$BRANCH_NAME"
+          echo "Added modifications to toml and changelog"
+
+      - name: Generate Changelog Message
+        id: changelog_message
+        run: |
+          # Generate Changelog Output
+          echo "content<<EOF" >> $GITHUB_OUTPUT
+          cat ${{ matrix.path }}/UNRELEASED.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+          # Remove UNRELEASED file after we've generated the changelog
+          rm ${{ matrix.path }}/UNRELEASED.md
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(release): prepare for v${{ matrix.version }} of ${{ matrix.name }}'
+          base: ${{ github.event.repository.default_branch || 'main' }}
+          delete-branch: 'false' # Don't delete version branches
           branch: release/${{ matrix.name }}-v${{ matrix.version }}
-          title: "🚀 Release ${{ matrix.name }} v${{ matrix.version }}"
+          title: "Release `v${{ matrix.version }}` of `${{ matrix.name }}`"
           body: |
-            ## Release ${{ matrix.name }} v${{ matrix.version }}
+            ## Release Broker
+            This PR brokers the release for `v${{ matrix.version }}` of `${{ matrix.name }}`.
             
+            ${{ steps.changelog_message.outputs.content }}
+            
+            ---
             This PR contains:
             - ✅ Updated version in `${{ matrix.path }}/Cargo.toml`
             - ✅ Generated changelog with git-cliff
             - ✅ Dry-run crates.io publish passed
             
-            ### Changes in this release:
-            
-            ```
-            $(cat ${{ matrix.path }}/UNRELEASED.md)
-            ```
-            
             **Merging this PR will:**
             1. Create a git tag `${{ matrix.name }}-v${{ matrix.version }}`
             2. Publish `${{ matrix.name }}` to crates.io
             3. Create a GitHub release
-            
-            ---
-            *This PR was created automatically by the release workflow*
           labels: |
             release
             automated
@@ -220,6 +208,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          lfs: false
           fetch-depth: 0
 
       - name: Install Rust toolchain
@@ -255,6 +244,7 @@ jobs:
           git push origin "${{ steps.extract_info.outputs.tag_name }}"
 
       - name: Publish to crates.io
+        if: false
         working-directory: ${{ steps.find_crate.outputs.crate_dir }}
         run: cargo publish
         env:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   # Job 1: Detect changed crates and create release PRs
   detect-and-release:
+    name: Detect Changes
     if: |
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
@@ -92,6 +93,7 @@ jobs:
 
   # Job 2: Create release PRs for each changed crate
   create-release-prs:
+    name: Create Release PR
     needs: detect-and-release
     if: needs.detect-and-release.outputs.matrix != '{"include":[]}'
     runs-on: ubuntu-latest
@@ -167,7 +169,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          author: 'GitHub <noreply@github.com>'
+          author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
           commit-message: 'chore(release): prepare for v${{ matrix.version }} of ${{ matrix.name }}'
           base: ${{ github.event.repository.default_branch || 'main' }}
           delete-branch: 'false' # Don't delete version branches
@@ -196,6 +198,7 @@ jobs:
 
   # Job 3: Finalize releases when release PRs are merged
   finalize-release:
+    name: Finalize Release
     if: |
       github.event_name == 'pull_request' && 
       github.event.action == 'closed' && 
@@ -211,6 +214,11 @@ jobs:
         with:
           lfs: false
           fetch-depth: 0
+
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -241,22 +249,26 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.extract_info.outputs.tag_name }}" -m "Release ${{ steps.extract_info.outputs.crate_name }} v${{ steps.extract_info.outputs.version }}"
+          git tag -f -a "${{ steps.extract_info.outputs.tag_name }}" -m "Release ${{ steps.extract_info.outputs.crate_name }} v${{ steps.extract_info.outputs.version }}"
           git push origin "${{ steps.extract_info.outputs.tag_name }}"
 
       - name: Publish to crates.io
-        if: false
         working-directory: ${{ steps.find_crate.outputs.crate_dir }}
         run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+      - name: Obtain Current Changes
+        working-directory: ${{ steps.find_crate.outputs.crate_dir }}
+        run: |
+          git cliff --current > RELEASE.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.extract_info.outputs.tag_name }}
-          name: Release ${{ steps.extract_info.outputs.crate_name }} v${{ steps.extract_info.outputs.version }}
-          body_path: ${{ steps.find_crate.outputs.crate_dir }}/CHANGELOG.md
+          name: ${{ steps.extract_info.outputs.crate_name }} v${{ steps.extract_info.outputs.version }}
+          body_path: ${{ steps.find_crate.outputs.crate_dir }}/RELEASE.md
           draft: false
           prerelease: false
         env:
@@ -264,5 +276,6 @@ jobs:
 
       - name: Cleanup release branch
         run: |
+          git checkout .
           git push origin --delete ${{ github.event.pull_request.head.ref }}
         continue-on-error: true

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,9 +1,6 @@
 name: Auto Release Monorepo
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types: [closed]
 
@@ -13,7 +10,10 @@ env:
 jobs:
   # Job 1: Detect changed crates and create release PRs
   detect-and-release:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]'
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -167,6 +167,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          author: 'GitHub <noreply@github.com>'
           commit-message: 'chore(release): prepare for v${{ matrix.version }} of ${{ matrix.name }}'
           base: ${{ github.event.repository.default_branch || 'main' }}
           delete-branch: 'false' # Don't delete version branches

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,4 +1,4 @@
-name: Auto Release
+name: Auto Release Monorepo
 
 on:
   push:
@@ -11,13 +11,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Job 1: Create release PR when changes are pushed to main
-  create-release-pr:
+  # Job 1: Detect changed crates and create release PRs
+  detect-and-release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      matrix: ${{ steps.detect-changes.outputs.matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,66 +35,167 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Generate changelog and determine next version
-        id: changelog
+      - name: Install cargo-workspaces
+        run: cargo install cargo-workspaces
+
+      - name: Detect changed crates
+        id: detect-changes
         run: |
-          # Get the next version using git-cliff
-          NEXT_VERSION=$(git-cliff --bumped-version)
-          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          # Get the last release tag
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           
-          # Generate unreleased changelog for PR body
+          # Find all crates in the workspace
+          CRATES=$(find . -name "Cargo.toml" -not -path "./target/*" | sort)
+          
+          # Array to store crates that need releases
+          CHANGED_CRATES=()
+          
+          for crate_toml in $CRATES; do
+            CRATE_DIR=$(dirname "$crate_toml")
+            CRATE_NAME=$(cargo metadata --no-deps --manifest-path "$crate_toml" --format-version 1 | jq -r '.packages[0].name')
+          
+            # Check if there are changes in this crate since last tag
+            if [ -z "$LAST_TAG" ] || git diff --name-only "$LAST_TAG"..HEAD | grep -q "^${CRATE_DIR#./}"; then
+              echo "Changes detected in crate: $CRATE_NAME at $CRATE_DIR"
+          
+              # Create git-cliff config for this specific crate
+              cat > "$CRATE_DIR/cliff.toml" << 'EOF'
+          [changelog]
+          header = """
+          # Changelog
+          All notable changes to this project will be documented in this file.
+          """
+          body = """
+          {% if version %}\
+              ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+          {% else %}\
+              ## [unreleased]
+          {% endif %}\
+          {% for group, commits in commits | group_by(attribute="group") %}
+              ### {{ group | striptags | trim | upper_first }}
+              {% for commit in commits %}
+                  - {% if commit.scope %}**{{commit.scope}}**: {% endif %}{{ commit.message | upper_first }}\
+              {% endfor %}
+          {% endfor %}\n
+          """
+          trim = true
+          
+          [git]
+          conventional_commits = true
+          filter_unconventional = true
+          commit_parsers = [
+              { message = "^feat", group = "Features" },
+              { message = "^fix", group = "Bug Fixes" },
+              { message = "^doc", group = "Documentation" },
+              { message = "^perf", group = "Performance" },
+              { message = "^refactor", group = "Refactor" },
+              { message = "^style", group = "Styling" },
+              { message = "^test", group = "Testing" },
+              { message = "^chore\\(release\\): prepare for", skip = true },
+              { message = "^chore", group = "Miscellaneous Tasks" },
+              { body = ".*security", group = "Security" },
+          ]
+          tag_pattern = "${CRATE_NAME}-v[0-9]*"
+          EOF
+          
+              # Get next version for this crate
+              cd "$CRATE_DIR"
+              NEXT_VERSION=$(git-cliff --bumped-version 2>/dev/null || echo "0.1.0")
+              cd - > /dev/null
+          
+              CHANGED_CRATES+=("{\"name\":\"$CRATE_NAME\",\"path\":\"$CRATE_DIR\",\"version\":\"$NEXT_VERSION\"}")
+            fi
+          done
+          
+          # Create JSON matrix for parallel processing
+          if [ ${#CHANGED_CRATES[@]} -gt 0 ]; then
+            MATRIX_JSON=$(printf '%s\n' "${CHANGED_CRATES[@]}" | jq -s '{"include": .}')
+            echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
+            echo "Found ${#CHANGED_CRATES[@]} crates with changes"
+          else
+            echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
+            echo "No crates with changes found"
+          fi
+
+  # Job 2: Create release PRs for each changed crate
+  create-release-prs:
+    needs: detect-and-release
+    if: needs.detect-and-release.outputs.matrix != '{"include":[]}'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      matrix: ${{ fromJson(needs.detect-and-release.outputs.matrix) }}
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate changelog and update version
+        working-directory: ${{ matrix.path }}
+        run: |
+          # Generate changelog
+          git-cliff --tag "${{ matrix.name }}-v${{ matrix.version }}" > CHANGELOG.md
           git-cliff --unreleased --strip header > UNRELEASED.md
           
-          # Generate full changelog with new version
-          git-cliff --tag $NEXT_VERSION > CHANGELOG.md
+          # Update Cargo.toml version
+          sed -i 's/^version = ".*"/version = "${{ matrix.version }}"/' Cargo.toml
 
-      - name: Update Cargo.toml version
-        run: |
-          sed -i 's/^version = ".*"/version = "${{ steps.changelog.outputs.next_version }}"/' Cargo.toml
-
-      - name: Cargo check (dry run)
+      - name: Cargo check for this crate
+        working-directory: ${{ matrix.path }}
         run: cargo check
 
       - name: Dry run crates.io publish
-        run: |
-          cargo publish --dry-run
+        working-directory: ${{ matrix.path }}
+        run: cargo publish --dry-run
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Create release branch
+      - name: Create release branch and commit
         run: |
-          BRANCH_NAME="release/v${{ steps.changelog.outputs.next_version }}"
+          BRANCH_NAME="release/${{ matrix.name }}-v${{ matrix.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b $BRANCH_NAME
-          git add Cargo.toml CHANGELOG.md
-          git commit -m "chore: release v${{ steps.changelog.outputs.next_version }}"
-          git push origin $BRANCH_NAME
-          echo "branch_name=$BRANCH_NAME" >> $GITHUB_ENV
+          git checkout -b "$BRANCH_NAME"
+          git add "${{ matrix.path }}/Cargo.toml" "${{ matrix.path }}/CHANGELOG.md"
+          git commit -m "chore(${{ matrix.name }}): release v${{ matrix.version }}"
+          git push origin "$BRANCH_NAME"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: release/v${{ steps.changelog.outputs.next_version }}
-          title: "🚀 Release v${{ steps.changelog.outputs.next_version }}"
+          branch: release/${{ matrix.name }}-v${{ matrix.version }}
+          title: "🚀 Release ${{ matrix.name }} v${{ matrix.version }}"
           body: |
-            ## Release v${{ steps.changelog.outputs.next_version }}
+            ## Release ${{ matrix.name }} v${{ matrix.version }}
             
             This PR contains:
-            - ✅ Updated version in Cargo.toml
+            - ✅ Updated version in `${{ matrix.path }}/Cargo.toml`
             - ✅ Generated changelog with git-cliff
             - ✅ Dry-run crates.io publish passed
             
             ### Changes in this release:
             
             ```
-            $(cat UNRELEASED.md)
+            $(cat ${{ matrix.path }}/UNRELEASED.md)
             ```
             
             **Merging this PR will:**
-            1. Create a git tag v${{ steps.changelog.outputs.next_version }}
-            2. Publish to crates.io
+            1. Create a git tag `${{ matrix.name }}-v${{ matrix.version }}`
+            2. Publish `${{ matrix.name }}` to crates.io
             3. Create a GitHub release
             
             ---
@@ -100,8 +203,9 @@ jobs:
           labels: |
             release
             automated
+            ${{ matrix.name }}
 
-  # Job 2: Finalize release when release PR is merged
+  # Job 3: Finalize releases when release PRs are merged
   finalize-release:
     if: |
       github.event_name == 'pull_request' && 
@@ -121,20 +225,37 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Get version from Cargo.toml
-        id: get_version
+      - name: Extract crate info from branch name
+        id: extract_info
         run: |
-          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          # Extract crate name and version from branch name like "release/my-crate-v1.2.3"
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          CRATE_INFO="${BRANCH_NAME#release/}"
+          
+          # Split on the last occurrence of "-v"
+          CRATE_NAME="${CRATE_INFO%-v*}"
+          VERSION="${CRATE_INFO##*-v}"
+          
+          echo "crate_name=$CRATE_NAME" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag_name=${CRATE_NAME}-v${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Find crate directory
+        id: find_crate
+        run: |
+          # Find the directory containing this crate
+          CRATE_DIR=$(find . -name "Cargo.toml" -not -path "./target/*" -exec grep -l "name = \"${{ steps.extract_info.outputs.crate_name }}\"" {} \; | head -1 | xargs dirname)
+          echo "crate_dir=$CRATE_DIR" >> $GITHUB_OUTPUT
 
       - name: Create Git Tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.get_version.outputs.version }}" -m "Release v${{ steps.get_version.outputs.version }}"
-          git push origin "v${{ steps.get_version.outputs.version }}"
+          git tag -a "${{ steps.extract_info.outputs.tag_name }}" -m "Release ${{ steps.extract_info.outputs.crate_name }} v${{ steps.extract_info.outputs.version }}"
+          git push origin "${{ steps.extract_info.outputs.tag_name }}"
 
       - name: Publish to crates.io
+        working-directory: ${{ steps.find_crate.outputs.crate_dir }}
         run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -142,9 +263,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v${{ steps.get_version.outputs.version }}
-          name: Release v${{ steps.get_version.outputs.version }}
-          body_path: CHANGELOG.md
+          tag_name: ${{ steps.extract_info.outputs.tag_name }}
+          name: Release ${{ steps.extract_info.outputs.crate_name }} v${{ steps.extract_info.outputs.version }}
+          body_path: ${{ steps.find_crate.outputs.crate_dir }}/CHANGELOG.md
           draft: false
           prerelease: false
         env:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,156 @@
+name: Auto Release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [closed]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Job 1: Create release PR when changes are pushed to main
+  create-release-pr:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate changelog and determine next version
+        id: changelog
+        run: |
+          # Get the next version using git-cliff
+          NEXT_VERSION=$(git-cliff --bumped-version)
+          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          
+          # Generate unreleased changelog for PR body
+          git-cliff --unreleased --strip header > UNRELEASED.md
+          
+          # Generate full changelog with new version
+          git-cliff --tag $NEXT_VERSION > CHANGELOG.md
+
+      - name: Update Cargo.toml version
+        run: |
+          sed -i 's/^version = ".*"/version = "${{ steps.changelog.outputs.next_version }}"/' Cargo.toml
+
+      - name: Cargo check (dry run)
+        run: cargo check
+
+      - name: Dry run crates.io publish
+        run: |
+          cargo publish --dry-run
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Create release branch
+        run: |
+          BRANCH_NAME="release/v${{ steps.changelog.outputs.next_version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b $BRANCH_NAME
+          git add Cargo.toml CHANGELOG.md
+          git commit -m "chore: release v${{ steps.changelog.outputs.next_version }}"
+          git push origin $BRANCH_NAME
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: release/v${{ steps.changelog.outputs.next_version }}
+          title: "🚀 Release v${{ steps.changelog.outputs.next_version }}"
+          body: |
+            ## Release v${{ steps.changelog.outputs.next_version }}
+            
+            This PR contains:
+            - ✅ Updated version in Cargo.toml
+            - ✅ Generated changelog with git-cliff
+            - ✅ Dry-run crates.io publish passed
+            
+            ### Changes in this release:
+            
+            ```
+            $(cat UNRELEASED.md)
+            ```
+            
+            **Merging this PR will:**
+            1. Create a git tag v${{ steps.changelog.outputs.next_version }}
+            2. Publish to crates.io
+            3. Create a GitHub release
+            
+            ---
+            *This PR was created automatically by the release workflow*
+          labels: |
+            release
+            automated
+
+  # Job 2: Finalize release when release PR is merged
+  finalize-release:
+    if: |
+      github.event_name == 'pull_request' && 
+      github.event.action == 'closed' && 
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Get version from Cargo.toml
+        id: get_version
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create Git Tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.get_version.outputs.version }}" -m "Release v${{ steps.get_version.outputs.version }}"
+          git push origin "v${{ steps.get_version.outputs.version }}"
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.get_version.outputs.version }}
+          name: Release v${{ steps.get_version.outputs.version }}
+          body_path: CHANGELOG.md
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup release branch
+        run: |
+          git push origin --delete ${{ github.event.pull_request.head.ref }}
+        continue-on-error: true

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,7 +1,3 @@
-# git-cliff ~ configuration file
-# https://git-cliff.org/docs/configuration
-
-
 [changelog]
 # A Tera template to be rendered as the changelog's footer.
 # See https://keats.github.io/tera/docs/#introduction
@@ -13,17 +9,15 @@ All notable changes to this project will be documented in this file.\n
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
-{% else %}\
-    ## [unreleased]
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% endif %}\
 {% for group, commits in commits | filter(attribute="merge_commit", value=false) | group_by(attribute="group") %}
-    ### {{ group | striptags | trim | upper_first }}
-    {% for commit in commits %}
-        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
-            {% if commit.breaking %}[**breaking**] {% endif %}\
-            {{ commit.message | upper_first }}\
-    {% endfor %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+  {% if commit.breaking %}[**breaking**] {% endif %}\
+  {{ commit.message | upper_first }}\
+{% endfor %}
 {% endfor %}\n
 """
 # A Tera template to be rendered as the changelog's footer.
@@ -70,7 +64,7 @@ protect_breaking_commits = false
 # Assigns commits to groups.
 # Optionally sets the commit's scope and can decide to exclude commits from further processing.
 commit_parsers = [
-#    Categorise Commits
+    #    Categorise Commits
     { message = "^feat", group = "<!-- 0 -->🚀 Features" },
     { message = "^sec", group = "<!-- 1 -->🔐 Security" },
     { message = "^fix", group = "<!-- 2 -->🐛 Bug Fixes" },
@@ -80,21 +74,20 @@ commit_parsers = [
     { message = "^style", group = "<!-- 6 -->🎨 Styling" },
     { message = "^test", group = "<!-- 7 -->🧪 Testing" },
     { message = "^mod", group = "<!-- 8 -->⚙️ General Changes" },
-    { message = "^chore\\(release\\): prepare for", skip = true },
-    { message = "^chore\\(deps.*\\)", skip = true },
-    { message = "^chore\\(pr\\)", skip = true },
-    { message = "^chore\\(pull\\)", skip = true },
     { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
-    { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
     { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
     { message = ".*", group = "<!-- 10 -->💼 Other" },
 
-#    Remove Empty Commits
+    #    Remove Chores
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    #    Remove Release Messages
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    #    Remove Empty Commits
     { body = "$^", skip = true },
-#    Remove Gitmoji
+    #    Remove Gitmoji
     { pattern = ' *(:\w+:|[\p{Emoji_Presentation}\p{Extended_Pictographic}](?:\u{FE0F})?\u{200D}?) *', replace = "" },
-
-
 ]
 # Exclude commits that are not matched by any commit parser.
 filter_commits = false

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,113 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+
+[changelog]
+# A Tera template to be rendered as the changelog's footer.
+# See https://keats.github.io/tera/docs/#introduction
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+# A Tera template to be rendered for each release in the changelog.
+# See https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | filter(attribute="merge_commit", value=false) | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+# A Tera template to be rendered as the changelog's footer.
+# See https://keats.github.io/tera/docs/#introduction
+footer = """
+RoutersOrg - 2025
+"""
+# Remove leading and trailing whitespaces from the changelog's body.
+trim = true
+# Render body even when there are no releases to process.
+render_always = true
+# An array of regex based postprocessors to modify the changelog.
+postprocessors = [
+    # Replace the placeholder <REPO> with a URL.
+    #{ pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" },
+]
+# render body even when there are no releases to process
+# render_always = true
+# output file path
+# output = "test.md"
+
+[git]
+# Parse commits according to the conventional commits specification.
+# See https://www.conventionalcommits.org
+conventional_commits = true
+# Exclude commits that do not match the conventional commits specification.
+filter_unconventional = true
+# Require all commits to be conventional.
+# Takes precedence over filter_unconventional.
+require_conventional = false
+# Split commits on newlines, treating each line as an individual commit.
+split_commits = false
+# An array of regex based parsers to modify commit messages prior to further processing.
+commit_preprocessors = [
+    # Replace issue numbers with link templates to be updated in `changelog.postprocessors`.
+    #{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
+    # Check spelling of the commit message using https://github.com/crate-ci/typos.
+    # If the spelling is incorrect, it will be fixed automatically.
+    #{ pattern = '.*', replace_command = 'typos --write-changes -' },
+]
+# Prevent commits that are breaking from being excluded by commit parsers.
+protect_breaking_commits = false
+# An array of regex based parsers for extracting data from the commit message.
+# Assigns commits to groups.
+# Optionally sets the commit's scope and can decide to exclude commits from further processing.
+commit_parsers = [
+#    Categorise Commits
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^sec", group = "<!-- 1 -->🔐 Security" },
+    { message = "^fix", group = "<!-- 2 -->🐛 Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 5 -->🚜 Refactor" },
+    { message = "^style", group = "<!-- 6 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 7 -->🧪 Testing" },
+    { message = "^mod", group = "<!-- 8 -->⚙️ General Changes" },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+    { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+    { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+    { message = ".*", group = "<!-- 10 -->💼 Other" },
+
+#    Remove Empty Commits
+    { body = "$^", skip = true },
+#    Remove Gitmoji
+    { pattern = ' *(:\w+:|[\p{Emoji_Presentation}\p{Extended_Pictographic}](?:\u{FE0F})?\u{200D}?) *', replace = "" },
+
+
+]
+# Exclude commits that are not matched by any commit parser.
+filter_commits = false
+# An array of link parsers for extracting external references, and turning them into URLs, using regex.
+link_parsers = []
+# Include only the tags that belong to the current branch.
+use_branch_tags = false
+# Order releases topologically instead of chronologically.
+topo_order = false
+# Order releases topologically instead of chronologically.
+topo_order_commits = true
+# Order of commits in each group/release within the changelog.
+# Allowed values: newest, oldest
+sort_commits = "oldest"
+# Process submodules commits
+recurse_submodules = false


### PR DESCRIPTION
Uses [Git Cliff](https://git-cliff.org/docs/) to automate release versioning. A GitHub actions runner is deployed after every merged PR into `main` which checks for changes to each crate in the repository. Should a crate experience a change requiring a minor or major bump, the service will raise a PR with a changelog indicating the changes made.

This new PR, when merged, will deploy the updated version and changes to crates.io, and raise a GitHub release with the changes within the release period. Furthermore, a changelog is kept under every crate to indicate the changes made there, categorised by conventional commit variants.