### PR TITLE
fix: Simple Matching Function

### DIFF
--- a/benches/map_match.rs
+++ b/benches/map_match.rs
@@ -71,7 +71,7 @@ fn target_benchmark(c: &mut criterion::Criterion) {
         let graph = Graph::new(path).expect("Graph must be created");
 
         let costing = CostingStrategies::default();
-        let runtime = OsmEdgeMetadata::runtime(None);
+        let runtime = OsmEdgeMetadata::default_runtime();
 
         ga.matches.iter().for_each(|sc| {
             let coordinates: LineString<f64> = LineString::try_from_wkt_str(sc.input_linestring)

--- a/examples/map_match.rs
+++ b/examples/map_match.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+use geo::LineString;
+use wkt::TryFromWkt;
+
+use routers::*;
+use routers_fixtures::{fixture, LOS_ANGELES, VENTURA_TRIP};
+
+fn main() {
+    let coordinates: LineString<f64> = LineString::try_from_wkt_str(VENTURA_TRIP)
+        .expect("Linestring must parse successfully.");
+
+    let path = Path::new(fixture!(LOS_ANGELES))
+        .as_os_str()
+        .to_ascii_lowercase();
+
+    let graph = Graph::new(path).expect("Graph must be created");
+
+    let route = graph
+        .r#match_simple(coordinates)
+        .expect("Match must complete successfully");
+
+    println!("Matched Route: {route:?}");
+}

--- a/examples/map_match.rs
+++ b/examples/map_match.rs
@@ -1,13 +1,13 @@
-use std::path::Path;
 use geo::LineString;
+use std::path::Path;
 use wkt::TryFromWkt;
 
 use routers::*;
-use routers_fixtures::{fixture, LOS_ANGELES, VENTURA_TRIP};
+use routers_fixtures::{LOS_ANGELES, VENTURA_TRIP, fixture};
 
 fn main() {
-    let coordinates: LineString<f64> = LineString::try_from_wkt_str(VENTURA_TRIP)
-        .expect("Linestring must parse successfully.");
+    let coordinates: LineString<f64> =
+        LineString::try_from_wkt_str(VENTURA_TRIP).expect("Linestring must parse successfully.");
 
     let path = Path::new(fixture!(LOS_ANGELES))
         .as_os_str()

--- a/libs/routers_codec/src/osm/block/item.rs
+++ b/libs/routers_codec/src/osm/block/item.rs
@@ -75,7 +75,7 @@ impl BlockItem {
     }
 
     #[inline]
-    pub fn raw_element_iter(&self) -> impl Iterator<Item = Element> {
+    pub fn raw_element_iter(&self) -> impl Iterator<Item = Element<'_>> {
         match self {
             BlockItem::PrimitiveBlock(primitive) => Either::Left(
                 primitive
@@ -102,7 +102,7 @@ impl BlockItem {
     }
 
     #[inline]
-    pub fn raw_par_iter(&mut self) -> impl ParallelIterator<Item = Element> + '_ {
+    pub fn raw_par_iter(&mut self) -> impl ParallelIterator<Item = Element<'_>> + '_ {
         match self {
             BlockItem::PrimitiveBlock(primitive) => Either::Left(
                 primitive

--- a/libs/routers_codec/src/osm/element/variants/mod.rs
+++ b/libs/routers_codec/src/osm/element/variants/mod.rs
@@ -200,7 +200,7 @@ pub mod common {
     }
 
     pub trait Referential {
-        fn indices(&self) -> impl Iterator<Item = ReferenceKey>;
+        fn indices(&self) -> impl Iterator<Item = ReferenceKey<'_>>;
 
         fn references(&self, block: &PrimitiveBlock) -> References {
             self.indices()

--- a/libs/routers_codec/src/osm/element/variants/relation.rs
+++ b/libs/routers_codec/src/osm/element/variants/relation.rs
@@ -26,7 +26,7 @@ impl Taggable for osm::Relation {
 }
 
 impl Referential for osm::Relation {
-    fn indices(&self) -> impl Iterator<Item = ReferenceKey> {
+    fn indices(&self) -> impl Iterator<Item = ReferenceKey<'_>> {
         self.roles_sid
             .iter()
             .zip(self.memids.iter())

--- a/libs/routers_codec/src/osm/element/variants/way.rs
+++ b/libs/routers_codec/src/osm/element/variants/way.rs
@@ -54,7 +54,7 @@ impl Taggable for osm::Way {
 }
 
 impl Referential for osm::Way {
-    fn indices(&self) -> impl Iterator<Item = ReferenceKey> {
+    fn indices(&self) -> impl Iterator<Item = ReferenceKey<'_>> {
         self.refs.iter().map(|id| Intermediate {
             role: &-1i32,
             index: id,

--- a/libs/routers_codec/src/primitive/mod.rs
+++ b/libs/routers_codec/src/primitive/mod.rs
@@ -33,6 +33,10 @@ pub trait Metadata: Clone + Debug + Send + Sync {
 
     fn pick(raw: Self::Raw<'_>) -> Self;
     fn runtime(ctx: Option<Self::TripContext>) -> Self::Runtime;
-
     fn accessible(&self, access: &Self::Runtime, direction: Direction) -> bool;
+
+    /// The default runtime for the specific metadata implementation
+    fn default_runtime() -> Self::Runtime {
+        Self::runtime(None)
+    }
 }

--- a/libs/routers_fixtures/src/lib.rs
+++ b/libs/routers_fixtures/src/lib.rs
@@ -1,8 +1,8 @@
 use std::path::{Path, PathBuf};
 
 pub const DISTRICT_OF_COLUMBIA: &str = "district-of-columbia.osm.pbf";
-pub const BADEN_WUERTTEMBERG: &str = "baden-wuerttemberg-latest.osm.pbf";
-pub const AUSTRALIA: &str = "australia-latest.osm.pbf";
+pub const BADEN_WUERTTEMBERG: &str = "baden-wuerttemberg.osm.pbf";
+pub const AUSTRALIA: &str = "australia.osm.pbf";
 pub const SYDNEY: &str = "sydney.osm.pbf";
 pub const LOS_ANGELES: &str = "los-angeles.osm.pbf";
 pub const ZURICH: &str = "zurich.osm.pbf";

--- a/src/graph/impls/osm.rs
+++ b/src/graph/impls/osm.rs
@@ -13,7 +13,7 @@ use rustc_hash::FxHashMap;
 
 use std::error::Error;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::Instant;
 
 pub type OsmGraph = Graph<OsmEntryId, OsmEdgeMetadata>;

--- a/src/graph/item.rs
+++ b/src/graph/item.rs
@@ -8,7 +8,6 @@ use rustc_hash::{FxHashMap, FxHasher};
 
 use std::fmt::{Debug, Formatter};
 use std::hash::BuildHasherDefault;
-use std::sync::{Arc, Mutex};
 #[cfg(feature = "tracing")]
 use tracing::Level;
 

--- a/src/graph/traits/match/definition.rs
+++ b/src/graph/traits/match/definition.rs
@@ -32,3 +32,20 @@ where
         linestring: LineString,
     ) -> Result<RoutedPath<E, M>, MatchError>;
 }
+
+// Simplifies the interface to the `Match` trait.
+pub trait MatchSimpleExt<E, M>: Match<E, M>
+where
+    E: Entry,
+    M: Metadata
+{
+    fn r#match_simple(&self, linestring: LineString) -> Result<RoutedPath<E, M>, MatchError> {
+        self.r#match(&M::runtime(None), SolverVariant::default(), linestring)
+    }
+
+    fn snap_simple(&self, linestring: LineString) -> Result<RoutedPath<E, M>, MatchError> {
+        self.snap(&M::runtime(None), SolverVariant::default(), linestring)
+    }
+}
+
+impl<T, E: Entry, M: Metadata> MatchSimpleExt<E, M> for T where T: Match<E, M> {}

--- a/src/graph/traits/match/definition.rs
+++ b/src/graph/traits/match/definition.rs
@@ -37,14 +37,14 @@ where
 pub trait MatchSimpleExt<E, M>: Match<E, M>
 where
     E: Entry,
-    M: Metadata
+    M: Metadata,
 {
     fn r#match_simple(&self, linestring: LineString) -> Result<RoutedPath<E, M>, MatchError> {
-        self.r#match(&M::runtime(None), SolverVariant::default(), linestring)
+        self.r#match(&M::default_runtime(), SolverVariant::default(), linestring)
     }
 
     fn snap_simple(&self, linestring: LineString) -> Result<RoutedPath<E, M>, MatchError> {
-        self.snap(&M::runtime(None), SolverVariant::default(), linestring)
+        self.snap(&M::default_runtime(), SolverVariant::default(), linestring)
     }
 }
 

--- a/src/graph/traits/match/mod.rs
+++ b/src/graph/traits/match/mod.rs
@@ -2,3 +2,4 @@ pub mod definition;
 mod implementation;
 
 pub use definition::Match;
+pub use definition::MatchSimpleExt;

--- a/src/graph/traits/mod.rs
+++ b/src/graph/traits/mod.rs
@@ -2,7 +2,7 @@ mod r#match;
 mod proximity;
 mod route;
 
-pub use r#match::Match;
+pub use r#match::{Match, MatchSimpleExt};
 pub use proximity::Scan;
 pub use route::Route;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -29,7 +29,7 @@ fn it_matches() {
     let path = Path::new(fixture!(source)).as_os_str().to_ascii_lowercase();
     let graph = Graph::new(path).expect("Graph must be created");
 
-    let runtime = OsmEdgeMetadata::runtime(None);
+    let runtime = OsmEdgeMetadata::default_runtime();
 
     // Yield the transition layers of each level
     // & Collapse the layers into a final vector

--- a/src/transition/candidate/entry.rs
+++ b/src/transition/candidate/entry.rs
@@ -156,6 +156,7 @@ where
 ///
 /// As it is large, this should only be used transitively
 /// like in [`Scan::nearest_edges`](crate::route::Scan::nearest_edges).
+#[derive(Debug)]
 pub struct FatEdge<E>
 where
     E: Entry,

--- a/src/transition/candidate/route.rs
+++ b/src/transition/candidate/route.rs
@@ -7,6 +7,7 @@ use geo::Point;
 
 /// A route representing the parsed output from a function
 /// passed through the transition graph.
+#[derive(Debug)]
 pub struct RoutedPath<E, M>
 where
     E: Entry,
@@ -61,6 +62,7 @@ where
 
 /// A representation of a path taken.
 /// Consists of an array of [PathElement]s, containing relevant information for positioning.
+#[derive(Debug)]
 pub struct Path<E, M>
 where
     E: Entry,
@@ -98,6 +100,7 @@ where
 /// element represents within the path, as well as metadata (Meta)
 /// for the path element, and the edge within the source network at
 /// which the element exists.
+#[derive(Debug)]
 pub struct PathElement<E, M>
 where
     E: Entry,

--- a/src/transition/solver/precompute_forward.rs
+++ b/src/transition/solver/precompute_forward.rs
@@ -3,7 +3,6 @@ use crate::transition::*;
 use log::{debug, info};
 
 use rustc_hash::FxHashMap;
-use std::sync::{Arc, Mutex};
 
 use geo::{Distance, Haversine};
 use itertools::Itertools;

--- a/src/transition/solver/selective_forward.rs
+++ b/src/transition/solver/selective_forward.rs
@@ -5,7 +5,6 @@ use log::{debug, info};
 
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
-use std::sync::{Arc, Mutex, RwLock};
 
 use geo::{Distance, Haversine};
 use itertools::Itertools;


### PR DESCRIPTION
Provides a `match_simple(..)` function which just accepts a `LineString(..)`. This is a simpler approach to matching, which is shown in the exemplar `map_match.rs` file. It does not allow for customising the runtime, or solver, by design. For which, defer to the `match(..)` function.

 Other changes include altering fixtures to remove the `-latest` suffix, fixing formatting issues with superfluous imports and adding a `Debug` trait derivation for the matched result.