### PR TITLE
feat: Reduction in Allocations in Codec

### DIFF
--- a/libs/routers_codec/src/osm/block/item.rs
+++ b/libs/routers_codec/src/osm/block/item.rs
@@ -90,7 +90,7 @@ impl BlockItem {
     }
 
     #[inline]
-    pub fn element_iter(&self) -> impl Iterator<Item = ProcessedElement> + '_ {
+    pub fn element_iter(&self) -> impl Iterator<Item = ProcessedElement<'_>> + '_ {
         match self {
             BlockItem::PrimitiveBlock(primitive) => Either::Left(
                 primitive
@@ -117,7 +117,7 @@ impl BlockItem {
     }
 
     #[inline]
-    pub fn par_iter(&mut self) -> impl ParallelIterator<Item = ProcessedElement> + '_ {
+    pub fn par_iter(&mut self) -> impl ParallelIterator<Item = ProcessedElement<'_>> + '_ {
         match self {
             BlockItem::PrimitiveBlock(primitive) => Either::Left(
                 primitive

--- a/libs/routers_codec/src/osm/element/item.rs
+++ b/libs/routers_codec/src/osm/element/item.rs
@@ -19,15 +19,18 @@ pub enum Element<'a> {
 }
 
 #[derive(Clone)]
-pub enum ProcessedElement {
+pub enum ProcessedElement<'a> {
     Node(Node<OsmEntryId>),
-    Way(Way),
-    Relation(Relation),
+    Way(Way<'a>),
+    Relation(Relation<'a>),
 }
 
-impl ProcessedElement {
+impl<'a> ProcessedElement<'a> {
     #[inline]
-    pub(crate) fn from_raw(element: Element, block: &osm::PrimitiveBlock) -> Vec<ProcessedElement> {
+    pub(crate) fn from_raw(
+        element: Element<'a>,
+        block: &'a osm::PrimitiveBlock,
+    ) -> Vec<ProcessedElement<'a>> {
         #[cfg(feature = "tracing")]
         if block.lat_offset.is_some() || block.lon_offset.is_some() || block.granularity.is_some() {
             debug!(

--- a/libs/routers_codec/src/osm/element/processed_iterator.rs
+++ b/libs/routers_codec/src/osm/element/processed_iterator.rs
@@ -22,11 +22,11 @@ impl ProcessedElementIterator {
 }
 
 impl Parallel for ProcessedElementIterator {
-    type Item<'a> = ProcessedElement;
+    type Item<'a> = ProcessedElement<'a>;
 
     fn for_each<F>(mut self, f: F)
     where
-        F: Fn(ProcessedElement) + Send + Sync,
+        F: for<'a> Fn(ProcessedElement<'a>) + Send + Sync,
     {
         self.iter.par_iter().for_each(|mut block| {
             block.par_iter().for_each(&f);
@@ -40,7 +40,7 @@ impl Parallel for ProcessedElementIterator {
         ident: Identity,
     ) -> T
     where
-        Map: Fn(ProcessedElement) -> T + Send + Sync,
+        Map: for<'a> Fn(ProcessedElement<'a>) -> T + Send + Sync,
         Reduce: Fn(T, T) -> T + Send + Sync,
         Identity: Fn() -> T + Send + Sync,
         T: Send,
@@ -58,7 +58,7 @@ impl Parallel for ProcessedElementIterator {
         ident: Identity,
     ) -> T
     where
-        Reduce: Fn(T, ProcessedElement) -> T + Send + Sync,
+        Reduce: for<'a> Fn(T, ProcessedElement<'a>) -> T + Send + Sync,
         Identity: Fn() -> T + Send + Sync,
         Combine: Fn(T, T) -> T + Send + Sync,
         T: Send,

--- a/libs/routers_codec/src/osm/element/variants/mod.rs
+++ b/libs/routers_codec/src/osm/element/variants/mod.rs
@@ -349,13 +349,13 @@ pub mod common {
         #[inline]
         pub fn one_way(&self) -> bool {
             self.get(Tags::ONE_WAY)
-                .is_some_and(|v| *v == "yes" || *v == "-1")
+                .is_some_and(|&v| v == "yes" || v == "-1")
         }
 
         #[inline]
         pub fn roundabout(&self) -> bool {
             self.get(Tags::JUNCTION)
-                .is_some_and(|v| *v == "roundabout" || *v == "circular")
+                .is_some_and(|&v| v == "roundabout" || v == "circular")
         }
 
         // Source: https://wiki.openstreetmap.org/wiki/Default_speed_limits

--- a/libs/routers_codec/src/osm/element/variants/mod.rs
+++ b/libs/routers_codec/src/osm/element/variants/mod.rs
@@ -139,8 +139,12 @@ pub mod common {
         }
     }
 
+    /// A relation-member role. Owned because the role string is recovered
+    /// from the block but `References` flows out of the Way/Relation as an
+    /// owned value (Way refs never carry roles — all `role=-1` — so this
+    /// allocation only fires for relations, which aren't on the hot path).
     #[derive(Clone, Debug)]
-    pub struct Role(pub TagString);
+    pub struct Role(pub String);
 
     #[derive(Clone, Debug)]
     pub struct Reference {
@@ -219,7 +223,7 @@ pub mod common {
                     let role = if *role == -1 {
                         None
                     } else {
-                        Some(Role(TagString::recover(*role as usize, block)))
+                        Some(Role(recover_str(*role as usize, block).to_string()))
                     };
 
                     #[cfg(debug_assertions)]
@@ -263,110 +267,95 @@ pub mod common {
         }
     }
 
-    #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Hash)]
-    pub struct TagString(String);
+    /// Resolve stringtable index `k` to a `&str` that borrows directly into
+    /// the block's bytes. UTF-8 validation runs lazily here — PBF entries
+    /// are valid UTF-8 in practice, so this is allocation-free in the
+    /// happy path. Out-of-range or invalid UTF-8 falls back to `""`.
+    #[inline]
+    pub fn recover_str<'b>(k: usize, block: &'b PrimitiveBlock) -> &'b str {
+        block
+            .stringtable
+            .s
+            .get(k)
+            .and_then(|bytes| core::str::from_utf8(bytes).ok())
+            .unwrap_or("")
+    }
 
-    impl Deref for TagString {
-        type Target = String;
+    /// Tag keys and values borrowed from a block's stringtable.
+    ///
+    /// `Tags<'a>` is a thin wrapper around `HashMap<&'a str, &'a str>` —
+    /// no `String` allocations per tag, no `TagString` indirection. Lookups
+    /// take `&str` directly via the standard HashMap `Borrow` plumbing.
+    #[derive(Clone, Debug)]
+    pub struct Tags<'a>(HashMap<&'a str, &'a str>);
 
-        fn deref(&self) -> &Self::Target {
-            &self.0
+    pub trait Taggable {
+        fn indices(&self) -> impl Iterator<Item = (&u32, &u32)>;
+        fn tags<'b>(&self, block: &'b PrimitiveBlock) -> Tags<'b> {
+            Tags::from_block(self.indices(), block)
         }
     }
 
-    impl From<String> for TagString {
-        fn from(s: String) -> Self {
-            TagString(s)
-        }
-    }
-
-    impl From<&str> for TagString {
-        fn from(s: &str) -> Self {
-            TagString(s.to_string())
-        }
-    }
-
-    impl TagString {
+    impl<'a> Tags<'a> {
         pub(crate) const HIGHWAY: &'static str = "highway";
         pub(crate) const ONE_WAY: &'static str = "oneway";
         pub(crate) const JUNCTION: &'static str = "junction";
         pub(crate) const LANES: &'static str = "lanes";
         pub(crate) const MAX_SPEED: &'static str = "maxspeed";
 
-        pub fn recover(k: usize, block: &PrimitiveBlock) -> TagString {
-            TagString::from(String::from_utf8_lossy(&block.stringtable.s[k]).into_owned())
-        }
-
-        pub fn parse<F: FromStr>(&self) -> Option<F> {
-            FromStr::from_str(self.as_str()).ok()
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub struct Tags(HashMap<TagString, TagString>);
-
-    pub trait Taggable {
-        fn indices(&self) -> impl Iterator<Item = (&u32, &u32)>;
-        fn tags(&self, block: &PrimitiveBlock) -> Tags {
-            Tags::from_block(self.indices(), block)
-        }
-    }
-
-    impl Tags {
-        pub fn new(map: HashMap<TagString, TagString>) -> Self {
+        pub fn new(map: HashMap<&'a str, &'a str>) -> Self {
             Tags(map)
         }
 
-        /// Takes an iterator of indicies within the string table of the
-        /// associated block, and recovers the strings at the specified
-        /// indexes, to generate an associative hashmap of the tag keys and values.
+        /// Takes an iterator of indices into the block's stringtable and
+        /// resolves each (key, value) pair as `&str` borrowed straight
+        /// from the block's bytes.
         ///
-        /// The iterator must yield in the order of (KeyIndex, ValueIndex).
-        /// This is most often implemented under the Taggable trait.
-        pub fn from_block<'a>(
-            iter: impl Iterator<Item = (&'a u32, &'a u32)>,
-            block: &PrimitiveBlock,
-        ) -> Self {
+        /// The iterator's items can borrow from any source (typically the
+        /// raw `osm::Way`/`osm::Relation` that owns the index arrays) —
+        /// the resulting `Tags<'a>` only borrows from the block.
+        pub fn from_block<'i, I>(iter: I, block: &'a PrimitiveBlock) -> Self
+        where
+            I: Iterator<Item = (&'i u32, &'i u32)>,
+        {
             Tags(
                 iter.map(|(&k, &v)| {
                     (
-                        TagString::recover(k as usize, block),
-                        TagString::recover(v as usize, block),
+                        recover_str(k as usize, block),
+                        recover_str(v as usize, block),
                     )
                 })
-                .collect::<HashMap<TagString, TagString>>(),
+                .collect(),
             )
         }
 
-        fn r#use(assoc: &str) -> TagString {
-            TagString::from(assoc)
+        #[inline]
+        pub(crate) fn get(&self, assoc: &str) -> Option<&&'a str> {
+            self.0.get(assoc)
         }
 
-        pub(crate) fn get(&self, assoc: &str) -> Option<&TagString> {
-            self.0.get(&Tags::r#use(assoc))
-        }
-
+        #[inline]
         pub(crate) fn r#as<F: FromStr>(&self, assoc: &str) -> Option<F> {
-            self.get(assoc).and_then(TagString::parse::<F>)
+            self.get(assoc).and_then(|v| F::from_str(v).ok())
         }
 
         #[inline]
         pub fn road_tag(&self) -> Option<&str> {
-            self.get(TagString::HIGHWAY)
-                .map(|v| v.as_str())
+            self.get(Tags::HIGHWAY)
+                .copied()
                 .filter(|v| VALID_ROADWAYS.contains(v))
         }
 
         #[inline]
         pub fn one_way(&self) -> bool {
-            self.get(TagString::ONE_WAY)
-                .is_some_and(|v| v.as_str() == "yes" || v.as_str() == "-1")
+            self.get(Tags::ONE_WAY)
+                .is_some_and(|v| *v == "yes" || *v == "-1")
         }
 
         #[inline]
         pub fn roundabout(&self) -> bool {
-            self.get(TagString::JUNCTION)
-                .is_some_and(|v| v.as_str() == "roundabout" || v.as_str() == "circular")
+            self.get(Tags::JUNCTION)
+                .is_some_and(|v| *v == "roundabout" || *v == "circular")
         }
 
         // Source: https://wiki.openstreetmap.org/wiki/Default_speed_limits
@@ -378,8 +367,8 @@ pub mod common {
         }
     }
 
-    impl Deref for Tags {
-        type Target = HashMap<TagString, TagString>;
+    impl<'a> Deref for Tags<'a> {
+        type Target = HashMap<&'a str, &'a str>;
 
         fn deref(&self) -> &Self::Target {
             &self.0

--- a/libs/routers_codec/src/osm/element/variants/relation.rs
+++ b/libs/routers_codec/src/osm/element/variants/relation.rs
@@ -3,14 +3,14 @@ use crate::osm;
 use crate::osm::element::variants::Intermediate;
 
 #[derive(Clone, Debug)]
-pub struct Relation {
+pub struct Relation<'a> {
     pub id: i64,
-    pub tags: Tags,
+    pub tags: Tags<'a>,
     pub refs: References,
 }
 
-impl Relation {
-    pub fn from_raw(relation: &osm::Relation, block: &osm::PrimitiveBlock) -> Self {
+impl<'a> Relation<'a> {
+    pub fn from_raw(relation: &'a osm::Relation, block: &'a osm::PrimitiveBlock) -> Self {
         Self {
             id: relation.id,
             tags: relation.tags(block),

--- a/libs/routers_codec/src/osm/element/variants/way.rs
+++ b/libs/routers_codec/src/osm/element/variants/way.rs
@@ -11,24 +11,24 @@ use crate::osm::PrimitiveBlock;
 use crate::osm::element::variants::Intermediate;
 
 #[derive(Clone, Debug)]
-pub struct Way {
+pub struct Way<'a> {
     id: OsmEntryId,
     refs: References,
-    tags: Tags,
+    tags: Tags<'a>,
 }
 
-impl Way {
+impl<'a> Way<'a> {
     pub fn id(&self) -> OsmEntryId {
         self.id
     }
 
     #[inline]
-    pub fn tags_owned(self) -> Tags {
+    pub fn tags_owned(self) -> Tags<'a> {
         self.tags
     }
 
     #[inline]
-    pub fn tags(&self) -> &Tags {
+    pub fn tags(&self) -> &Tags<'a> {
         &self.tags
     }
 
@@ -38,7 +38,7 @@ impl Way {
     }
 
     #[inline]
-    pub fn from_raw(value: &osm::Way, block: &PrimitiveBlock) -> Self {
+    pub fn from_raw(value: &'a osm::Way, block: &'a PrimitiveBlock) -> Self {
         Way {
             id: OsmEntryId::way(value.id),
             refs: value.references(block),

--- a/libs/routers_codec/src/osm/mod.rs
+++ b/libs/routers_codec/src/osm/mod.rs
@@ -61,7 +61,7 @@ pub mod meta {
 
     use crate::osm::access_tag::AccessTag;
     use crate::osm::access_tag::access::AccessValue;
-    use crate::osm::element::{TagString, Tags};
+    use crate::osm::element::Tags;
     use crate::osm::primitives::condition::VehicleProperty;
     use crate::osm::primitives::*;
     use crate::osm::speed_limit::SpeedLimitCollection;
@@ -81,14 +81,14 @@ pub mod meta {
     }
 
     impl Metadata for OsmEdgeMetadata {
-        type Raw<'a> = &'a Tags;
+        type Raw<'a> = &'a Tags<'a>;
         type Runtime = OsmTripConfiguration;
         type TripContext = primitive::context::TripContext;
 
         fn pick(raw: Self::Raw<'_>) -> Self {
             Self {
-                road_class: raw.r#as::<RoadClass>(TagString::HIGHWAY),
-                lane_count: raw.r#as::<NonZeroU8>(TagString::LANES),
+                road_class: raw.r#as::<RoadClass>(Tags::HIGHWAY),
+                lane_count: raw.r#as::<NonZeroU8>(Tags::LANES),
                 speed_limit: raw.speed_limit(),
                 access: raw.access(),
             }

--- a/libs/routers_codec/src/osm/parsers/access_tag/access.rs
+++ b/libs/routers_codec/src/osm/parsers/access_tag/access.rs
@@ -1,5 +1,5 @@
 use crate::osm::speed_limit::restriction::Restriction;
-use crate::osm::{Parser, TagString, Tags};
+use crate::osm::{Parser, Tags};
 
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display, EnumIter, EnumString};
@@ -103,7 +103,7 @@ impl AccessTag {
         })
     }
 
-    fn from_tag((key, value): (&TagString, &TagString)) -> Option<Self> {
+    fn from_tag((key, value): (&&str, &&str)) -> Option<Self> {
         Self::from_key_value(key, value).ok()
     }
 
@@ -114,7 +114,7 @@ impl AccessTag {
 }
 
 impl Parser for Vec<AccessTag> {
-    fn parse(tags: &Tags) -> Option<Self> {
+    fn parse(tags: &Tags<'_>) -> Option<Self> {
         let as_vec = tags
             .iter()
             .filter_map(AccessTag::from_tag)

--- a/libs/routers_codec/src/osm/parsers/access_tag/mod.rs
+++ b/libs/routers_codec/src/osm/parsers/access_tag/mod.rs
@@ -8,7 +8,7 @@ pub trait Access {
     fn access(&self) -> Vec<AccessTag>;
 }
 
-impl Access for Tags {
+impl Access for Tags<'_> {
     fn access(&self) -> Vec<AccessTag> {
         Vec::<AccessTag>::parse(self)
             .unwrap_or_default()

--- a/libs/routers_codec/src/osm/parsers/mod.rs
+++ b/libs/routers_codec/src/osm/parsers/mod.rs
@@ -6,5 +6,5 @@ pub use access_tag::Access;
 pub use speed_limit::SpeedLimit;
 
 pub trait Parser: Sized {
-    fn parse(tags: &crate::osm::Tags) -> Option<Self>;
+    fn parse(tags: &crate::osm::Tags<'_>) -> Option<Self>;
 }

--- a/libs/routers_codec/src/osm/parsers/speed_limit/collection.rs
+++ b/libs/routers_codec/src/osm/parsers/speed_limit/collection.rs
@@ -1,4 +1,4 @@
-use crate::osm::element::{TagString, Tags};
+use crate::osm::element::Tags;
 use crate::osm::speed_limit::limit::{SpeedLimitEntry, SpeedLimitVariant};
 use crate::osm::speed_limit::subtypes::SpeedLimitConditions;
 use crate::osm::speed_limit::{PossiblyConditionalSpeedLimit, SpeedLimitExt};
@@ -54,11 +54,11 @@ impl SpeedLimitExt for SpeedLimitCollection {
 }
 
 impl Parser for SpeedLimitCollection {
-    fn parse(tags: &Tags) -> Option<Self> {
+    fn parse(tags: &Tags<'_>) -> Option<Self> {
         // Standard structure follows:
         let known_limits = tags
             .iter()
-            .filter(|(key, _)| key.starts_with(TagString::MAX_SPEED))
+            .filter(|(key, _)| key.starts_with(Tags::MAX_SPEED))
             .filter_map(|(l, v)| SpeedLimitEntry::parse_tag(l, v))
             .sorted_by_key(|item| format!("{:?}", item))
             .collect::<Vec<_>>();

--- a/libs/routers_codec/src/osm/parsers/speed_limit/limit.rs
+++ b/libs/routers_codec/src/osm/parsers/speed_limit/limit.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::osm::element::TagString;
 use crate::osm::primitives::*;
 use crate::osm::speed_limit::restriction::{Restriction, RestrictionOptionals};
 use crate::osm::speed_limit::subtypes;
@@ -121,7 +120,7 @@ pub struct SpeedLimitEntry {
 }
 
 impl SpeedLimitEntry {
-    pub(crate) fn parse_tag(label: &TagString, value: &TagString) -> Option<Self> {
+    pub(crate) fn parse_tag(label: &&str, value: &&str) -> Option<Self> {
         let restriction = Restriction::parse(label);
 
         // Is lane-based (i.e. maxspeed:lanes=50|20|10)
@@ -136,8 +135,7 @@ impl SpeedLimitEntry {
 
             SpeedLimitVariant::PerLane(PerLaneSpeedLimit(per_lane_limit))
         } else {
-            let as_str = value.as_str();
-            let speed_limit = PossiblyConditionalSpeedLimit::parse(as_str)?;
+            let speed_limit = PossiblyConditionalSpeedLimit::parse(value)?;
             SpeedLimitVariant::Blanket(speed_limit)
         };
 

--- a/libs/routers_codec/src/osm/parsers/speed_limit/mod.rs
+++ b/libs/routers_codec/src/osm/parsers/speed_limit/mod.rs
@@ -31,7 +31,7 @@ pub trait SpeedLimit {
     fn speed_limit(&self) -> Option<SpeedLimitCollection>;
 }
 
-impl SpeedLimit for Tags {
+impl SpeedLimit for Tags<'_> {
     fn speed_limit(&self) -> Option<SpeedLimitCollection> {
         SpeedLimitCollection::parse(self)
     }

--- a/libs/routers_codec/src/osm/parsers/speed_limit/test.rs
+++ b/libs/routers_codec/src/osm/parsers/speed_limit/test.rs
@@ -1,7 +1,7 @@
 #![allow(unsafe_code)]
 
 use crate::osm::Parser;
-use crate::osm::element::{TagString, Tags};
+use crate::osm::element::Tags;
 
 use crate::osm::speed_limit::SpeedLimitCollection;
 use crate::osm::speed_limit::limit::SpeedLimitEntry;
@@ -15,9 +15,9 @@ use core::num::NonZeroU16;
 use std::collections::HashMap;
 
 #[cfg(test)]
-fn parse_singular(key: &str, value: &str) -> SpeedLimitEntry {
-    let mut tags = HashMap::new();
-    tags.insert(TagString::from(key), TagString::from(value));
+fn parse_singular<'a>(key: &'a str, value: &'a str) -> SpeedLimitEntry {
+    let mut tags: HashMap<&'a str, &'a str> = HashMap::new();
+    tags.insert(key, value);
 
     let as_tags = Tags::new(tags);
     let limit = SpeedLimitCollection::parse(&as_tags);


### PR DESCRIPTION
A performance win when reducing allocations by removing the `TagString` abstraction, which is slightly cleaner as well. This is mostly to offset the performance loss from migrating to `buffa`.