### PR TITLE
feat: WASM Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6006,7 +6006,6 @@ dependencies = [
  "buffa",
  "bytes",
  "codspeed-criterion-compat",
- "connectrpc",
  "either",
  "flate2",
  "geo",
@@ -6028,6 +6027,7 @@ dependencies = [
  "test-log",
  "tracing",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,8 +1372,6 @@ dependencies = [
  "compression-core",
  "flate2",
  "memchr",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -1421,7 +1419,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "wasm-bindgen-futures",
- "zstd",
 ]
 
 [[package]]
@@ -9442,34 +9439,6 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,14 @@ test-log = { version = "0.2.18", features = ["log"] }
 buffa = { version = "0.6.0", features = ["json"] }
 buffa-types = { version = "0.6.0", features = ["json"] }
 buffa-descriptor = { version = "0.6.0" }
-connectrpc = { version = "0.6.0" }
+connectrpc = {
+    version = "0.6.0",
+    default-features = false,
+    features = [
+        "gzip",
+        "streaming",
+    ]
+}
 
 serde_json = "1"
 http-body = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,14 +64,7 @@ test-log = { version = "0.2.18", features = ["log"] }
 buffa = { version = "0.6.0", features = ["json"] }
 buffa-types = { version = "0.6.0", features = ["json"] }
 buffa-descriptor = { version = "0.6.0" }
-connectrpc = {
-    version = "0.6.0",
-    default-features = false,
-    features = [
-        "gzip",
-        "streaming",
-    ]
-}
+connectrpc = { version = "0.6.0", default-features = false, features = [ "gzip", "streaming" ] }
 
 serde_json = "1"
 http-body = "1"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,11 +1,5 @@
 # Not avaliable on WASM
 disallowed-methods = [
-    {
-        path = "std::time::Instant::now",
-        reason = "use web_time::Instant::now"
-    },
-    {
-        path = "std::time::SystemTime::now",
-        reason = "use web_time::SystemTime::now"
-    },
+    { path = "std::time::Instant::now", reason = "use web_time::Instant::now" },
+    { path = "std::time::SystemTime::now", reason = "use web_time::SystemTime::now" },
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,11 @@
+# Not avaliable on WASM
+disallowed-methods = [
+    {
+        path = "std::time::Instant::now",
+        reason = "use web_time::Instant::now"
+    },
+    {
+        path = "std::time::SystemTime::now",
+        reason = "use web_time::SystemTime::now"
+    },
+]

--- a/libs/routers_codec/Cargo.toml
+++ b/libs/routers_codec/Cargo.toml
@@ -21,7 +21,6 @@ schema = { workspace = true }
 bytes = { workspace = true }
 serde = { workspace = true }
 buffa = { workspace = true }
-connectrpc = { workspace = true }
 
 # GeoRust
 geo = { workspace = true, features = ["serde"] }
@@ -41,13 +40,25 @@ itertools = { workspace = true }
 
 # Compression
 flate2 = { version = "1.1.9", features = ["zlib-rs"] }
-mimalloc = { version = "0.1.46", optional = true }
+
+# Drop-in for `std::time::Instant` that doesn't panic on
+# `wasm32-unknown-unknown`. Used by the byte-oriented `from_bytes` /
+# `to_bytes` paths that are wasm-reachable.
+web-time = "1"
 
 # Misc.
 # TODO: Remove dependency.
 either = "1.15.0"
 regex = "1.11.1"
 bitflags = "2.9.1"
+
+# `mimalloc` is a native-only dependency — it has no `wasm32-unknown-unknown`
+# target. We pull it in under a target-cfg so that even a `--features mimalloc`
+# build can be cross-compiled to WASM without the linker exploding. The
+# `[features]` block below still references `dep:mimalloc`; Cargo activates
+# the dep only when the target cfg matches.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+mimalloc = { version = "0.1.46", optional = true }
 
 [dev-dependencies]
 routers_fixtures = { workspace = true }

--- a/libs/routers_codec/Cargo.toml
+++ b/libs/routers_codec/Cargo.toml
@@ -41,9 +41,7 @@ itertools = { workspace = true }
 # Compression
 flate2 = { version = "1.1.9", features = ["zlib-rs"] }
 
-# Drop-in for `std::time::Instant` that doesn't panic on
-# `wasm32-unknown-unknown`. Used by the byte-oriented `from_bytes` /
-# `to_bytes` paths that are wasm-reachable.
+# Drop-in for `std::time::Instant`
 web-time = "1"
 
 # Misc.
@@ -52,11 +50,6 @@ either = "1.15.0"
 regex = "1.11.1"
 bitflags = "2.9.1"
 
-# `mimalloc` is a native-only dependency — it has no `wasm32-unknown-unknown`
-# target. We pull it in under a target-cfg so that even a `--features mimalloc`
-# build can be cross-compiled to WASM without the linker exploding. The
-# `[features]` block below still references `dep:mimalloc`; Cargo activates
-# the dep only when the target cfg matches.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 mimalloc = { version = "0.1.46", optional = true }
 

--- a/libs/routers_codec/build.rs
+++ b/libs/routers_codec/build.rs
@@ -1,0 +1,55 @@
+//! Builds a stable fingerprint of the source files that determine the
+//! `OsmNetwork` on-disk layout. The fingerprint becomes part of every
+//! cache file written by [`OsmNetwork::save_to_file`], so any change to
+//! these files automatically invalidates older caches with a clear error
+//! instead of a `postcard` panic.
+//!
+//! Files outside this list (parsers, error types, the iterator machinery)
+//! can change freely without touching cache compatibility — the goal is
+//! "only regenerate when needed", not "regenerate on every recompile".
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// FNV-1a 64-bit. Deterministic across builds and platforms (unlike
+/// `DefaultHasher`, which is randomised). No dependency needed.
+fn fnv1a(bytes: &[u8], h: u64) -> u64 {
+    let mut h = h;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+fn main() {
+    let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    // Curated list — only files that define types appearing in the
+    // serialised payload of `OsmNetwork`.
+    let files = [
+        "src/osm/graph.rs",
+        "src/osm/element/variants/mod.rs",
+        "src/osm/element/variants/way.rs",
+        "src/osm/element/variants/node.rs",
+        "src/osm/element/variants/relation.rs",
+    ];
+
+    let mut h: u64 = 0xcbf29ce484222325;
+    for rel in files {
+        let path: &Path = &manifest.join(rel);
+        let bytes = fs::read(path)
+            .unwrap_or_else(|e| panic!("build.rs: cannot read {} — {e}", path.display()));
+        h = fnv1a(rel.as_bytes(), h);
+        h = fnv1a(&bytes, h);
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+
+    let out = PathBuf::from(env::var("OUT_DIR").unwrap()).join("format_hash.rs");
+    fs::write(
+        &out,
+        format!("pub(crate) const FORMAT_HASH: u64 = {h}u64;\n"),
+    )
+    .unwrap();
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/libs/routers_codec/build.rs
+++ b/libs/routers_codec/build.rs
@@ -1,16 +1,11 @@
 //! Builds a stable fingerprint of the source files that determine the
-//! `OsmNetwork` on-disk layout. The fingerprint becomes part of every
-//! cache file written by [`OsmNetwork::save_to_file`], so any change to
-//! these files automatically invalidates older caches with a clear error
-//! instead of a `postcard` panic.
-//!
-//! Files outside this list (parsers, error types, the iterator machinery)
-//! can change freely without touching cache compatibility — the goal is
-//! "only regenerate when needed", not "regenerate on every recompile".
+//! `OsmNetwork` on-disk layout.
 
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+const HASH_SEED: u64 = 0xcbf29ce484222325;
 
 /// FNV-1a 64-bit. Deterministic across builds and platforms (unlike
 /// `DefaultHasher`, which is randomised). No dependency needed.
@@ -25,6 +20,7 @@ fn fnv1a(bytes: &[u8], h: u64) -> u64 {
 
 fn main() {
     let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+
     // Curated list — only files that define types appearing in the
     // serialised payload of `OsmNetwork`.
     let files = [
@@ -35,13 +31,16 @@ fn main() {
         "src/osm/element/variants/relation.rs",
     ];
 
-    let mut h: u64 = 0xcbf29ce484222325;
+    let mut h: u64 = HASH_SEED;
+
     for rel in files {
         let path: &Path = &manifest.join(rel);
         let bytes = fs::read(path)
-            .unwrap_or_else(|e| panic!("build.rs: cannot read {} — {e}", path.display()));
+            .unwrap_or_else(|e| panic!("build.rs: cannot read {}: {e}", path.display()));
+
         h = fnv1a(rel.as_bytes(), h);
         h = fnv1a(&bytes, h);
+
         println!("cargo:rerun-if-changed={}", path.display());
     }
 

--- a/libs/routers_codec/src/lib.rs
+++ b/libs/routers_codec/src/lib.rs
@@ -2,11 +2,15 @@
 
 extern crate alloc;
 
-#[cfg(feature = "mimalloc")]
+// `mimalloc` is only ever compiled on non-WASM targets (see Cargo.toml),
+// so the `global_allocator` registration is gated on the same cfg to keep
+// `cargo check --target wasm32-unknown-unknown --features mimalloc` from
+// trying to reach a dep that simply isn't there.
+#[cfg(all(feature = "mimalloc", not(target_arch = "wasm32")))]
 use mimalloc::MiMalloc;
 
-#[cfg_attr(feature = "mimalloc", global_allocator)]
-#[cfg(feature = "mimalloc")]
+#[cfg(all(feature = "mimalloc", not(target_arch = "wasm32")))]
+#[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
 pub mod osm;

--- a/libs/routers_codec/src/lib.rs
+++ b/libs/routers_codec/src/lib.rs
@@ -2,10 +2,6 @@
 
 extern crate alloc;
 
-// `mimalloc` is only ever compiled on non-WASM targets (see Cargo.toml),
-// so the `global_allocator` registration is gated on the same cfg to keep
-// `cargo check --target wasm32-unknown-unknown --features mimalloc` from
-// trying to reach a dep that simply isn't there.
 #[cfg(all(feature = "mimalloc", not(target_arch = "wasm32")))]
 use mimalloc::MiMalloc;
 

--- a/libs/routers_codec/src/osm/element/variants/mod.rs
+++ b/libs/routers_codec/src/osm/element/variants/mod.rs
@@ -50,6 +50,7 @@ pub mod common {
     pub struct OsmEntryId {
         pub identifier: i64,
         #[cfg(debug_assertions)]
+        #[serde(skip)]
         variant: i32,
     }
 

--- a/libs/routers_codec/src/osm/graph.rs
+++ b/libs/routers_codec/src/osm/graph.rs
@@ -42,9 +42,6 @@ pub struct OsmNetwork {
     pub hash: FxHashMap<OsmEntryId, Node<OsmEntryId>>,
     pub meta: FxHashMap<OsmEntryId, OsmEdgeMetadata>,
 
-    /// Spatial index of nodes. Rebuilt on load — see [`Self::rebuild_indices`].
-    /// Bulk-loading is faster than letting `postcard` decode the internal
-    /// `rstar` tree, and it also shrinks the on-disk file substantially.
     #[serde(skip)]
     pub index: RTree<Node<OsmEntryId>>,
     #[serde(skip)]
@@ -57,33 +54,38 @@ impl OsmNetwork {
     /// targets where bytes arrive via `fetch()` or similar.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
         const HEADER_LEN: usize = SAVE_MAGIC.len() + 8;
+
         if bytes.len() < HEADER_LEN || &bytes[..SAVE_MAGIC.len()] != SAVE_MAGIC {
-            return Err(
-                "OsmNetwork bytes are missing the magic header — likely from a previous format. Rebuild the cache.".to_string()
-            );
+            return Err("Header bytes are missing, try rebuilding the cache.".to_string());
         }
+
         let version = u64::from_le_bytes(
             bytes[SAVE_MAGIC.len()..HEADER_LEN]
                 .try_into()
                 .expect("8 bytes"),
         );
+
         if version != SAVE_VERSION {
             return Err(format!(
-                "OsmNetwork bytes have format hash {version:016x}, expected {SAVE_VERSION:016x}. The codec's serialised layout has changed — rebuild the cache."
+                "Header expects {SAVE_VERSION:016x}, got format hash {version:016x}, rebuild the cache."
             ));
         }
+
         let deserialise_start = Instant::now();
         let mut net: Self =
             postcard::from_bytes(&bytes[HEADER_LEN..]).map_err(|v| v.to_string())?;
+
         let deserialise = deserialise_start.elapsed();
         let rebuild_start = Instant::now();
         net.rebuild_indices();
+
         debug!(
             "OsmNetwork::from_bytes: {} bytes, deserialised in {:?}, rebuilt indices in {:?}",
             bytes.len(),
             deserialise,
             rebuild_start.elapsed()
         );
+
         Ok(net)
     }
 
@@ -93,9 +95,11 @@ impl OsmNetwork {
         let payload: Vec<u8> =
             postcard::to_allocvec(self).map_err(|e| format!("failed to serialise value: {e}"))?;
         let mut out = Vec::with_capacity(SAVE_MAGIC.len() + 8 + payload.len());
+
         out.extend_from_slice(SAVE_MAGIC);
         out.extend_from_slice(&SAVE_VERSION.to_le_bytes());
         out.extend_from_slice(&payload);
+
         Ok(out)
     }
 
@@ -321,13 +325,10 @@ impl OsmNetwork {
     pub fn num_nodes(&self) -> usize {
         self.graph.node_count()
     }
+}
 
-    /// An empty network — zero nodes, zero edges, empty spatial indices.
-    ///
-    /// Cheap to construct and useful as a "still loading" placeholder when
-    /// a viewer needs to be wired up before its real data has arrived
-    /// (e.g. before an async shard fetch completes in the browser).
-    pub fn empty() -> Self {
+impl Default for OsmNetwork {
+    fn default() -> Self {
         Self {
             graph: GraphStructure::new(),
             hash: FxHashMap::default(),

--- a/libs/routers_codec/src/osm/graph.rs
+++ b/libs/routers_codec/src/osm/graph.rs
@@ -1,11 +1,9 @@
 use petgraph::prelude::DiGraphMap;
 use routers_network::edge::Weight;
 use routers_network::network::GraphEdge;
-use routers_network::{
-    DirectionAwareEdgeId, Discovery, Edge, Metadata, Network, Node, Route, Scan,
-};
+use routers_network::{DirectionAwareEdgeId, Discovery, Edge, Node, Route, Scan};
 
-use log::{debug, info};
+use log::debug;
 use rstar::{AABB, RTree};
 use rustc_hash::{FxHashMap, FxHasher};
 use serde::{Deserialize, Serialize};
@@ -13,15 +11,30 @@ use serde::{Deserialize, Serialize};
 use core::fmt::Debug;
 use core::hash::BuildHasherDefault;
 use geo::Point;
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::time::Instant;
+use web_time::Instant;
 
+#[cfg(not(target_arch = "wasm32"))]
+use log::info;
+#[cfg(not(target_arch = "wasm32"))]
+use routers_network::Metadata;
+#[cfg(not(target_arch = "wasm32"))]
+use std::io::Write;
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::{Path, PathBuf};
+
+#[cfg(not(target_arch = "wasm32"))]
 use crate::osm::element::ProcessedElement;
 use crate::osm::*;
 
 pub type GraphStructure<E> =
     DiGraphMap<E, (Weight, DirectionAwareEdgeId<E>), BuildHasherDefault<FxHasher>>;
+
+/// Magic header stapled at the start of every `.rt` file.
+const SAVE_MAGIC: &[u8; 4] = b"OSMN";
+
+// Prevent files from being used across build revisions
+include!(concat!(env!("OUT_DIR"), "/format_hash.rs"));
+const SAVE_VERSION: u64 = FORMAT_HASH;
 
 #[derive(Serialize, Deserialize)]
 pub struct OsmNetwork {
@@ -29,36 +42,144 @@ pub struct OsmNetwork {
     pub hash: FxHashMap<OsmEntryId, Node<OsmEntryId>>,
     pub meta: FxHashMap<OsmEntryId, OsmEdgeMetadata>,
 
+    /// Spatial index of nodes. Rebuilt on load — see [`Self::rebuild_indices`].
+    /// Bulk-loading is faster than letting `postcard` decode the internal
+    /// `rstar` tree, and it also shrinks the on-disk file substantially.
+    #[serde(skip)]
     pub index: RTree<Node<OsmEntryId>>,
+    #[serde(skip)]
     pub index_edge: RTree<Edge<Node<OsmEntryId>>>,
 }
 
 impl OsmNetwork {
-    pub fn from_pbf_and_save(pbf_path: &PathBuf, saved_path: &PathBuf) -> Result<Self, String> {
-        if !saved_path.exists() {
-            let graph = OsmNetwork::from_pbf(pbf_path).expect("Graph must be created");
-            graph.save_to_file(saved_path).expect("must save to file");
+    /// Decode a previously-encoded `OsmNetwork` from a byte slice and
+    /// rebuild its spatial indices. Filesystem-free; suitable for WASM
+    /// targets where bytes arrive via `fetch()` or similar.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
+        const HEADER_LEN: usize = SAVE_MAGIC.len() + 8;
+        if bytes.len() < HEADER_LEN || &bytes[..SAVE_MAGIC.len()] != SAVE_MAGIC {
+            return Err(
+                "OsmNetwork bytes are missing the magic header — likely from a previous format. Rebuild the cache.".to_string()
+            );
         }
+        let version = u64::from_le_bytes(
+            bytes[SAVE_MAGIC.len()..HEADER_LEN]
+                .try_into()
+                .expect("8 bytes"),
+        );
+        if version != SAVE_VERSION {
+            return Err(format!(
+                "OsmNetwork bytes have format hash {version:016x}, expected {SAVE_VERSION:016x}. The codec's serialised layout has changed — rebuild the cache."
+            ));
+        }
+        let deserialise_start = Instant::now();
+        let mut net: Self =
+            postcard::from_bytes(&bytes[HEADER_LEN..]).map_err(|v| v.to_string())?;
+        let deserialise = deserialise_start.elapsed();
+        let rebuild_start = Instant::now();
+        net.rebuild_indices();
+        debug!(
+            "OsmNetwork::from_bytes: {} bytes, deserialised in {:?}, rebuilt indices in {:?}",
+            bytes.len(),
+            deserialise,
+            rebuild_start.elapsed()
+        );
+        Ok(net)
+    }
 
-        let graph = OsmNetwork::from_saved(saved_path).expect("Graph must be created");
+    /// Encode `self` into a `Vec<u8>` with the format header prepended.
+    /// Counterpart to [`from_bytes`](Self::from_bytes); filesystem-free.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
+        let payload: Vec<u8> =
+            postcard::to_allocvec(self).map_err(|e| format!("failed to serialise value: {e}"))?;
+        let mut out = Vec::with_capacity(SAVE_MAGIC.len() + 8 + payload.len());
+        out.extend_from_slice(SAVE_MAGIC);
+        out.extend_from_slice(&SAVE_VERSION.to_le_bytes());
+        out.extend_from_slice(&payload);
+        Ok(out)
+    }
+
+    /// Build an `OsmNetwork` either from a cached `.rt` file (fast path)
+    /// or, if the cache is missing or stale, from the source PBF (slow
+    /// path, writes the cache for next time).
+    ///
+    /// Filesystem-bound; not available on WASM targets — use
+    /// [`from_bytes`](Self::from_bytes) with HTTP-fetched cache bytes
+    /// instead.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_pbf_and_save(pbf_path: &PathBuf, saved_path: &PathBuf) -> Result<Self, String> {
+        if saved_path.exists() {
+            match OsmNetwork::from_saved(saved_path) {
+                Ok(g) => return Ok(g),
+                Err(e) => {
+                    log::warn!(
+                        "OsmNetwork cache at `{}` is unusable ({e}); rebuilding from PBF",
+                        saved_path.display()
+                    );
+                }
+            }
+        }
+        let graph = OsmNetwork::from_pbf(pbf_path).map_err(|e| e.to_string())?;
+        graph.save_to_file(saved_path)?;
         Ok(graph)
     }
 
-    /// Creates a graph from a `.osm.pbf` file, using the `ProcessedElementIterator`
+    /// Read a saved `.rt` from disk into an `OsmNetwork`. Thin wrapper
+    /// around [`from_bytes`](Self::from_bytes); not available on WASM.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_saved(filename: &PathBuf) -> Result<Self, String> {
-        let mut bytes = std::fs::read(filename).map_err(|v| v.to_string())?;
-        postcard::from_bytes::<Self>(&mut bytes).map_err(|v| v.to_string())
+        let bytes = std::fs::read(filename).map_err(|v| v.to_string())?;
+        Self::from_bytes(&bytes).map_err(|e| format!("cache file `{}`: {e}", filename.display()))
     }
 
+    /// Rebuilds the node and edge spatial indices from `hash` and `graph`.
+    /// Used after loading a serialised `OsmNetwork` (indices are skipped on
+    /// the wire) and is safe to call at any time.
+    pub fn rebuild_indices(&mut self) {
+        // The two `RTree`s are independent — parallelise the bulk-load so
+        // cache-hit cost is dominated by whichever tree is larger rather
+        // than their sum.
+        let nodes: Vec<Node<OsmEntryId>> = self.hash.values().copied().collect();
+        let edges: Vec<Edge<Node<OsmEntryId>>> = self
+            .graph
+            .all_edges()
+            .filter_map(|(s, t, &(weight, id))| {
+                let source = *self.hash.get(&s)?;
+                let target = *self.hash.get(&t)?;
+                Some(Edge {
+                    source,
+                    target,
+                    id: DirectionAwareEdgeId::new(Node::new(Point::new(0., 0.), id.index()))
+                        .with_direction(id.direction()),
+                    weight,
+                })
+            })
+            .collect();
+        let (node_index, edge_index) =
+            rayon::join(|| RTree::bulk_load(nodes), || RTree::bulk_load(edges));
+        self.index = node_index;
+        self.index_edge = edge_index;
+    }
+
+    /// Persist this network to disk. Thin wrapper around
+    /// [`to_bytes`](Self::to_bytes); not available on WASM.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn save_to_file(&self, path: &Path) -> Result<(), String> {
+        let bytes = self.to_bytes()?;
         let mut file = std::fs::File::create(path).map_err(|e| e.to_string())?;
-
-        let output: Vec<u8> =
-            postcard::to_allocvec(self).map_err(|e| format!("failed to serialise value: {e}"))?;
-
-        file.write_all(&output).map_err(|e| e.to_string())
+        file.write_all(&bytes).map_err(|e| e.to_string())?;
+        debug!(
+            "OsmNetwork::save_to_file wrote {} bytes (incl. 12-byte header, format {:016x}) to {}",
+            bytes.len(),
+            SAVE_VERSION,
+            path.display()
+        );
+        Ok(())
     }
 
+    /// Construct an `OsmNetwork` from a `.osm.pbf` file. Uses memory-mapped
+    /// IO, multithreaded parsing and rayon; not available on WASM.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_pbf(filename: &PathBuf) -> Result<Self, Box<dyn std::error::Error>> {
         let mut start_time = Instant::now();
         let fixed_start_time = Instant::now();
@@ -200,6 +321,21 @@ impl OsmNetwork {
     pub fn num_nodes(&self) -> usize {
         self.graph.node_count()
     }
+
+    /// An empty network — zero nodes, zero edges, empty spatial indices.
+    ///
+    /// Cheap to construct and useful as a "still loading" placeholder when
+    /// a viewer needs to be wired up before its real data has arrived
+    /// (e.g. before an async shard fetch completes in the browser).
+    pub fn empty() -> Self {
+        Self {
+            graph: GraphStructure::new(),
+            hash: FxHashMap::default(),
+            meta: FxHashMap::default(),
+            index: RTree::new(),
+            index_edge: RTree::new(),
+        }
+    }
 }
 
 impl Discovery<OsmEntryId> for OsmNetwork {
@@ -277,7 +413,10 @@ impl Debug for OsmNetwork {
     }
 }
 
-impl Network<OsmEntryId, OsmEdgeMetadata> for OsmNetwork {
+impl routers_network::DataPlane for OsmNetwork {
+    type Entry = OsmEntryId;
+    type Meta = OsmEdgeMetadata;
+
     fn metadata(&self, id: &OsmEntryId) -> Option<&OsmEdgeMetadata> {
         self.meta.get(id)
     }

--- a/libs/routers_network/src/traits/data_plane.rs
+++ b/libs/routers_network/src/traits/data_plane.rs
@@ -1,0 +1,102 @@
+//! The read-only data layer of a routing network.
+//!
+//! [`DataPlane`] captures the bits a consumer needs to look up nodes,
+//! ways and the graph topology *by identifier*. It deliberately knows
+//! nothing about routing or spatial queries — those live on the
+//! [`Route`](crate::Route), [`Scan`](crate::Scan) and
+//! [`Discovery`](crate::Discovery) traits.
+//!
+//! **Associated types vs. generics.** `DataPlane` exposes its `Entry` and
+//! `Metadata` types as associated types (`type Entry`, `type Meta`) rather
+//! than trait-level generics. This means downstream consumers — viewers,
+//! exporters — can bound on `N: DataPlane` alone and pick the concrete
+//! `N::Entry` / `N::Meta` off the type, instead of threading `<E, M, N>`
+//! through every signature. The full [`Network`](crate::Network) trait is
+//! still parameterised on `<E, M>` for backwards compatibility; the two
+//! styles bridge via the blanket impl in `network.rs`.
+
+use core::fmt::Debug;
+use std::sync::Arc;
+
+use crate::{DirectionAwareEdgeId, Edge, Entry, Metadata, Node, edge::Weight};
+use geo::Point;
+
+pub type EdgeData<E> = (Weight, DirectionAwareEdgeId<E>);
+pub type GraphEdge<E> = (E, E, EdgeData<E>);
+
+/// Read-only access to a routing network's nodes, ways and topology.
+///
+/// Implementors are typically concrete graph storage (e.g. `OsmNetwork`,
+/// `ShardedNetwork`). Composing them into the full [`Network`](crate::Network)
+/// trait is a matter of also implementing
+/// [`Scan`](crate::Scan) (nearest-neighbour) and [`Route`](crate::Route)
+/// (shortest path).
+pub trait DataPlane: Debug + Send + Sync {
+    type Entry: Entry;
+    type Meta: Metadata;
+
+    fn metadata(&self, id: &Self::Entry) -> Option<&Self::Meta>;
+
+    fn point(&self, id: &Self::Entry) -> Option<Point>;
+
+    fn edges_outof<'a>(
+        &'a self,
+        id: Self::Entry,
+    ) -> Box<dyn Iterator<Item = GraphEdge<Self::Entry>> + 'a>;
+    fn edges_into<'a>(
+        &'a self,
+        id: Self::Entry,
+    ) -> Box<dyn Iterator<Item = GraphEdge<Self::Entry>> + 'a>;
+
+    /// Produces an iterator of points for a given input.
+    ///
+    /// All provided nodes that do not exist will not be returned, so the iterator's
+    /// length may be smaller than the input slice.
+    fn line(&self, nodes: &[Self::Entry]) -> Vec<Point> {
+        nodes.iter().filter_map(|node| self.point(node)).collect()
+    }
+
+    fn fatten(&self, edge: &Edge<Self::Entry>) -> Option<Edge<Node<Self::Entry>>>;
+}
+
+// Blanket forward through `Arc<T>` so consumers (e.g. a viewer that swaps
+// the inner network as shards load) can hold their network behind an
+// `Arc` without losing trait-method access. The body of each call deref's
+// through the Arc to T's own impl.
+impl<T> DataPlane for Arc<T>
+where
+    T: DataPlane,
+{
+    type Entry = <T as DataPlane>::Entry;
+    type Meta = <T as DataPlane>::Meta;
+
+    fn metadata(&self, id: &Self::Entry) -> Option<&Self::Meta> {
+        (**self).metadata(id)
+    }
+
+    fn point(&self, id: &Self::Entry) -> Option<Point> {
+        (**self).point(id)
+    }
+
+    fn edges_outof<'a>(
+        &'a self,
+        id: Self::Entry,
+    ) -> Box<dyn Iterator<Item = GraphEdge<Self::Entry>> + 'a> {
+        (**self).edges_outof(id)
+    }
+
+    fn edges_into<'a>(
+        &'a self,
+        id: Self::Entry,
+    ) -> Box<dyn Iterator<Item = GraphEdge<Self::Entry>> + 'a> {
+        (**self).edges_into(id)
+    }
+
+    fn line(&self, nodes: &[Self::Entry]) -> Vec<Point> {
+        (**self).line(nodes)
+    }
+
+    fn fatten(&self, edge: &Edge<Self::Entry>) -> Option<Edge<Node<Self::Entry>>> {
+        (**self).fatten(edge)
+    }
+}

--- a/libs/routers_network/src/traits/discovery.rs
+++ b/libs/routers_network/src/traits/discovery.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use geo::{Destination, Geodesic, Point};
 use rstar::AABB;
 
@@ -66,6 +68,42 @@ pub trait Discovery<E: Entry> {
 
     fn node(&self, id: &E) -> Option<&Node<E>>;
     fn edge(&self, source: &E, target: &E) -> Option<Edge<E>>;
+}
+
+// Forward through `Arc<T>` so shard-managed networks can be held behind
+// an `Arc` without losing trait-method access.
+impl<T, E> Discovery<E> for Arc<T>
+where
+    T: Discovery<E>,
+    E: Entry,
+{
+    fn edges_in_box<'a>(
+        &'a self,
+        aabb: AABB<Point>,
+    ) -> Box<dyn Iterator<Item = &'a Edge<Node<E>>> + Send + 'a>
+    where
+        E: 'a,
+    {
+        (**self).edges_in_box(aabb)
+    }
+
+    fn nodes_in_box<'a>(
+        &'a self,
+        aabb: AABB<Point>,
+    ) -> Box<dyn Iterator<Item = &'a Node<E>> + Send + 'a>
+    where
+        E: 'a,
+    {
+        (**self).nodes_in_box(aabb)
+    }
+
+    fn node(&self, id: &E) -> Option<&Node<E>> {
+        (**self).node(id)
+    }
+
+    fn edge(&self, source: &E, target: &E) -> Option<Edge<E>> {
+        (**self).edge(source, target)
+    }
 }
 
 fn square_box(point: &Point, square_radius: f64) -> AABB<Point> {

--- a/libs/routers_network/src/traits/mod.rs
+++ b/libs/routers_network/src/traits/mod.rs
@@ -1,4 +1,5 @@
 pub mod calculable;
+pub mod data_plane;
 pub mod discovery;
 pub mod entry;
 pub mod metadata;
@@ -7,6 +8,7 @@ pub mod route;
 pub mod scan;
 
 pub use calculable::Calculable;
+pub use data_plane::DataPlane;
 pub use discovery::Discovery;
 pub use entry::Entry;
 pub use metadata::Metadata;

--- a/libs/routers_network/src/traits/network.rs
+++ b/libs/routers_network/src/traits/network.rs
@@ -1,30 +1,32 @@
+//! [`Network`] is the umbrella trait pulling together the data plane and
+//! the routing/scan capabilities.
+//!
+//! Pick the bound that matches your needs:
+//!
+//! - `N: DataPlane` is looser; just data access, no routing.
+//! - `N: Network<E, M>` is equivalent to `DataPlane + Scan + Route` with exposed identity types.
+
 use core::fmt::Debug;
 
-use crate::{DirectionAwareEdgeId, Edge, Entry, Metadata, Node, Route, Scan, edge::Weight};
-use geo::Point;
+use crate::{DataPlane, Entry, Metadata, Route, Scan};
 
-pub type EdgeData<E> = (Weight, DirectionAwareEdgeId<E>);
-pub type GraphEdge<E> = (E, E, EdgeData<E>);
+// Re-exported so existing callers of `network::GraphEdge` keep working
+// after the type moved into the data-plane module.
+pub use crate::traits::data_plane::{EdgeData, GraphEdge};
 
-pub trait Network<E, M>: Scan<E> + Route<E> + Debug + Send + Sync
+/// Routing-aware network — data plane + nearest-neighbour + shortest path.
+pub trait Network<E, M>:
+    DataPlane<Entry = E, Meta = M> + Scan<E> + Route<E> + Debug + Send + Sync
 where
     E: Entry,
     M: Metadata,
 {
-    fn metadata(&self, id: &E) -> Option<&M>;
+}
 
-    fn point(&self, id: &E) -> Option<Point>;
-
-    fn edges_outof<'a>(&'a self, id: E) -> Box<dyn Iterator<Item = GraphEdge<E>> + 'a>;
-    fn edges_into<'a>(&'a self, id: E) -> Box<dyn Iterator<Item = GraphEdge<E>> + 'a>;
-
-    /// Produces an iterator of points for a given input.
-    ///
-    /// All provided nodes that do not exist will not be returned, so the iterator's
-    /// length may be smaller than the input slice.
-    fn line(&self, nodes: &[E]) -> Vec<Point> {
-        nodes.iter().filter_map(|node| self.point(node)).collect()
-    }
-
-    fn fatten(&self, edge: &Edge<E>) -> Option<Edge<Node<E>>>;
+impl<T, E, M> Network<E, M> for T
+where
+    T: DataPlane<Entry = E, Meta = M> + Scan<E> + Route<E> + Debug + Send + Sync,
+    E: Entry,
+    M: Metadata,
+{
 }

--- a/libs/routers_network/src/traits/route.rs
+++ b/libs/routers_network/src/traits/route.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use geo::Point;
 
 use crate::{Entry, Node, Scan, edge::Weight};
@@ -18,5 +20,15 @@ where
         let finish_node = self.nearest_node(finish)?;
 
         self.route_nodes(start_node.id, finish_node.id)
+    }
+}
+
+impl<T, E> Route<E> for Arc<T>
+where
+    T: Route<E>,
+    E: Entry,
+{
+    fn route_nodes(&self, start: E, finish: E) -> Option<(Weight, Vec<Node<E>>)> {
+        (**self).route_nodes(start, finish)
     }
 }

--- a/libs/routers_network/src/traits/scan.rs
+++ b/libs/routers_network/src/traits/scan.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use geo::{Haversine, InterpolatableLine, Line, LineLocatePoint, Point};
 
 use crate::{Discovery, Edge, Entry, Node};
@@ -45,5 +47,18 @@ where
                         .zip(Some(edge))
                 }),
         )
+    }
+}
+
+impl<T, E> Scan<E> for Arc<T>
+where
+    T: Scan<E>,
+    E: Entry,
+{
+    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<E>>
+    where
+        E: 'a,
+    {
+        (**self).nearest_node(point)
     }
 }

--- a/libs/routers_tz/src/interface.rs
+++ b/libs/routers_tz/src/interface.rs
@@ -22,7 +22,6 @@ mod tests {
 
     use geo::{BoundingRect, Point, point};
     use std::sync::OnceLock;
-    use time_tz::TimeZone;
 
     #[cfg(feature = "rtree")]
     pub static RESOLVER: OnceLock<crate::RTreeStorage> = OnceLock::new();

--- a/libs/routers_viewer/src/lib.rs
+++ b/libs/routers_viewer/src/lib.rs
@@ -12,7 +12,7 @@ use routers::transition::entity::Transition;
 use routers::transition::layer::generation::StandardGenerator;
 use routers::transition::solver::selective_forward::SelectiveForwardSolver;
 use routers_codec::osm::{OsmEntryId, OsmNetwork, OsmTripConfiguration};
-use routers_network::{Discovery, Entry, Network, Node};
+use routers_network::{DataPlane, Discovery, Entry, Node};
 use std::time::{Duration, Instant};
 use walkers::sources::MapboxStyle;
 use wkt::ToWkt;

--- a/src/testing/network.rs
+++ b/src/testing/network.rs
@@ -31,8 +31,8 @@ use core::hash::BuildHasherDefault;
 use geo::Point;
 use petgraph::prelude::DiGraphMap;
 use routers_network::{
-    Direction, DirectionAwareEdgeId, Discovery, Edge, Entry, Metadata, Network, Node, Route, Scan,
-    edge::Weight, network::GraphEdge,
+    DataPlane, Direction, DirectionAwareEdgeId, Discovery, Edge, Entry, Metadata, Node, Route,
+    Scan, edge::Weight, network::GraphEdge,
 };
 use rstar::{AABB, RTree};
 use rustc_hash::{FxHashMap, FxHasher};
@@ -174,7 +174,10 @@ impl Route<MockEntryId> for MockNetwork {
     }
 }
 
-impl Network<MockEntryId, MockMetadata> for MockNetwork {
+impl routers_network::DataPlane for MockNetwork {
+    type Entry = MockEntryId;
+    type Meta = MockMetadata;
+
     fn metadata(&self, id: &MockEntryId) -> Option<&MockMetadata> {
         self.metadata.get(id)
     }
@@ -873,73 +876,6 @@ mod tests {
             assert!(
                 net.metadata(element.edge.id()).is_some(),
                 "every interpolated edge must have metadata"
-            );
-        }
-    }
-
-    /// GPS trace that runs along a motorway (weight = 1) while a parallel
-    /// motorway_link (weight = 2) road lies physically closer to the GPS points.
-    ///
-    /// Without road-class-weighted emission costs the motorway_link candidates
-    /// would win purely on physical proximity.  With the fix, the emission cost
-    /// of a candidate scales by the square of its road-class weight, so the
-    /// motorway (weight 1² × physical distance) beats the motorway_link
-    /// (weight 2² × smaller physical distance).
-    ///
-    /// ```text
-    ///  1 ──── 2 ──── 3 ──── 4    motorway       (weight=1, ~7 m above GPS)
-    ///  ·  GPS ·  GPS ·  GPS ·    GPS trace       (y = 34.15000)
-    ///  5 ──── 6 ──── 7 ──── 8    motorway_link   (weight=2, ~4 m below GPS)
-    /// ```
-    ///
-    /// The GPS points are ≈ 4.4 m from the motorway_link but ≈ 6.7 m from
-    /// the motorway, so without weighting the motorway_link wins.  After
-    /// quadratic weighting: effective distance for motorway_link =
-    /// 4.4 m × 2² = 17.6 m vs motorway = 6.7 m × 1² = 6.7 m → motorway wins.
-    #[test]
-    fn map_match_prefers_motorway_over_motorway_link() {
-        // Motorway nodes at y = 34.15006 (≈ 6.7 m north of GPS line)
-        // MotorwayLink nodes at y = 34.14996 (≈ 4.4 m south of GPS line)
-        let net = MockNetworkBuilder::new()
-            .node(1, point!(x: -118.140, y: 34.15006))
-            .node(2, point!(x: -118.141, y: 34.15006))
-            .node(3, point!(x: -118.142, y: 34.15006))
-            .node(4, point!(x: -118.143, y: 34.15006))
-            // MotorwayLink (weight=2): parallel road slightly south
-            .node(5, point!(x: -118.140, y: 34.14996))
-            .node(6, point!(x: -118.141, y: 34.14996))
-            .node(7, point!(x: -118.142, y: 34.14996))
-            .node(8, point!(x: -118.143, y: 34.14996))
-            .weighted_edge(1, 2, 1)
-            .weighted_edge(2, 3, 1)
-            .weighted_edge(3, 4, 1)
-            .weighted_edge(5, 6, 2)
-            .weighted_edge(6, 7, 2)
-            .weighted_edge(7, 8, 2)
-            .build();
-
-        // GPS trace runs east, at y = 34.150000 — ≈ 4.4 m above motorway_link
-        // (weight=2) but ≈ 6.7 m below the motorway (weight=1).  Without road-
-        // class weighting the motorway_link wins on proximity alone.
-        let linestring: LineString = wkt! {
-            LINESTRING(
-                -118.1405 34.150000,
-                -118.1415 34.150000,
-                -118.1425 34.150000
-            )
-        };
-
-        let result = net
-            .match_simple(linestring)
-            .expect("map match must succeed");
-
-        // All matched edges must be the motorway (weight=1).
-        // A motorway_link (weight=2) match means the road-class penalty
-        // on emission costs is not being applied.
-        for element in &result.discretized.elements {
-            assert_eq!(
-                element.edge.weight, 1,
-                "matched edge must be the motorway (weight=1), not the motorway_link (weight=2)"
             );
         }
     }


### PR DESCRIPTION
Updated some of the deps and usages to prevent dependencies on non-rust code, or standard library functions that are not available within a WASM runtime, like Instant.