### PR TITLE
fix: Remove `tonic` Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -820,7 +820,7 @@ dependencies = [
  "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
- "tower 0.5.3",
+ "tower",
 ]
 
 [[package]]
@@ -1420,7 +1420,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "wasm-bindgen-futures",
@@ -4651,7 +4651,6 @@ dependencies = [
  "prost 0.13.5",
  "reqwest",
  "thiserror 2.0.18",
- "tokio",
  "tonic 0.12.3",
  "tracing",
 ]
@@ -5641,8 +5640,6 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -5652,7 +5649,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -5665,16 +5662,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5692,9 +5679,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -5882,7 +5866,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -7603,9 +7587,6 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost 0.13.5",
@@ -7613,7 +7594,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7643,7 +7623,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7690,26 +7670,6 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.6",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -7740,7 +7700,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ opentelemetry = { version = "0.29.1" }
 opentelemetry_sdk = { version = "0.29.0", features = [
     "rt-tokio",
 ] }
-opentelemetry-otlp = { version = "0.29.0", features = ["tls", "grpc-tonic", "trace"] }
+opentelemetry-otlp = { version = "0.29.0", features = ["tls", "trace"] }
 opentelemetry-stdout = { version = "0.29.0", features = ["trace", "logs", "metrics"] }
 
 # Benchmarking
@@ -125,12 +125,6 @@ bytes = { version = "1.10.1", features = ["default", "serde"] }
 prost = "0.14.1"
 prost-types = "0.14.1"
 prost-build = "0.14.1"
-tonic-prost-build = "0.14.2"
-tonic-prost = "0.14.2"
-tonic-build = "0.14.2"
-tonic-reflection = "0.14.2"
-tonic-web = "0.14.2"
-tonic = "0.14.2"
 
 # === Profiles ===
 [profile.release]


### PR DESCRIPTION
Resolves the following outstanding issues:
- https://github.com/routers-org/routers/issues/107
- https://github.com/routers-org/routers/issues/106
- https://github.com/routers-org/routers/issues/105
- https://github.com/routers-org/routers/issues/101
- https://github.com/routers-org/routers/issues/100
- https://github.com/routers-org/routers/issues/99
- https://github.com/routers-org/routers/issues/91
- https://github.com/routers-org/routers/issues/90
- https://github.com/routers-org/routers/issues/87
- https://github.com/routers-org/routers/issues/86
- https://github.com/routers-org/routers/issues/68
