### PR TITLE
feat: Smaller Fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ todo.md
 
 /libs/routers_fixtures/resources/*
 
-!district-of-columbia.osm.pbf
-!los-angeles.osm.pbf
-!zurich.osm.pbf
-!sydney.osm.pbf
+!district-of-columbia-minified*
+!los-angeles-minified*
+!zurich-minified*
+!sydney-minified*

--- a/libs/routers_codec/benches/codec_target.rs
+++ b/libs/routers_codec/benches/codec_target.rs
@@ -34,7 +34,7 @@ fn iterate_blocks_each() {
     }
 
     assert_eq!(header_blocks, 1);
-    assert_eq!(primitive_blocks, 237);
+    assert_eq!(primitive_blocks, 21);
 }
 
 fn parallel_iterate_blocks_each() {
@@ -50,7 +50,7 @@ fn parallel_iterate_blocks_each() {
         })
         .reduce(|| (0, 0), |a, b| (a.0 + b.0, a.1 + b.1));
 
-    assert_eq!(elements, (237, 1));
+    assert_eq!(elements, (21, 1));
 }
 
 fn compare_to_osmpbf() {
@@ -79,7 +79,7 @@ fn compare_to_osmpbf() {
     }
 
     assert_eq!(header_blocks, 1);
-    assert_eq!(primitive_blocks, 237);
+    assert_eq!(primitive_blocks, 21);
 }
 
 fn ingest_and_count() {

--- a/libs/routers_codec/src/osm/test.rs
+++ b/libs/routers_codec/src/osm/test.rs
@@ -67,7 +67,7 @@ fn iterate_blocks_each() {
     }
 
     assert_eq!(header_blocks, 1);
-    assert_eq!(primitive_blocks, 237);
+    assert_eq!(primitive_blocks, 21);
 }
 
 #[test_log::test]
@@ -85,5 +85,5 @@ fn parallel_iterate_blocks_each() {
         })
         .reduce(|| (0, 0), |a, b| (a.0 + b.0, a.1 + b.1));
 
-    assert_eq!(elements, (237, 1));
+    assert_eq!(elements, (21, 1));
 }

--- a/libs/routers_fixtures/resources/district-of-columbia-minified.osm.pbf
+++ b/libs/routers_fixtures/resources/district-of-columbia-minified.osm.pbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fe865845a88be7f058d22427119082b86fdf3e916144ff1937341958f0b1afb
+size 1818208

--- a/libs/routers_fixtures/resources/district-of-columbia.osm.pbf
+++ b/libs/routers_fixtures/resources/district-of-columbia.osm.pbf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5aabfaa36f9e877f254555a30a0ed3ec0a474f1299c5118ab65bb3e63de5009f
-size 16868085

--- a/libs/routers_fixtures/resources/los-angeles-minified.osm.pbf
+++ b/libs/routers_fixtures/resources/los-angeles-minified.osm.pbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b62d263526a03e8bdc8869c60eb0c632d01d2ba9536780da80cd496eb67a6c50
+size 96156907

--- a/libs/routers_fixtures/resources/los-angeles.osm.pbf
+++ b/libs/routers_fixtures/resources/los-angeles.osm.pbf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e2eb07d2c149a9687494537853745eb2f6f603b40d5c46f37291b1d200a87be
-size 461856891

--- a/libs/routers_fixtures/resources/sydney-minified.osm.pbf
+++ b/libs/routers_fixtures/resources/sydney-minified.osm.pbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc1d69d5d5895f36b72fde46c08840c8a84cf01392f9c335e8eb7160b404defe
+size 12467731

--- a/libs/routers_fixtures/resources/sydney.osm.pbf
+++ b/libs/routers_fixtures/resources/sydney.osm.pbf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fafe0974b2cc89c6e7f6a5d7811fede32d88b44bdf7860f08f62f40a5b117b21
-size 29819901

--- a/libs/routers_fixtures/resources/zurich-minified.osm.pbf
+++ b/libs/routers_fixtures/resources/zurich-minified.osm.pbf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22d185c370d0cb7d4a270095dfd189c8a98699a86c0d0e7f098c804602a512b9
+size 16557898

--- a/libs/routers_fixtures/resources/zurich.osm.pbf
+++ b/libs/routers_fixtures/resources/zurich.osm.pbf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8dc3017bdfba4bb21dd3eacfbb166d23e74a5a58885bf0c2edd8c1133e3b8d9c
-size 49420209

--- a/libs/routers_fixtures/src/lib.rs
+++ b/libs/routers_fixtures/src/lib.rs
@@ -1,11 +1,11 @@
 use std::path::{Path, PathBuf};
 
-pub const DISTRICT_OF_COLUMBIA: &str = "district-of-columbia.osm.pbf";
-pub const BADEN_WUERTTEMBERG: &str = "baden-wuerttemberg.osm.pbf";
-pub const AUSTRALIA: &str = "australia.osm.pbf";
-pub const SYDNEY: &str = "sydney.osm.pbf";
-pub const LOS_ANGELES: &str = "los-angeles.osm.pbf";
-pub const ZURICH: &str = "zurich.osm.pbf";
+pub const DISTRICT_OF_COLUMBIA: &str = "district-of-columbia-minified.osm.pbf";
+pub const BADEN_WUERTTEMBERG: &str = "baden-wuerttemberg-minified.osm.pbf";
+pub const AUSTRALIA: &str = "australia-minified.osm.pbf";
+pub const SYDNEY: &str = "sydney-minified.osm.pbf";
+pub const LOS_ANGELES: &str = "los-angeles-minified.osm.pbf";
+pub const ZURICH: &str = "zurich-minified.osm.pbf";
 
 pub mod macros {
     #[macro_export]


### PR DESCRIPTION
Reduces the size of the .osm.pbf fixtures by stripping information, such as relations and non-traversable-edges, which are not used by this organisation. 