### PR TITLE
fix: Scope Protobuf to Domain

### DIFF
--- a/libs/routers_grpc/buf.yaml
+++ b/libs/routers_grpc/buf.yaml
@@ -2,6 +2,3 @@ version: v2
 modules:
   - path: proto
     name: buf.build/routers/api
-    includes:
-      - proto/api
-      - proto/model

--- a/libs/routers_grpc/proto/routers/api/match/v1/definition.proto
+++ b/libs/routers_grpc/proto/routers/api/match/v1/definition.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+package routers.api.match.v1;
+
+import "routers/model/v1/costing.proto";
+import "routers/model/v1/geo.proto";
+import "routers/model/v1/route.proto";
+
+message MatchRequest {
+  // A list of coordinates to match
+  repeated model.v1.Coordinate data = 1;
+
+  // The distance (in m) used to search for the closest edges, using a square scan.
+  // The default value is 50 meters.
+  optional double search_distance = 2;
+
+  // The maximum distance (in m) between coordinates before a new route is started.
+  optional double breakage_distance = 3;
+
+  // Configurable options to dictate the costing functions
+  model.v1.CostOptions options = 4;
+}
+
+message MatchResponse {
+  repeated model.v1.MatchedRoute matches = 1;
+}
+
+message SnapRequest {
+  // A list of coordinates to match
+  repeated model.v1.Coordinate data = 1;
+
+  // The distance (in m) used to search for the closest edges, using a square scan.
+  // The default value is 50 meters.
+  optional double search_distance = 2;
+
+  // The maximum distance (in m) between coordinates before a new route is started.
+  optional double breakage_distance = 3;
+
+  // Configurable options to dictate the costing functions
+  model.v1.CostOptions options = 4;
+}
+
+message SnapResponse {
+  repeated model.v1.MatchedRoute matches = 1;
+}

--- a/libs/routers_grpc/proto/routers/api/match/v1/service.proto
+++ b/libs/routers_grpc/proto/routers/api/match/v1/service.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package routers.api.match.v1;
+
+import "routers/api/match/v1/definition.proto";
+
+service MatchService {
+  // Matches an input route to a given underlying map.
+  //
+  // Uses a transition graph to probabilistically determine the
+  // most likely set of points taken in order to traverse the
+  // input coordinates.
+  //
+  // This algorithm should be used to matching positions accurately
+  // to a network, useful when the exact edges and nodes traversed
+  // are important. Useful when input coordinates are not precise
+  // or contain error, since the algorithm will use a holistic
+  // understanding of the network and request to produce an output.
+  rpc Match(MatchRequest) returns (MatchResponse);
+
+  // Naively snaps an input route to a given underlying map.
+  // This RPC does so by finding the closest node on the network
+  // to each input position, finding the fastest route between each.
+  //
+  // Should be used for visualisation tooling in aggregate, i.e.
+  // understanding many trips at once. Useful when the map contains
+  // nodes which are far apart, and input locations are precise.
+  //
+  // ### Notice
+  //
+  // This is faster than the Match call, however is not to be
+  // used for accurate routing information since it does not have
+  // a holistic understanding of the trips composition. Therefore,
+  // classified as a naive match, a "snap".
+  //
+  rpc Snap(SnapRequest) returns (SnapResponse);
+}

--- a/libs/routers_grpc/proto/routers/api/optimise/v1/definition.proto
+++ b/libs/routers_grpc/proto/routers/api/optimise/v1/definition.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+package routers.api.optimise.v1;
+
+import "routers/model/v1/costing.proto";
+import "routers/model/v1/geo.proto";
+
+// The request message containing the user's name.
+message RouteRequest {
+  routers.model.v1.Coordinate start = 1;
+  routers.model.v1.Coordinate end = 2;
+  routers.model.v1.Costing costing_method = 3;
+}
+
+// The response message including pathing, and weighted heuristics
+message RouteResponse {
+  repeated model.v1.Coordinate shape = 1;
+  uint32 cost = 2;
+}

--- a/libs/routers_grpc/proto/routers/api/optimise/v1/service.proto
+++ b/libs/routers_grpc/proto/routers/api/optimise/v1/service.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+package routers.api.optimise.v1;
+
+import "routers/api/optimise/v1/definition.proto";
+
+// The routing service
+service OptimiseService {
+  // Returns most the appropriate route between the starting and ending locations,
+  // in order to minimise the cost taken to perform the route.
+  rpc Route(RouteRequest) returns (RouteResponse);
+}

--- a/libs/routers_grpc/proto/routers/api/scan/v1/definition.proto
+++ b/libs/routers_grpc/proto/routers/api/scan/v1/definition.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package routers.api.scan.v1;
+
+import "routers/model/v1/geo.proto";
+import "routers/model/v1/route.proto";
+
+message PointRequest {
+  model.v1.Coordinate coordinate = 1;
+}
+
+message EdgeRequest {
+  model.v1.Coordinate coordinate = 1;
+}
+
+message PointResponse {
+  model.v1.Coordinate coordinate = 1;
+}
+
+message EdgeResponse {
+  model.v1.Coordinate node = 1;
+  repeated model.v1.RouteEdge edges = 2;
+}
+
+// Specifies the distance and a position from which to search
+message PointSnappedRequest {
+  model.v1.Coordinate coordinate = 1;
+  double search_radius = 2;
+}
+
+message PointSnappedResponse {
+  model.v1.Coordinate coordinate = 1;
+}

--- a/libs/routers_grpc/proto/routers/api/scan/v1/service.proto
+++ b/libs/routers_grpc/proto/routers/api/scan/v1/service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+package routers.api.scan.v1;
+
+import "routers/api/scan/v1/definition.proto";
+
+// The scan service, to find elements near or around a given position
+service ScanService {
+  // Provides the coordinate of the closest point on the map to the input
+  rpc Point(PointRequest) returns (PointResponse);
+
+  // Provides the closest coordinate upon the map to the input, which is interpolated.
+  // In such that the input position may exist between edges on the graph, and therefore
+  // is considered a "virtual" or "snapped" point.
+  rpc PointSnapped(PointSnappedRequest) returns (PointSnappedResponse);
+
+  // Returns the edge(s) associated to the closest point to the input coordinate
+  rpc Edge(EdgeRequest) returns (EdgeResponse);
+}

--- a/libs/routers_grpc/proto/routers/model/v1/costing.proto
+++ b/libs/routers_grpc/proto/routers/model/v1/costing.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package routers.model.v1;
+
+message CostOptions {
+  // The vehicle costing method to use for map matching.
+  model.v1.Costing costing_method = 1;
+
+  // The optimised solver to be used for map matching.
+  model.v1.OptimiseFor optimise_for = 2;
+}
+
+// Allow the service to optimise based on the requested parameters.
+enum OptimiseFor {
+  OPTIMISE_FOR_UNSPECIFIED = 0;
+  OPTIMISE_FOR_SPEED = 1;
+  OPTIMISE_FOR_PARALLELISM = 2;
+  OPTIMISE_FOR_CONSISTENCY = 3;
+}
+
+message Costing {
+  message CarModel {
+    float height = 1;
+    float width = 2;
+  }
+
+  message TruckModel {
+    float height = 1;
+    float width = 2;
+    float length = 3;
+
+    float axle_load = 4;
+    uint32 axle_count = 5;
+
+    bool hazardous_load = 6;
+  }
+
+  message BusModel {
+    float height = 1;
+    float width = 2;
+  }
+
+  oneof variation {
+    CarModel car = 1;
+    BusModel bus = 2;
+    TruckModel truck = 3;
+  }
+}

--- a/libs/routers_grpc/proto/routers/model/v1/geo.proto
+++ b/libs/routers_grpc/proto/routers/model/v1/geo.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+package routers.model.v1;
+
+message NodeIdentifier {
+  int64 id = 1;
+  Coordinate coordinate = 2;
+}
+
+message EdgeIdentifier {
+  int64 id = 1;
+}
+
+message Coordinate {
+  double latitude = 1;
+  double longitude = 2;
+}
+
+// Optional metadata to provide context for the edge.
+// The values visible here are dependent on the data
+// available in the underlying map.
+message EdgeMetadata {
+  optional uint32 lane_count = 1;
+  optional uint32 speed_limit = 2;
+
+  // Describes all the possible names of the given edge,
+  // including road names. Used to identify or display the edge.
+  repeated string names = 5;
+}
+
+// There is a `source` and `target` node within the edge,
+// with id, `id`. The edge's length is the length the matched
+// vehicle travelled, not its raw length.
+message Edge {
+  // The underlying map identification for the edge.
+  // In OSM for example, this is the Edge-ID.
+  EdgeIdentifier id = 1;
+
+  // The source node the edge begins from
+  NodeIdentifier source = 2;
+
+  // The target node the edge ends at
+  NodeIdentifier target = 3;
+
+  // Length of the edge, in meters.
+  double length = 4;
+
+  EdgeMetadata metadata = 5;
+}

--- a/libs/routers_grpc/proto/routers/model/v1/route.proto
+++ b/libs/routers_grpc/proto/routers/model/v1/route.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package routers.model.v1;
+
+import "routers/model/v1/geo.proto";
+
+// Describes the edges within the graph that was transitioned.
+// This allows for the evaluation of features such as those derived
+// from street names, consistency of edge transitions, etc.
+//
+// The edge is described by the following diagram:
+// ```
+//
+//                             75%
+//                          Departure
+//                              |
+//         + ---- + ---- + ---- + ---- + End of edge
+//   Start of edge       |
+//                     Join
+//                      50%
+// ```
+// The `join_percent` and `depart_percent` describe the percentage
+// of the edge that the vehicle was on when it joined and departed
+// the edge, respectively, see diagram.
+//
+// The `routed_length` is the length of the edge in the match, in meters,
+// not the length of the underlying edge.
+message RouteEdge {
+  // The edge information for the routed component.
+  // Note:
+  //  As seen in the message comment, there is no guarantee the entire edge is utilised.
+  //  Therefore, this message is used to determine the utilised edge segment.
+  Edge edge = 1;
+
+  // TODO: Direction (?)
+
+  // Join %. See message comment.
+  uint32 join_percent = 5;
+
+  // Depart %. See message comment.
+  uint32 depart_percent = 6;
+
+  // Length of the routed segment of the edge, in meters.
+  uint32 routed_length = 7;
+}
+
+message RouteElement {
+  Coordinate coordinate = 1;
+  RouteEdge edge = 2;
+}
+
+message MatchedRoute {
+  repeated RouteElement discretized = 1;
+  repeated RouteElement interpolated = 2;
+
+  uint32 cost = 5;
+}

--- a/libs/routers_grpc/src/definition.rs
+++ b/libs/routers_grpc/src/definition.rs
@@ -11,11 +11,11 @@ pub mod proto {
 }
 
 pub mod api {
-    pub use super::proto::api::*;
+    pub use super::proto::routers::api::*;
 }
 
 pub mod model {
-    pub use super::proto::model::v1::*;
+    pub use super::proto::routers::model::v1::*;
 }
 
 pub mod optimise {


### PR DESCRIPTION
Scopes the protobuf to the `routers` project so that imports import as `routers/...` instead of simply `model/...` which reduces the likelihood of package collisions, or otherwise.