### PR TITLE
feat: Allow Compiling with `--all-features`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6038,7 +6038,9 @@ dependencies = [
  "geo",
  "geohash",
  "log",
+ "routers_schema",
  "strum",
+ "wkt",
 ]
 
 [[package]]
@@ -6049,6 +6051,7 @@ dependencies = [
  "num-traits",
  "rstar 0.12.2",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -6130,6 +6133,7 @@ dependencies = [
  "prost-build",
  "routers_geo",
  "routers_rpc",
+ "routers_schema",
  "serde",
  "serde_qs",
  "strum",

--- a/buf.yaml
+++ b/buf.yaml
@@ -5,6 +5,7 @@ modules:
     name: buf.build/osm/model
     includes:
       - schema/proto/osm
+      - schema/proto/mvt
   - path: schema/proto
     name: buf.build/routers/api
     includes:
@@ -13,3 +14,4 @@ modules:
 lint:
   ignore:
     - schema/proto/osm
+    - schema/proto/mvt

--- a/libs/routers_geo/Cargo.toml
+++ b/libs/routers_geo/Cargo.toml
@@ -10,7 +10,10 @@ log = { version = "0.4.27", features = [] }
 strum = { workspace = true }
 
 geo = { workspace = true }
+wkt = { workspace = true }
 geohash = "0.13.1"
+
+schema = { workspace = true }
 
 [features]
 tile = []

--- a/libs/routers_geo/src/cluster.rs
+++ b/libs/routers_geo/src/cluster.rs
@@ -7,8 +7,11 @@ use wkt::ToWkt;
 
 use crate::coord::point::FeatureKey;
 use crate::error::GeoError;
+
 #[cfg(feature = "tile")]
-use crate::{geo::TileItem, routers_codec::mvt::Value};
+use crate::coord::point::TileItem;
+#[cfg(feature = "tile")]
+use schema::proto::mvt::Value;
 
 #[derive(PartialEq, Clone)]
 pub enum Classification {
@@ -62,11 +65,11 @@ impl<T: Clone> TileItem<Value> for Clustered<T> {
         vec![
             (
                 Self::Key::NumberOfPoints,
-                Value::from_int(self.points.len() as i64),
+                Value::default().with_sint_value(self.points.len() as i64),
             ),
             (
                 Self::Key::ConvexHull,
-                Value::from_string(self.convex_hull.wkt_string()),
+                Value::default().with_string_value(self.convex_hull.wkt_string()),
             ),
         ]
     }

--- a/libs/routers_network/Cargo.toml
+++ b/libs/routers_network/Cargo.toml
@@ -9,13 +9,15 @@ license = "GPL-3.0-or-later"
 geo = { workspace = true, features = ["serde"] }
 rstar = { workspace = true }
 serde = { workspace = true }
+tracing = { workspace = true, optional = true }
+
 num-traits = "0.2"
 
 [dev-dependencies]
 
 [features]
 fixtures = []
-tracing = []
+tracing = ["dep:tracing"]
 
 [lints]
 workspace = true

--- a/libs/routers_network/src/traits/route.rs
+++ b/libs/routers_network/src/traits/route.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use geo::Point;
 
 use crate::{Entry, Node, Scan, edge::Weight};
+#[cfg(feature = "tracing")]
+use tracing::Level;
 
 pub trait Route<E>: Scan<E>
 where

--- a/libs/routers_tiles/Cargo.toml
+++ b/libs/routers_tiles/Cargo.toml
@@ -26,6 +26,8 @@ strum = { workspace = true }
 tracing = { version = "0.1.41", optional = true }
 async-trait = "0.1.88"
 
+schema = { workspace = true }
+
 [dev-dependencies]
 futures = "0.3.31"
 routers_rpc = { path = "../routers_rpc", features = ["telemetry"] }

--- a/libs/routers_tiles/build.rs
+++ b/libs/routers_tiles/build.rs
@@ -1,7 +1,7 @@
 use prost_build::Config;
 
 fn main() -> Result<(), Box<dyn core::error::Error>> {
-    let protos = ["proto/mvt/mvt.proto", "proto/example/example.proto"];
+    let protos = ["proto/example/example.proto"];
 
     let includes = ["proto"];
     let mut cfg = Config::new();

--- a/libs/routers_tiles/src/datasource/query.rs
+++ b/libs/routers_tiles/src/datasource/query.rs
@@ -1,5 +1,3 @@
-use async_trait::async_trait;
-
 pub struct Query<T, F> {
     pub parameters: T,
     pub filter: F,
@@ -26,7 +24,6 @@ impl<T, F> Query<T, F> {
     }
 }
 
-#[async_trait]
 pub trait TileQuery<In, Filter, Out, Item> {
     type Error;
     type Parameters<'a>
@@ -38,11 +35,12 @@ pub trait TileQuery<In, Filter, Out, Item> {
 
     const QUERY_TABLE: &'static str;
 
-    async fn query(
+    fn query(
         input: Query<In, Option<Filter>>,
         params: Self::Parameters<'_>,
         conn: Self::Connection<'_>,
-    ) -> Result<Out, Self::Error>;
+    ) -> impl std::future::Future<Output = Result<Out, Self::Error>> + Send;
+
     fn batch(query: Query<Self::Parameters<'_>, (u8, u32, u32)>) -> In;
     fn filter(filter: &Self::Parameters<'_>, item: &Item) -> bool;
 }

--- a/libs/routers_tiles/src/example/tile.rs
+++ b/libs/routers_tiles/src/example/tile.rs
@@ -3,10 +3,9 @@ use crate::datasource::connectors::bigtable::{
 };
 use crate::datasource::date::format_date;
 use crate::error::TileError;
-use crate::proto::{Example, Feature, Tile, Value};
+use crate::proto::Example;
 use crate::query::{DatedRange, MVTTile, QueryParams, Range};
 use crate::{Fragment, Query, Repo, TileQuery, layer, tile};
-use axum::async_trait;
 use axum::extract::{Path, State};
 use bigtable_rs::bigtable::RowCell;
 use bigtable_rs::google::bigtable::v2::row_range::{EndKey, StartKey};
@@ -17,6 +16,7 @@ use log::info;
 use prost::Message;
 use routers_geo::TileItem;
 use routers_geo::coord::point::FeatureKey;
+use schema::proto::mvt::{Tile, Value};
 use serde::Deserialize;
 use std::sync::Arc;
 use strum::{EnumCount, EnumIter, EnumProperty, VariantArray};
@@ -39,8 +39,8 @@ impl TileItem<Value> for Example {
 
     fn entries<'a>(&self) -> Vec<(Self::Key, Value)> {
         vec![
-            (Self::Key::KeyA, Value::from_int(self.a)),
-            (Self::Key::KeyB, Value::from_int(self.b)),
+            (Self::Key::KeyA, Value::default().with_sint_value(self.a)),
+            (Self::Key::KeyB, Value::default().with_sint_value(self.b)),
         ]
     }
 }
@@ -64,7 +64,6 @@ pub struct ExampleParams {
     filter_b: Range<i64>,
 }
 
-#[async_trait]
 impl TileQuery<Vec<RowRange>, RowFilter, MVTTile, Example> for Example {
     type Error = TileError;
     type Parameters<'a> = (ExampleParams, u8);

--- a/libs/routers_tiles/src/lib.rs
+++ b/libs/routers_tiles/src/lib.rs
@@ -2,10 +2,6 @@ extern crate alloc;
 
 #[allow(clippy::all)]
 pub mod proto {
-    //! MapboxVectorTile Protobuf Definitions
-    include!(concat!(env!("OUT_DIR"), "/mvt.rs"));
-
-    /// Example Service Protobuf
     #[cfg(feature = "example")]
     include!(concat!(env!("OUT_DIR"), "/example.rs"));
 }

--- a/libs/routers_tiles/src/macros.rs
+++ b/libs/routers_tiles/src/macros.rs
@@ -2,10 +2,10 @@ pub mod tile_macro {
     #[macro_export]
     macro_rules! tile {
         ( $vec:expr ) => {
-            Ok(MVTTile(Tile::from($vec)))
+            Ok(MVTTile(Tile { layers: $vec, ..Default::default() }))
         };
         ( $( $x:expr ),* $(,)? ) => {
-            Ok(MVTTile(Tile::from(vec![ $( $x ),* ])))
+            Ok(MVTTile(Tile { layers: vec![ $( $x ),* ], ..Default::default() }))
         };
     }
 }
@@ -14,7 +14,7 @@ pub mod layer_macro {
     #[macro_export]
     macro_rules! layer {
         ($c:expr, $z:ident, $t:literal) => {
-            MVTLayer::from(($c, $z, format!("{}", $t))).0
+            crate::MVTLayer::from(($c, $z, format!("{}", $t))).0
         };
         ($c:ident, $z:ident, $t:literal) => {
             MVTLayer::from(($c, $z, format!("{}", $t))).0

--- a/libs/routers_tiles/src/primitives/layer.rs
+++ b/libs/routers_tiles/src/primitives/layer.rs
@@ -1,4 +1,4 @@
-use crate::proto::{Feature, GeomType, Layer, Value};
+use schema::proto::mvt::{Feature, GeomType, Layer, Value};
 
 use routers_geo::cluster::Clustered;
 use routers_geo::coord::point::TileItem;
@@ -31,6 +31,7 @@ where
             extent: Some(MVT_EXTENT),
             version: MVT_VERSION,
             keys: keys.iter().map(|k| k.to_string()).collect(),
+            ..Default::default()
         })
     }
 }
@@ -57,6 +58,7 @@ where
             extent: Some(MVT_EXTENT),
             version: MVT_VERSION,
             keys: keys.iter().map(|k| k.to_string()).collect(),
+            ..Default::default()
         })
     }
 }
@@ -82,8 +84,9 @@ where
             tags: (0..key_length)
                 .flat_map(|i| [i, (index as u32) * key_length + i])
                 .collect(),
-            r#type: Some(i32::from(GeomType::Point)),
+            r#type: Some(GeomType::POINT),
             geometry: vec![(1 & 0x7) | (1 << 3), zig(px), zig(py)],
+            ..Default::default()
         })
     }
 }

--- a/libs/routers_tiles/src/primitives/mod.rs
+++ b/libs/routers_tiles/src/primitives/mod.rs
@@ -4,7 +4,5 @@ pub use fragment::*;
 pub mod layer;
 pub use layer::*;
 
-pub mod mvt;
-
 pub mod repository;
 pub use repository::*;

--- a/libs/routers_tiles/src/query/tile.rs
+++ b/libs/routers_tiles/src/query/tile.rs
@@ -1,4 +1,4 @@
-use crate::proto::Tile;
+use schema::proto::mvt::Tile;
 
 pub struct MVTTile(pub(crate) Tile);
 

--- a/schema/proto/mvt/mvt.proto
+++ b/schema/proto/mvt/mvt.proto
@@ -1,0 +1,79 @@
+// Taken from https://github.com/mapbox/vector-tile-spec/blob/master/2.1/vector_tile.proto
+syntax = "proto2";
+
+package mvt;
+
+option optimize_for = LITE_RUNTIME;
+
+message Tile {
+  repeated Layer layers = 3;
+  extensions 16 to 8191;
+}
+
+// GeomType is described in section 4.3.4 of the specification
+enum GeomType {
+  UNKNOWN = 0;
+  POINT = 1;
+  LINESTRING = 2;
+  POLYGON = 3;
+}
+
+// Variant type encoding
+// The use of values is described in section 4.1 of the specification
+message Value {
+  // Exactly one of these values must be present in a valid message
+  optional string string_value = 1;
+  optional float float_value = 2;
+  optional double double_value = 3;
+  optional int64 int_value = 4;
+  optional uint64 uint_value = 5;
+  optional sint64 sint_value = 6;
+  optional bool bool_value = 7;
+
+  extensions 8 to max;
+}
+
+// Features are described in section 4.2 of the specification
+message Feature {
+  optional uint64 id = 1 [default = 0];
+
+  // Tags of this feature are encoded as repeated pairs of
+  // integers.
+  // A detailed description of tags is located in sections
+  // 4.2 and 4.4 of the specification
+  repeated uint32 tags = 2 [packed = true];
+
+  // The type of geometry stored in this feature.
+  optional GeomType type = 3 [default = UNKNOWN];
+
+  // Contains a stream of commands and parameters (vertices).
+  // A detailed description on geometry encoding is located in
+  // section 4.3 of the specification.
+  repeated uint32 geometry = 4 [packed = true];
+}
+
+// Layers are described in section 4.1 of the specification
+message Layer {
+  // Any compliant implementation must first read the version
+  // number encoded in this message and choose the correct
+  // implementation for this version number before proceeding to
+  // decode other parts of this message.
+  required uint32 version = 15 [default = 1];
+
+  required string name = 1;
+
+  // The actual features in this tile.
+  repeated Feature features = 2;
+
+  // Dictionary encoding for keys
+  repeated string keys = 3;
+
+  // Dictionary encoding for values
+  repeated Value values = 4;
+
+  // Although this is an "optional" field it is required by the specification.
+  // See https://github.com/mapbox/vector-tile-spec/issues/47
+  optional uint32 extent = 5 [default = 4096];
+
+  extensions 16 to max;
+}

--- a/src/transition/match/implementation.rs
+++ b/src/transition/match/implementation.rs
@@ -11,6 +11,9 @@ use log::info;
 use routers_network::Network;
 use routers_network::{Entry, Metadata};
 
+#[cfg(feature = "tracing")]
+use tracing::Level;
+
 impl<T, E: Entry, M: Metadata> Match<E, M, T> for T
 where
     T: Network<E, M>,


### PR DESCRIPTION
A collection of bugs have accumulated to mean the workspace no longer compiled with `--all-features`, this fixes this, along with moving the mapbox vector tile protobuf into the shared schema crate, so it no longer needs to be cross-depended on.