### PR TITLE
fix: Double-Copying and Padded Strategy in Sharding

### DIFF
--- a/libs/routers_codec/src/osm/graph.rs
+++ b/libs/routers_codec/src/osm/graph.rs
@@ -347,7 +347,11 @@ impl Discovery<OsmEntryId> for OsmNetwork {
     where
         OsmEntryId: 'a,
     {
-        Box::new(self.index_edge.locate_in_envelope_intersecting(&aabb).copied())
+        Box::new(
+            self.index_edge
+                .locate_in_envelope_intersecting(&aabb)
+                .copied(),
+        )
     }
 
     fn nodes_in_box<'a>(

--- a/libs/routers_codec/src/osm/graph.rs
+++ b/libs/routers_codec/src/osm/graph.rs
@@ -343,11 +343,11 @@ impl Discovery<OsmEntryId> for OsmNetwork {
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Edge<Node<OsmEntryId>>> + Send + 'a>
+    ) -> Box<dyn Iterator<Item = Edge<Node<OsmEntryId>>> + Send + 'a>
     where
         OsmEntryId: 'a,
     {
-        Box::new(self.index_edge.locate_in_envelope_intersecting(&aabb))
+        Box::new(self.index_edge.locate_in_envelope_intersecting(&aabb).copied())
     }
 
     fn nodes_in_box<'a>(

--- a/libs/routers_network/src/traits/discovery.rs
+++ b/libs/routers_network/src/traits/discovery.rs
@@ -6,12 +6,7 @@ use rstar::AABB;
 use crate::{Edge, Entry, Node};
 
 pub trait Discovery<E: Entry> {
-    /// Returns an iterator of *owned* `Edge<Node<E>>` values whose endpoints
-    /// fall within the given AABB. Owned (not borrowed) so implementations
-    /// can materialise edges on the fly from sparser representations — this
-    /// avoids holding a redundant `RTree<Edge<Node<E>>>` alongside the
-    /// node-RTree and graph adjacency, which roughly halves runtime RAM at
-    /// the cost of two hash lookups per result.
+    /// Returns an iterator of edges which fall within the given AABB.
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
@@ -19,7 +14,7 @@ pub trait Discovery<E: Entry> {
     where
         E: 'a;
 
-    /// TODO: Document
+    /// Returns an iterator of nodes which fall within the given AABB.
     fn nodes_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,

--- a/libs/routers_network/src/traits/discovery.rs
+++ b/libs/routers_network/src/traits/discovery.rs
@@ -6,11 +6,16 @@ use rstar::AABB;
 use crate::{Edge, Entry, Node};
 
 pub trait Discovery<E: Entry> {
-    /// TODO: Document
+    /// Returns an iterator of *owned* `Edge<Node<E>>` values whose endpoints
+    /// fall within the given AABB. Owned (not borrowed) so implementations
+    /// can materialise edges on the fly from sparser representations — this
+    /// avoids holding a redundant `RTree<Edge<Node<E>>>` alongside the
+    /// node-RTree and graph adjacency, which roughly halves runtime RAM at
+    /// the cost of two hash lookups per result.
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Edge<Node<E>>> + Send + 'a>
+    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a>
     where
         E: 'a;
 
@@ -44,21 +49,13 @@ pub trait Discovery<E: Entry> {
         self.nodes_in_box(aabb)
     }
 
-    /// A function which returns an unsorted iterator of [`FatEdge`] references which are within
-    /// the provided `distance` of the input [point](Point).
-    ///
-    /// ### Note
-    /// This function implements a square-scan.
-    ///
-    /// Therefore, it bounds the search to be within a square-radius of the origin. Therefore,
-    /// it may not select every node within the supplied distance, or it may select more nodes.
-    /// This resolution method is however significantly cheaper than a circular scan, so a wider
-    /// or shorter search radius may be required in some use-cases.
+    /// Owned-iterator counterpart to [`Discovery::edges_in_box`]. See its
+    /// doc-comment for why this yields by-value rather than by-reference.
     fn edges_at_distance<'a>(
         &'a self,
         point: &Point,
         distance: f64,
-    ) -> Box<dyn Iterator<Item = &'a Edge<Node<E>>> + Send + 'a>
+    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a>
     where
         E: 'a,
     {
@@ -80,7 +77,7 @@ where
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Edge<Node<E>>> + Send + 'a>
+    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a>
     where
         E: 'a,
     {

--- a/libs/routers_network/src/traits/discovery.rs
+++ b/libs/routers_network/src/traits/discovery.rs
@@ -44,8 +44,16 @@ pub trait Discovery<E: Entry> {
         self.nodes_in_box(aabb)
     }
 
-    /// Owned-iterator counterpart to [`Discovery::edges_in_box`]. See its
-    /// doc-comment for why this yields by-value rather than by-reference.
+    /// A function which returns an unsorted iterator of [`FatEdge`] references which are within
+    /// the provided `distance` of the input [point](Point).
+    ///
+    /// ### Note
+    /// This function implements a square-scan.
+    ///
+    /// Therefore, it bounds the search to be within a square-radius of the origin. Therefore,
+    /// it may not select every node within the supplied distance, or it may select more nodes.
+    /// This resolution method is however significantly cheaper than a circular scan, so a wider
+    /// or shorter search radius may be required in some use-cases.
     fn edges_at_distance<'a>(
         &'a self,
         point: &Point,

--- a/libs/routers_network/src/traits/scan.rs
+++ b/libs/routers_network/src/traits/scan.rs
@@ -28,7 +28,7 @@ where
         &'a self,
         point: &'a Point,
         distance: f64,
-    ) -> Box<dyn Iterator<Item = (Point, &'a Edge<Node<E>>)> + Send + 'a>
+    ) -> Box<dyn Iterator<Item = (Point, Edge<Node<E>>)> + Send + 'a>
     where
         E: 'a,
     {

--- a/libs/routers_shard/src/composite/mod.rs
+++ b/libs/routers_shard/src/composite/mod.rs
@@ -35,8 +35,7 @@ where
     /// Spatial index over all unique nodes across all shards.
     index: RTree<Node<E>>,
 
-    /// Slim spatial index over edges — see `ShardedNetwork::index_edge`
-    /// for rationale. Required for correct HMM candidate enumeration.
+    /// Spatial index over unique edges, in all shards.
     index_edge: RTree<crate::network::EdgeRef<E>>,
 }
 

--- a/libs/routers_shard/src/composite/mod.rs
+++ b/libs/routers_shard/src/composite/mod.rs
@@ -13,7 +13,7 @@ use petgraph::prelude::DiGraphMap;
 use rstar::RTree;
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 
-use routers_network::{DirectionAwareEdgeId, Edge, Entry, Metadata, Node, edge::Weight};
+use routers_network::{DirectionAwareEdgeId, Entry, Metadata, Node, edge::Weight};
 
 use crate::network::ShardedNetwork;
 use crate::strategy::ShardId;
@@ -32,8 +32,12 @@ where
     graph: GraphStructure<E>,
     hash: FxHashMap<E, Node<E>>,
 
+    /// Spatial index over all unique nodes across all shards.
     index: RTree<Node<E>>,
-    index_edge: RTree<Edge<Node<E>>>,
+
+    /// Slim spatial index over edges — see `ShardedNetwork::index_edge`
+    /// for rationale. Required for correct HMM candidate enumeration.
+    index_edge: RTree<crate::network::EdgeRef<E>>,
 }
 
 impl<E, M, S> MultiShardNetwork<E, M, S>
@@ -49,9 +53,6 @@ where
         let mut nodes_seen: FxHashSet<E> = FxHashSet::default();
         let mut nodes: Vec<Node<E>> = Vec::new();
 
-        let mut edges_seen: FxHashSet<(E, E, routers_network::Direction)> = FxHashSet::default();
-        let mut edges: Vec<Edge<Node<E>>> = Vec::new();
-
         for shard in &shards {
             for (id, node) in &shard.hash {
                 if nodes_seen.insert(*id) {
@@ -63,14 +64,16 @@ where
             for (src, dst, &(weight, edge_id)) in shard.graph.all_edges() {
                 graph.add_edge(src, dst, (weight, edge_id));
             }
-
-            for edge in shard.index_edge.iter() {
-                if edges_seen.insert((edge.source.id, edge.target.id, edge.id.direction())) {
-                    edges.push(*edge);
-                }
-            }
         }
 
+        let edges: Vec<crate::network::EdgeRef<E>> = graph
+            .all_edges()
+            .filter_map(|(s, t, _)| {
+                let src_pos = hash.get(&s)?.position;
+                let tgt_pos = hash.get(&t)?.position;
+                Some(crate::network::EdgeRef::new(s, t, src_pos, tgt_pos))
+            })
+            .collect();
         let (index, index_edge) =
             rayon::join(|| RTree::bulk_load(nodes), || RTree::bulk_load(edges));
 

--- a/libs/routers_shard/src/composite/network.rs
+++ b/libs/routers_shard/src/composite/network.rs
@@ -9,7 +9,7 @@ use routers_network::{
 };
 
 use super::MultiShardNetwork;
-use crate::strategy::ShardId;
+use crate::{network::EdgeRef, strategy::ShardId};
 
 impl<E, M, S> Debug for MultiShardNetwork<E, M, S>
 where
@@ -84,11 +84,30 @@ where
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Edge<Node<E>>> + Send + 'a>
+    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a>
     where
         E: 'a,
     {
-        Box::new(self.index_edge.locate_in_envelope_intersecting(&aabb))
+        Box::new(
+            self.index_edge
+                .locate_in_envelope_intersecting(&aabb)
+                .filter_map(move |&EdgeRef { source, target, .. }| {
+                    let source = *self.hash.get(&source)?;
+                    let target = *self.hash.get(&target)?;
+
+                    let &(weight, id) = self.graph.edge_weight(*source, *target)?;
+
+                    let node = Node::new(Point::new(0., 0.), id.index());
+                    let id = DirectionAwareEdgeId::new(node).with_direction(id.direction());
+
+                    Some(Edge {
+                        source,
+                        target,
+                        id,
+                        weight,
+                    })
+                }),
+        )
     }
 
     fn nodes_in_box<'a>(

--- a/libs/routers_shard/src/lib.rs
+++ b/libs/routers_shard/src/lib.rs
@@ -22,7 +22,7 @@ pub use network::{ShardSource, ShardedNetwork};
 pub use selection::{Selection, SelectionMode};
 pub use strategy::{
     ShardId, ShardingStrategy,
-    geohash::{Geohash, GeohashStrategy},
+    geohash::{Geohash, GeohashParseError, GeohashStrategy},
     quadtree::{QuadKey, QuadTreeStrategy},
 };
 

--- a/libs/routers_shard/src/network.rs
+++ b/libs/routers_shard/src/network.rs
@@ -31,6 +31,38 @@ use crate::strategy::{ShardId, ShardingStrategy};
 pub type GraphStructure<E> =
     DiGraphMap<E, (Weight, DirectionAwareEdgeId<E>), BuildHasherDefault<FxHasher>>;
 
+/// Slim spatial-index entry for edges.
+#[derive(Clone, Copy, Debug)]
+pub struct EdgeRef<E: Entry> {
+    pub source: E,
+    pub target: E,
+
+    bbox_min: Point,
+    bbox_max: Point,
+}
+
+impl<E: Entry> EdgeRef<E> {
+    pub fn new(source: E, target: E, src_pos: Point, tgt_pos: Point) -> Self {
+        let (sx, sy) = src_pos.x_y();
+        let (tx, ty) = tgt_pos.x_y();
+
+        Self {
+            source,
+            target,
+
+            bbox_min: Point::new(sx.min(tx), sy.min(ty)),
+            bbox_max: Point::new(sx.max(tx), sy.max(ty)),
+        }
+    }
+}
+
+impl<E: Entry> rstar::RTreeObject for EdgeRef<E> {
+    type Envelope = AABB<Point>;
+    fn envelope(&self) -> Self::Envelope {
+        AABB::from_corners(self.bbox_min, self.bbox_max)
+    }
+}
+
 /// A data source from which a [`ShardedNetwork`] can be built.
 ///
 /// Implement this trait on any type that provides an iterable collection of
@@ -75,10 +107,13 @@ where
     pub hash: FxHashMap<E, Node<E>>,
     pub meta: FxHashMap<E, M>,
 
+    /// Spatial index over nodes.
     #[serde(skip)]
     pub index: RTree<Node<E>>,
+
+    /// Spatial index over edge (references).
     #[serde(skip)]
-    pub index_edge: RTree<Edge<Node<E>>>,
+    pub index_edge: RTree<EdgeRef<E>>,
 
     /// The shard this node has authority over.
     pub owned: S,
@@ -118,20 +153,38 @@ where
         let mut hash: FxHashMap<E, Node<E>> = FxHashMap::default();
         let mut meta: FxHashMap<E, M> = FxHashMap::default();
 
-        for (id, pos) in source.nodes() {
-            let shard = strategy.locate(pos);
-            if selection.contains(&shard) {
+        let all_nodes: FxHashMap<E, Point> = source.nodes().collect();
+
+        // Consider a node, if (either or..):
+        // 1. It's shard is in the loaded set, or
+        // 2. It's position falls within the optional padded buffer.
+        for (&id, &pos) in &all_nodes {
+            let admit = selection.padding_contains(pos) || {
+                let shard = strategy.locate(pos);
+                selection.contains(&shard)
+            };
+            if admit {
                 hash.insert(id, Node::new(pos, id));
                 graph.add_node(id);
             }
         }
 
         for (from, to, weight, m) in source.edges() {
-            if hash.contains_key(&from) && hash.contains_key(&to) {
-                let edge_id = DirectionAwareEdgeId::new(from);
-                graph.add_edge(from, to, (weight, edge_id));
-                meta.entry(from).or_insert(m);
+            if !hash.contains_key(&from) {
+                continue;
             }
+
+            if !hash.contains_key(&to) {
+                if let Some(&pos) = all_nodes.get(&to) {
+                    hash.insert(to, Node::new(pos, to));
+                    graph.add_node(to);
+                } else {
+                    continue;
+                }
+            }
+
+            graph.add_edge(from, to, (weight, DirectionAwareEdgeId::new(from)));
+            meta.entry(from).or_insert(m);
         }
 
         let mut net = Self {
@@ -143,42 +196,33 @@ where
             owned: selection.owned,
             loaded: selection.loaded.clone(),
         };
+
         net.rebuild_indices();
         Ok(net)
     }
 
-    /// Rebuild the spatial indices (`index` and `index_edge`) from the
-    /// `hash` and `graph` fields.
+    /// Rebuild the spatial indices from `hash` + `graph`.
     ///
-    /// The indices are intentionally not serialised — bulk-loading an
-    /// `RTree` from N items is O(N log N) and runs at hundreds of MB/s in
-    /// practice, which is faster than letting `postcard` decode a tree
-    /// structure that takes proportionally more bytes on disk. Call this
-    /// after deserialising a network in custom code paths;
-    /// [`from_cached`](Self::from_cached) does it for you.
+    /// Both the node RTree and the slim edge RTree are intentionally not
+    /// serialised — bulk-loading is O(N log N) at hundreds of MB/s,
+    /// faster than letting `postcard` decode tree structures that take
+    /// proportionally more bytes on disk.
     pub fn rebuild_indices(&mut self) {
-        // Bulk-loading the two `RTree`s is the dominant cost on cache hits
-        // (~350ms for a 9-shard Sydney load). The two trees are independent
-        // so we farm them out to `rayon::join` and pay one tree's worth of
-        // wall-clock time instead of the sum.
         let nodes: Vec<Node<E>> = self.hash.values().copied().collect();
-        let edges: Vec<Edge<Node<E>>> = self
+        let edges: Vec<EdgeRef<E>> = self
             .graph
             .all_edges()
-            .filter_map(|(s, t, &(weight, id))| {
+            .filter_map(|(s, t, _)| {
                 let source = *self.hash.get(&s)?;
                 let target = *self.hash.get(&t)?;
-                Some(Edge {
-                    source,
-                    target,
-                    id: DirectionAwareEdgeId::new(Node::new(Point::new(0., 0.), id.index()))
-                        .with_direction(id.direction()),
-                    weight,
-                })
+
+                Some(EdgeRef::new(s, t, source.position, target.position))
             })
             .collect();
+
         let (node_index, edge_index) =
             rayon::join(|| RTree::bulk_load(nodes), || RTree::bulk_load(edges));
+
         self.index = node_index;
         self.index_edge = edge_index;
     }
@@ -309,11 +353,30 @@ where
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Edge<Node<E>>> + Send + 'a>
+    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a>
     where
         E: 'a,
     {
-        Box::new(self.index_edge.locate_in_envelope_intersecting(&aabb))
+        Box::new(
+            self.index_edge
+                .locate_in_envelope_intersecting(&aabb)
+                .filter_map(move |EdgeRef { source, target, .. }| {
+                    let source = *self.hash.get(&source)?;
+                    let target = *self.hash.get(&target)?;
+
+                    let &(weight, id) = self.graph.edge_weight(source.id, target.id)?;
+
+                    let node = Node::new(Point::new(0., 0.), id.index());
+                    let id = DirectionAwareEdgeId::new(node).with_direction(id.direction());
+
+                    Some(Edge {
+                        source,
+                        target,
+                        id,
+                        weight,
+                    })
+                }),
+        )
     }
 
     fn nodes_in_box<'a>(

--- a/libs/routers_shard/src/network.rs
+++ b/libs/routers_shard/src/network.rs
@@ -202,11 +202,6 @@ where
     }
 
     /// Rebuild the spatial indices from `hash` + `graph`.
-    ///
-    /// Both the node RTree and the slim edge RTree are intentionally not
-    /// serialised — bulk-loading is O(N log N) at hundreds of MB/s,
-    /// faster than letting `postcard` decode tree structures that take
-    /// proportionally more bytes on disk.
     pub fn rebuild_indices(&mut self) {
         let nodes: Vec<Node<E>> = self.hash.values().copied().collect();
         let edges: Vec<EdgeRef<E>> = self

--- a/libs/routers_shard/src/selection.rs
+++ b/libs/routers_shard/src/selection.rs
@@ -8,24 +8,24 @@
 //! holds purely for handover continuity.
 
 use crate::strategy::{ShardId, ShardingStrategy};
+use geo::{Point, Rect, coord};
 use rustc_hash::FxHashSet;
 
 /// Describes how to expand an owned shard into a loaded selection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SelectionMode {
     /// Load only the owned shard.
-    ///
-    /// Cheapest, but trips that approach a shard boundary lose connectivity
-    /// before the orchestrator can hand them off.
     Owned,
 
     /// Load the owned shard plus its immediate cardinal/diagonal neighbours.
     ///
     /// For the quad-tree strategy this is the canonical "9-cell" arrangement
-    /// (owned + 8 neighbours). The owned shard is the only one for which the
-    /// node accepts new traffic; the rest exist purely to keep edges
-    /// resolvable across the boundary.
+    /// (owned + 8 neighbours).
     OwnedAndNeighbours,
+
+    /// Load the owned shard plus the raw nodes/edges that fall within
+    /// `padding_distance` metres of its bounds.
+    OwnedAndPadded { padding_distance: f64 },
 }
 
 #[derive(Debug, Clone)]
@@ -35,6 +35,14 @@ pub struct Selection<S: ShardId> {
     /// The full set of shards whose data must be present in the local graph,
     /// including `owned`. Look-ups during ingestion use this set.
     pub loaded: FxHashSet<S>,
+    /// Optional geographic buffer around the owned shard's bounds.
+    ///
+    /// When present, the network builder additionally admits any node
+    /// whose position lies inside this rectangle, regardless of which
+    /// shard it belongs to. Used by
+    /// [`SelectionMode::OwnedAndPadded`] to materialise a small strip of
+    /// cross-boundary data without loading whole neighbour shards.
+    pub padding: Option<Rect>,
 }
 
 impl<S: ShardId> Selection<S> {
@@ -43,13 +51,24 @@ impl<S: ShardId> Selection<S> {
         St: ShardingStrategy<Id = S>,
     {
         let mut loaded = FxHashSet::default();
-        loaded.insert(owned.clone());
-        if matches!(mode, SelectionMode::OwnedAndNeighbours) {
-            for n in strategy.neighbours(&owned) {
-                loaded.insert(n);
+        loaded.insert(owned);
+        let padding = match mode {
+            SelectionMode::Owned => None,
+            SelectionMode::OwnedAndNeighbours => {
+                for n in strategy.neighbours(&owned) {
+                    loaded.insert(n);
+                }
+                None
             }
+            SelectionMode::OwnedAndPadded { padding_distance } => {
+                Some(padded_bounds(strategy.bounds(&owned), padding_distance))
+            }
+        };
+        Self {
+            owned,
+            loaded,
+            padding,
         }
-        Self { owned, loaded }
     }
 
     /// Returns `true` if the shard `id` is part of the loaded selection.
@@ -57,4 +76,32 @@ impl<S: ShardId> Selection<S> {
     pub fn contains(&self, id: &S) -> bool {
         self.loaded.contains(id)
     }
+
+    /// Returns `true` if `point` falls within the padded buffer (if any).
+    ///
+    /// Returns `false` when no padding is configured — selection
+    /// membership in that case is decided purely by shard id.
+    #[inline]
+    pub fn padding_contains(&self, point: Point) -> bool {
+        let Some(rect) = self.padding.as_ref() else {
+            return false;
+        };
+        let (x, y) = point.x_y();
+        let min = rect.min();
+        let max = rect.max();
+        x >= min.x && x <= max.x && y >= min.y && y <= max.y
+    }
+}
+
+/// Expand `rect` by `padding_meters` in both axes, using a local
+/// equirectangular conversion centred on the rectangle's midpoint.
+fn padded_bounds(rect: Rect, padding_meters: f64) -> Rect {
+    const M_PER_DEG: f64 = 111_320.0;
+    let cy = 0.5 * (rect.min().y + rect.max().y);
+    let pad_y = padding_meters / M_PER_DEG;
+    let pad_x = padding_meters / (M_PER_DEG * cy.to_radians().cos().abs().max(1e-6));
+    Rect::new(
+        coord! { x: rect.min().x - pad_x, y: rect.min().y - pad_y },
+        coord! { x: rect.max().x + pad_x, y: rect.max().y + pad_y },
+    )
 }

--- a/libs/routers_shard/src/selection.rs
+++ b/libs/routers_shard/src/selection.rs
@@ -37,11 +37,14 @@ pub struct Selection<S: ShardId> {
     pub loaded: FxHashSet<S>,
     /// Optional geographic buffer around the owned shard's bounds.
     ///
-    /// When present, the network builder additionally admits any node
-    /// whose position lies inside this rectangle, regardless of which
-    /// shard it belongs to. Used by
-    /// [`SelectionMode::OwnedAndPadded`] to materialise a small strip of
-    /// cross-boundary data without loading whole neighbour shards.
+    /// Used by [`SelectionMode::OwnedAndPadded`] to obtain a small
+    /// strip of cross-boundary data without loading whole neighbour shards.
+    ///
+    /// As such, it scales more efficiently than [`SelectionMode::OwnedAndNeighbours`]
+    /// when the padding distance is constant and shard sizes are large.
+    ///
+    /// When given enough information about vehicle movement, an entire
+    /// shard can be excessive, and have higher memory usage than required.
     pub padding: Option<Rect>,
 }
 

--- a/libs/routers_shard/src/strategy/geohash.rs
+++ b/libs/routers_shard/src/strategy/geohash.rs
@@ -9,6 +9,8 @@ use core::fmt;
 use geo::{Point, Rect, coord};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+use std::str::FromStr;
+use thiserror::Error;
 
 const BASE32: &[u8; 32] = b"0123456789bcdefghjkmnpqrstuvwxyz";
 const MAX_PRECISION: usize = 12;
@@ -27,6 +29,37 @@ impl Display for Geohash {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum GeohashParseError {
+    #[error("invalid length {0}: must be 1–12")]
+    InvalidLength(usize),
+    #[error("invalid character '{0}'")]
+    InvalidChar(char),
+}
+
+impl FromStr for Geohash {
+    type Err = GeohashParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let precision = s.len();
+        if precision == 0 || precision > MAX_PRECISION {
+            return Err(GeohashParseError::InvalidLength(precision));
+        }
+        let mut data = [0u8; MAX_PRECISION];
+        for (i, ch) in s.chars().enumerate() {
+            let idx = BASE32
+                .iter()
+                .position(|&b| b == ch as u8)
+                .ok_or(GeohashParseError::InvalidChar(ch))?;
+            data[i] = idx as u8;
+        }
+        Ok(Geohash {
+            data,
+            precision: precision as u8,
+        })
     }
 }
 

--- a/libs/routers_shard/tests/padded.rs
+++ b/libs/routers_shard/tests/padded.rs
@@ -1,0 +1,165 @@
+//! End-to-end tests for [`SelectionMode::OwnedAndPadded`].
+//!
+//! Verifies that the padded buffer:
+//!
+//! - Pulls in raw graph nodes lying just outside the owned shard, even
+//!   when those nodes' own shards are not loaded.
+//! - Leaves the `loaded` set as `{owned}`, so no whole neighbour shard
+//!   is materialised regardless of precision.
+//! - Excludes nodes that fall outside both the owned shard and the
+//!   buffer.
+
+mod common;
+
+use common::MemSource;
+use geo::Point;
+use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId};
+use routers_shard::{GeohashStrategy, Selection, SelectionMode, ShardedNetwork, ShardingStrategy};
+
+fn build<S: routers_shard::ShardId>(
+    source: &MemSource,
+    strategy: &impl ShardingStrategy<Id = S>,
+    selection: &Selection<S>,
+) -> ShardedNetwork<OsmEntryId, OsmEdgeMetadata, S> {
+    ShardedNetwork::from_source(source, strategy, selection).expect("build")
+}
+
+#[test]
+fn padded_buffer_admits_nodes_outside_owned_shard() {
+    // Dense grid at sub-metre pitch so the buffer admits a measurable
+    // number of nodes outside the owned cell.
+    let origin = Point::new(13.4, 52.5);
+    let step = 0.0001; // ~11 m N/S
+    let source = MemSource::grid(origin, 40, 40, step);
+    let strategy = GeohashStrategy::with_precision(7);
+    let owned = strategy.locate(Point::new(
+        origin.x() + 20.0 * step,
+        origin.y() + 20.0 * step,
+    ));
+
+    let owned_only = Selection::new(&strategy, owned, SelectionMode::Owned);
+    let padded = Selection::new(
+        &strategy,
+        owned,
+        SelectionMode::OwnedAndPadded {
+            padding_distance: 50.0,
+        },
+    );
+
+    let net_owned = build(&source, &strategy, &owned_only);
+    let net_padded = build(&source, &strategy, &padded);
+
+    assert!(
+        net_padded.num_nodes() > net_owned.num_nodes(),
+        "padded buffer should admit extra nodes (owned={}, padded={})",
+        net_owned.num_nodes(),
+        net_padded.num_nodes(),
+    );
+}
+
+#[test]
+fn padded_mode_does_not_load_extra_shards() {
+    // Even when the buffer admits cross-boundary nodes, the resulting
+    // network's `loaded` set must remain just the owned shard — the
+    // whole point of the mode at coarse precision.
+    let source = MemSource::grid(Point::new(13.4, 52.5), 40, 40, 0.0001);
+    let strategy = GeohashStrategy::with_precision(7);
+    let owned = strategy.locate(Point::new(13.402, 52.502));
+
+    let padded = Selection::new(
+        &strategy,
+        owned,
+        SelectionMode::OwnedAndPadded {
+            padding_distance: 50.0,
+        },
+    );
+
+    let net = build(&source, &strategy, &padded);
+    assert_eq!(net.loaded.len(), 1);
+    assert!(net.loaded.contains(&owned));
+}
+
+#[test]
+fn larger_buffer_admits_more_nodes_than_smaller_buffer() {
+    // Monotonicity: widening the buffer can only ever admit more
+    // primary nodes, never fewer.
+    let source = MemSource::grid(Point::new(13.4, 52.5), 80, 80, 0.0001);
+    let strategy = GeohashStrategy::with_precision(7);
+    let owned = strategy.locate(Point::new(13.404, 52.504));
+
+    let small = build(
+        &source,
+        &strategy,
+        &Selection::new(
+            &strategy,
+            owned,
+            SelectionMode::OwnedAndPadded {
+                padding_distance: 10.0,
+            },
+        ),
+    );
+    let large = build(
+        &source,
+        &strategy,
+        &Selection::new(
+            &strategy,
+            owned,
+            SelectionMode::OwnedAndPadded {
+                padding_distance: 100.0,
+            },
+        ),
+    );
+
+    assert!(
+        large.num_nodes() >= small.num_nodes(),
+        "larger buffer should admit at least as many nodes (small={}, large={})",
+        small.num_nodes(),
+        large.num_nodes(),
+    );
+    assert!(
+        large.num_nodes() > small.num_nodes(),
+        "with a meaningfully larger buffer we expect strictly more nodes",
+    );
+}
+
+#[test]
+fn padded_at_coarse_precision_admits_strip_without_whole_neighbours() {
+    // Geohash precision 3 cells are ~150 km wide; a 200 m buffer at
+    // those scales is a thin strip. The padded network should be
+    // strictly smaller than the OwnedAndNeighbours equivalent (which
+    // would pull in the surrounding 150-km cells in full) while still
+    // admitting some cross-boundary nodes vs. Owned alone.
+    let source = MemSource::grid(Point::new(13.0, 52.0), 200, 200, 0.01);
+    let strategy = GeohashStrategy::with_precision(3);
+    let owned = strategy.locate(Point::new(13.5, 52.5));
+
+    let owned_only = build(
+        &source,
+        &strategy,
+        &Selection::new(&strategy, owned, SelectionMode::Owned),
+    );
+    let padded = build(
+        &source,
+        &strategy,
+        &Selection::new(
+            &strategy,
+            owned,
+            SelectionMode::OwnedAndPadded {
+                padding_distance: 200.0,
+            },
+        ),
+    );
+    let full = build(
+        &source,
+        &strategy,
+        &Selection::new(&strategy, owned, SelectionMode::OwnedAndNeighbours),
+    );
+
+    assert!(padded.num_nodes() >= owned_only.num_nodes());
+    assert!(
+        padded.num_nodes() < full.num_nodes(),
+        "padded ({}) should be much smaller than full neighbours ({}) at coarse precision",
+        padded.num_nodes(),
+        full.num_nodes(),
+    );
+}

--- a/libs/routers_shard/tests/selection.rs
+++ b/libs/routers_shard/tests/selection.rs
@@ -55,6 +55,61 @@ fn neighbour_mode_at_boundary_drops_to_fewer_neighbours() {
 }
 
 #[test]
+fn padded_mode_loaded_set_is_owned_only() {
+    // OwnedAndPadded never adds whole neighbour shards: the padded
+    // strip is carried as geometry, not as extra shard ids.
+    let strategy = GeohashStrategy::with_precision(3);
+    let owned = strategy.locate(Point::new(13.4, 52.5));
+    let sel = Selection::new(
+        &strategy,
+        owned,
+        SelectionMode::OwnedAndPadded {
+            padding_distance: 50.0,
+        },
+    );
+    assert_eq!(sel.loaded.len(), 1);
+    assert!(sel.contains(&owned));
+    assert!(sel.padding.is_some());
+}
+
+#[test]
+fn padded_buffer_extends_beyond_owned_bounds() {
+    let strategy = GeohashStrategy::with_precision(6);
+    let owned = strategy.locate(Point::new(13.4, 52.5));
+    let cell = strategy.bounds(&owned);
+    let sel = Selection::new(
+        &strategy,
+        owned,
+        SelectionMode::OwnedAndPadded {
+            padding_distance: 50.0,
+        },
+    );
+    let padding = sel.padding.expect("padded mode sets a buffer");
+    // The buffer encloses the cell strictly.
+    assert!(padding.min().x < cell.min().x);
+    assert!(padding.max().x > cell.max().x);
+    assert!(padding.min().y < cell.min().y);
+    assert!(padding.max().y > cell.max().y);
+
+    // A point well inside the cell is in the padding region; a point
+    // far outside it is not.
+    let centre = Point::new(
+        0.5 * (cell.min().x + cell.max().x),
+        0.5 * (cell.min().y + cell.max().y),
+    );
+    assert!(sel.padding_contains(centre));
+    assert!(!sel.padding_contains(Point::new(centre.x() + 10.0, centre.y())));
+}
+
+#[test]
+fn padding_contains_false_when_no_buffer() {
+    let strategy = QuadTreeStrategy::with_depth(8);
+    let owned = strategy.locate(Point::new(13.4, 52.5));
+    let sel = Selection::new(&strategy, owned, SelectionMode::Owned);
+    assert!(!sel.padding_contains(Point::new(13.4, 52.5)));
+}
+
+#[test]
 fn selection_contains_only_loaded() {
     let strategy = QuadTreeStrategy::with_depth(6);
     let owned = strategy.locate(Point::new(13.4, 52.5));

--- a/src/testing/network.rs
+++ b/src/testing/network.rs
@@ -109,11 +109,15 @@ impl Discovery<MockEntryId> for MockNetwork {
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Edge<Node<MockEntryId>>> + Send + 'a>
+    ) -> Box<dyn Iterator<Item = Edge<Node<MockEntryId>>> + Send + 'a>
     where
         MockEntryId: 'a,
     {
-        Box::new(self.edge_index.locate_in_envelope_intersecting(&aabb))
+        Box::new(
+            self.edge_index
+                .locate_in_envelope_intersecting(&aabb)
+                .cloned(),
+        )
     }
 
     fn nodes_in_box<'a>(


### PR DESCRIPTION
Includes an `OwnedAndPadded` strategy which allows the system to load a owned shard with a fixed padding radius around which it includes geographic information. This is similar to `OwnedAndNeighbours`, but does not operate at the shard-level. 

Where neighbors loaded in neighboring shards of the same depth, this does so on a fixed distance-basis. It scales more efficiently for lower-depths but can be become less regular at higher shard precision. It's most effective when the amount of padding is known in advance, such as vehicular movements which can be expected to have a particular bounding. At geohash level 3 for example, the padding prevents loading in 8 level-3 shards into memory when only a couple hundred meters is actually required.