### PR TITLE
fix: Cleanup HELM Chart

### DIFF
--- a/infrastructure/Justfile
+++ b/infrastructure/Justfile
@@ -3,7 +3,7 @@ mod matcher "matcher"
 mod orchestrator "orchestrator"
 
 mod chart "chart"
-mod devstack "devstack"
+mod dev "dev"
 
 build: historian::build matcher::build orchestrator::build
 

--- a/infrastructure/Justfile
+++ b/infrastructure/Justfile
@@ -3,9 +3,12 @@ mod matcher "matcher"
 mod orchestrator "orchestrator"
 
 mod chart "chart"
+mod devstack "devstack"
 
 build: historian::build matcher::build orchestrator::build
 
 bringup: chart::bringup
+
+patch: chart::patch
 
 teardown: chart::teardown

--- a/infrastructure/chart/Justfile
+++ b/infrastructure/chart/Justfile
@@ -3,7 +3,7 @@
 #   ROUTERS_NAMESPACE      release namespace
 #   ROUTERS_VALUES         values file to layer on top of values.yaml
 #   ROUTERS_SHARD_CACHE    absolute hostPath for the shard directory
-namespace := env("ROUTERS_NAMESPACE", "routers-dev")
+namespace := env("ROUTERS_NAMESPACE", "routers")
 values := env("ROUTERS_VALUES", "values-local-dev.yaml")
 shard-cache := env("ROUTERS_SHARD_CACHE", `cd .. && cd .. && pwd` + "/target/shard_cache")
 
@@ -17,6 +17,15 @@ bringup:
         -n {{ namespace }} --create-namespace \
         -f {{ values }} \
         --set shardCache.hostPath={{ shard-cache }}
+
+# Re-apply the chart against an existing release and roll workloads so any
+# configmap/env changes actually reach the pods. Assumes `bringup` has run.
+patch:
+    helm upgrade routers-realtime . \
+        -n {{ namespace }} \
+        -f {{ values }} \
+        --set shardCache.hostPath={{ shard-cache }}
+    kubectl rollout restart deployment,statefulset -n {{ namespace }}
 
 # Uninstall the release. Set ROUTERS_DELETE_NAMESPACE=1 to also drop the
 # namespace (only safe if nothing else lives in it).

--- a/infrastructure/chart/files/grafana-dashboard.json
+++ b/infrastructure/chart/files/grafana-dashboard.json
@@ -30,7 +30,7 @@
           "interval": "1s", "datasource": { "type": "prometheus", "uid": "prometheus" }
         },
         {
-          "expr": "sum(rate(routers_events_published_total[3s]))",
+          "expr": "sum(rate(nats_varz_in_msgs[3s]))",
           "legendFormat": "published to NATS",
           "interval": "1s", "datasource": { "type": "prometheus", "uid": "prometheus" }
         },

--- a/infrastructure/chart/templates/prometheus-scrape.yaml
+++ b/infrastructure/chart/templates/prometheus-scrape.yaml
@@ -1,63 +1,48 @@
 {{- if .Values.prometheusScrape.enabled }}
-apiVersion: v1
-kind: Secret
+# ServiceMonitor CRs consumed by kube-prometheus-stack's Prometheus (which
+# lives in a different namespace — see infrastructure/dev). For the operator
+# to pick these up cross-namespace, the Prometheus resource must be
+# configured with a permissive `serviceMonitorNamespaceSelector` and
+# `serviceMonitorSelector` (see the dev values file).
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  name: routers-additional-scrape
+  name: routers-orchestrator
   labels:
     {{- include "routers.labels" . | nindent 4 }}
-stringData:
-  scrape.yaml: |
-    - job_name: routers-orchestrator
-      scrape_interval: 1s
-      kubernetes_sd_configs:
-        - role: pod
-          namespaces:
-            names: [{{ .Release.Namespace }}]
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_pod_label_app]
-          action: keep
-          regex: orchestrator(-shard)?
-        - source_labels: [__meta_kubernetes_pod_ip, __meta_kubernetes_pod_annotation_prometheus_io_port]
-          separator: ":"
-          target_label: __address__
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-          target_label: __metrics_path__
-          regex: (.+)
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_name]
-          target_label: pod
-        - source_labels: [__meta_kubernetes_pod_node_name]
-          target_label: node
-
-    - job_name: routers-matcher
-      scrape_interval: 1s
-      kubernetes_sd_configs:
-        - role: pod
-          namespaces:
-            names: [{{ .Release.Namespace }}]
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_pod_label_app]
-          action: keep
-          regex: matcher
-        - source_labels: [__meta_kubernetes_pod_ip, __meta_kubernetes_pod_annotation_prometheus_io_port]
-          separator: ":"
-          target_label: __address__
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-          target_label: __metrics_path__
-          regex: (.+)
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_name]
-          target_label: pod
-        - source_labels: [__meta_kubernetes_pod_node_name]
-          target_label: node
-
-{{- with .Values.infra.nats.metricsTarget }}
-    - job_name: nats
-      scrape_interval: 10s
-      static_configs:
-        - targets:
-            - {{ . }}
-          labels:
-            component: nats
-{{- end }}
+spec:
+  namespaceSelector:
+    matchNames: [{{ .Release.Namespace }}]
+  selector:
+    matchLabels:
+      app: orchestrator-shard
+  endpoints:
+    - port: metrics
+      interval: 1s
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: node
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: routers-matcher
+  labels:
+    {{- include "routers.labels" . | nindent 4 }}
+spec:
+  namespaceSelector:
+    matchNames: [{{ .Release.Namespace }}]
+  selector:
+    matchLabels:
+      app: matcher
+  endpoints:
+    - port: metrics
+      interval: 1s
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: node
 {{- end }}

--- a/infrastructure/chart/values-local-dev.yaml
+++ b/infrastructure/chart/values-local-dev.yaml
@@ -1,6 +1,8 @@
 # Local Development Chart Configuration.
 # Debug logging + local-hostPath shard cache + in-cluster infra addresses
-# assumed to live in the `routers-dev` namespace of the same cluster.
+# assumed to live in the `routers-dev` devstack namespace of the same cluster
+# (see `infrastructure/devstack/`). The routers release itself lives in
+# `routers` by default.
 
 infra:
   nats:

--- a/infrastructure/dev/Justfile
+++ b/infrastructure/dev/Justfile
@@ -13,13 +13,26 @@ bringup: repos
         -n {{ namespace }} --create-namespace \
         -f kube-prometheus-stack-values.yaml
     @echo ""
-    @echo "Devstack ready. To open Grafana:  just devstack grafana"
+    @echo "Dev stack ready. To open Grafana:  just dev grafana"
 
-# Port-forward Grafana on localhost:3000. Anonymous Admin is enabled in the
-# devstack values, so no login is required. Ctrl-C to stop the forward.
-grafana port="3000":
-    @echo "Grafana: http://localhost:{{ port }}"
-    kubectl port-forward -n {{ namespace }} svc/kube-prometheus-stack-grafana {{ port }}:80
+# Port-forward Grafana on localhost:{{ port }} (default 3030) and open the
+# routers-realtime dashboard in the browser. Anonymous Admin is enabled in
+# the dev values, so no login is required. Ctrl-C to stop the forward.
+grafana port="3030":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    url="http://localhost:{{ port }}/d/routers-realtime/routers-realtime?orgId=1&from=now-15m&to=now&timezone=browser&refresh=5s"
+    echo "Grafana: $url"
+    kubectl port-forward -n {{ namespace }} svc/kube-prometheus-stack-grafana {{ port }}:80 &
+    pf_pid=$!
+    trap 'kill $pf_pid 2>/dev/null || true' EXIT
+    # Wait for the forward to accept connections before opening the browser.
+    for _ in $(seq 1 40); do
+        if curl -sf -o /dev/null "http://localhost:{{ port }}/api/health"; then break; fi
+        sleep 0.25
+    done
+    (command -v open >/dev/null && open "$url") || (command -v xdg-open >/dev/null && xdg-open "$url") || true
+    wait $pf_pid
 
 # Re-apply devstack helm values against existing releases and roll workloads
 # to pick up config changes. Assumes `bringup` has run.

--- a/infrastructure/dev/Justfile
+++ b/infrastructure/dev/Justfile
@@ -3,9 +3,10 @@ namespace := "routers-dev"
 bringup: repos
     helm upgrade --install nats nats/nats \
         -n {{ namespace }} --create-namespace \
-        --set config.jetstream.enabled=true \
         --set promExporter.enabled=true \
-        --set promExporter.port=7777
+        --set promExporter.port=7777 \
+        --set promExporter.podMonitor.enabled=true \
+        --set-json 'promExporter.podMonitor.merge={"spec":{"podMetricsEndpoints":[{"port":"prom-metrics","interval":"1s"}]}}'
     helm upgrade --install valkey oci://registry-1.docker.io/bitnamicharts/valkey \
         -n {{ namespace }} --create-namespace \
         --set auth.enabled=false
@@ -39,9 +40,10 @@ grafana port="3030":
 patch: repos
     helm upgrade nats nats/nats \
         -n {{ namespace }} \
-        --set config.jetstream.enabled=true \
         --set promExporter.enabled=true \
-        --set promExporter.port=7777
+        --set promExporter.port=7777 \
+        --set promExporter.podMonitor.enabled=true \
+        --set-json 'promExporter.podMonitor.merge={"spec":{"podMetricsEndpoints":[{"port":"prom-metrics","interval":"1s"}]}}'
     helm upgrade valkey oci://registry-1.docker.io/bitnamicharts/valkey \
         -n {{ namespace }} \
         --set auth.enabled=false

--- a/infrastructure/dev/Justfile
+++ b/infrastructure/dev/Justfile
@@ -1,0 +1,54 @@
+namespace := "routers-dev"
+
+bringup: repos
+    helm upgrade --install nats nats/nats \
+        -n {{ namespace }} --create-namespace \
+        --set config.jetstream.enabled=true \
+        --set promExporter.enabled=true \
+        --set promExporter.port=7777
+    helm upgrade --install valkey oci://registry-1.docker.io/bitnamicharts/valkey \
+        -n {{ namespace }} --create-namespace \
+        --set auth.enabled=false
+    helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
+        -n {{ namespace }} --create-namespace \
+        -f kube-prometheus-stack-values.yaml
+    @echo ""
+    @echo "Devstack ready. To open Grafana:  just devstack grafana"
+
+# Port-forward Grafana on localhost:3000. Anonymous Admin is enabled in the
+# devstack values, so no login is required. Ctrl-C to stop the forward.
+grafana port="3000":
+    @echo "Grafana: http://localhost:{{ port }}"
+    kubectl port-forward -n {{ namespace }} svc/kube-prometheus-stack-grafana {{ port }}:80
+
+# Re-apply devstack helm values against existing releases and roll workloads
+# to pick up config changes. Assumes `bringup` has run.
+patch: repos
+    helm upgrade nats nats/nats \
+        -n {{ namespace }} \
+        --set config.jetstream.enabled=true \
+        --set promExporter.enabled=true \
+        --set promExporter.port=7777
+    helm upgrade valkey oci://registry-1.docker.io/bitnamicharts/valkey \
+        -n {{ namespace }} \
+        --set auth.enabled=false
+    helm upgrade kube-prometheus-stack prometheus-community/kube-prometheus-stack \
+        -n {{ namespace }} \
+        -f kube-prometheus-stack-values.yaml
+    kubectl rollout restart deployment,statefulset -n {{ namespace }}
+
+teardown:
+    helm uninstall kube-prometheus-stack -n {{ namespace }} --ignore-not-found
+    helm uninstall valkey -n {{ namespace }} --ignore-not-found
+    helm uninstall nats -n {{ namespace }} --ignore-not-found
+    @if [ "${ROUTERS_DEVSTACK_DELETE_NAMESPACE:-0}" = "1" ]; then \
+        echo "Deleting namespace {{ namespace }}"; \
+        kubectl delete namespace {{ namespace }} --ignore-not-found; \
+    fi
+
+# Ensure required helm repos are available. The valkey chart is pulled via
+# OCI so needs no `helm repo add`.
+repos:
+    @helm repo list 2>/dev/null | grep -q '^nats\s' || helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+    @helm repo list 2>/dev/null | grep -q '^prometheus-community\s' || helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    @helm repo update nats prometheus-community >/dev/null

--- a/infrastructure/dev/kube-prometheus-stack-values.yaml
+++ b/infrastructure/dev/kube-prometheus-stack-values.yaml
@@ -1,0 +1,11 @@
+# Local-dev only: Grafana with no login. Anyone hitting the port-forward is
+# logged in as Admin. Do not use these values outside a developer's machine.
+grafana:
+  grafana.ini:
+    auth.anonymous:
+      enabled: true
+      org_role: Admin
+    auth:
+      disable_login_form: true
+    users:
+      allow_sign_up: false

--- a/infrastructure/dev/kube-prometheus-stack-values.yaml
+++ b/infrastructure/dev/kube-prometheus-stack-values.yaml
@@ -1,6 +1,11 @@
 # Local-dev only: Grafana with no login. Anyone hitting the port-forward is
 # logged in as Admin. Do not use these values outside a developer's machine.
 grafana:
+  # Discover dashboard ConfigMaps in every namespace so the routers chart
+  # (installed elsewhere) can ship its dashboard alongside its templates.
+  sidecar:
+    dashboards:
+      searchNamespace: ALL
   grafana.ini:
     auth.anonymous:
       enabled: true
@@ -9,3 +14,15 @@ grafana:
       disable_login_form: true
     users:
       allow_sign_up: false
+
+# Discover ServiceMonitors and PodMonitors from any namespace and any labels
+# so the routers chart (installed into a different namespace) can register
+# its scrape targets without coupling to this release's helm labels.
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelector: {}
+    serviceMonitorNamespaceSelector: {}
+    podMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelector: {}
+    podMonitorNamespaceSelector: {}

--- a/infrastructure/historian/historian.yaml
+++ b/infrastructure/historian/historian.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orchestrator
-  namespace: routers-dev
+  namespace: routers
   labels:
     app: orchestrator
 spec:
@@ -52,7 +52,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: orchestrator-metrics
-  namespace: routers-dev
+  namespace: routers
   labels:
     app: orchestrator
 spec:

--- a/infrastructure/matcher/matcher.yaml
+++ b/infrastructure/matcher/matcher.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: matcher
-  namespace: routers-dev
+  namespace: routers
   labels:
     app: matcher
 spec:
@@ -67,7 +67,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: matcher-metrics
-  namespace: routers-dev
+  namespace: routers
   labels:
     app: matcher
 spec:

--- a/infrastructure/orchestrator/orchestrator.yaml
+++ b/infrastructure/orchestrator/orchestrator.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orchestrator
-  namespace: routers-dev
+  namespace: routers
   labels:
     app: orchestrator
 spec:
@@ -52,7 +52,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: orchestrator-metrics
-  namespace: routers-dev
+  namespace: routers
   labels:
     app: orchestrator
 spec:

--- a/libs/routers_realtime/bin/matcher.rs
+++ b/libs/routers_realtime/bin/matcher.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use async_nats::{ConnectOptions, ServerAddr};
 use clap::Parser;
 use futures::{SinkExt, StreamExt};
+use geo::LineString;
 use log::{error, info};
 use routers::r#match::MatchOptions;
 use routers::{Match, PredicateCache, SolverVariant};
@@ -88,25 +89,26 @@ async fn main() -> anyhow::Result<()> {
     let cache = Arc::new(PredicateCache::<E, M, _>::default());
     let runtime = OsmEdgeMetadata::runtime(None);
 
+    let opts = MatchOptions::new()
+        .with_runtime(runtime.clone())
+        .with_cache(cache.clone())
+        .with_solver(SolverVariant::Fastest)
+        .with_search_distance(args.search_distance);
+
     while let Some(MatchContext {
         history,
         vehicle_id,
     }) = source.next().await
     {
-        let opts = MatchOptions::new()
-            .with_runtime(runtime.clone())
-            .with_cache(cache.clone())
-            .with_solver(SolverVariant::Fastest)
-            .with_search_distance(args.search_distance);
-
-        match network.r#match(history.into(), opts) {
+        let linestring = LineString::from(history);
+        match network.r#match(linestring.clone(), opts.clone()) {
             Ok(path) => {
                 sink.send(MatchResult { path, vehicle_id })
                     .await
                     .context("could not emit result to sink")?;
             }
             Err(err) => {
-                error!("unable to match payload: {err}");
+                error!("unable to match payload: {err} (linestring={linestring:?})");
             }
         }
     }

--- a/libs/routers_realtime/bin/orchestrator.rs
+++ b/libs/routers_realtime/bin/orchestrator.rs
@@ -1,7 +1,10 @@
+use std::time::Duration;
+
 use anyhow::Context;
 use async_nats::{ConnectOptions, ServerAddr};
 use clap::Parser;
 use futures::{SinkExt, StreamExt};
+use geo::{Distance, Haversine};
 use log::info;
 use routers_realtime::bus::{NATSSink, NATSStream};
 use routers_realtime::event::{MatchContext, Payload, RawEvent};
@@ -32,6 +35,16 @@ struct Args {
     /// The number of context entries to retrieve from Redis for each vehicle.
     #[arg(short, long = "context-window", env, default_value = "10")]
     context_window: usize,
+
+    /// Points older than this will be discarded from history, regardless
+    /// of if it's within the KV store, or not.
+    #[arg(long, env, value_parser = humantime::parse_duration, default_value = "120s")]
+    gap: Duration,
+
+    /// Consecutive points further away than this will be treated as a "teleport",
+    /// and dropped along with everything older.
+    #[arg(long, env, default_value = "2000")]
+    jump: f64,
 }
 
 #[tokio::main]
@@ -70,7 +83,25 @@ async fn main() -> anyhow::Result<()> {
             .await
             .context("could not get entries from redis store")?
             .into_iter()
-            .map(|RawEvent { point, .. }| point);
+            .scan(
+                (payload.point, payload.event_ms),
+                |(prev_p, prev_ms),
+                 RawEvent {
+                     point, event_ms, ..
+                 }| {
+                    let duration = Duration::from_millis(prev_ms.abs_diff(event_ms));
+                    let distance = Haversine.distance(*prev_p, point);
+
+                    if duration <= args.gap && distance <= args.jump {
+                        *prev_p = point;
+                        *prev_ms = event_ms;
+                        Some(point)
+                    } else {
+                        None
+                    }
+                },
+            )
+            .collect::<Vec<_>>();
 
         let history = std::iter::once(payload.point).chain(context).collect();
 

--- a/libs/routers_realtime/bin/replay.rs
+++ b/libs/routers_realtime/bin/replay.rs
@@ -10,7 +10,6 @@ use indicatif_log_bridge::LogWrapper;
 use itertools::izip;
 use log::{debug, info};
 use polars::prelude::*;
-use routers::Reachable;
 use routers_realtime::{bus::NATSSink, event::Payload};
 use routers_shard::{GeohashStrategy, ShardingStrategy};
 use std::{fmt::Write, path::PathBuf, time::Duration};
@@ -39,7 +38,7 @@ struct Args {
     loops: usize,
 
     /// Shard precision level to send the events as
-    #[arg(short, env, long, default_value_t = 5)]
+    #[arg(short, env, long, default_value_t = 4)]
     precision: u8,
 
     /// The subject prefix to use for the NATS events stream

--- a/libs/routers_realtime/bin/replay.rs
+++ b/libs/routers_realtime/bin/replay.rs
@@ -10,6 +10,7 @@ use indicatif_log_bridge::LogWrapper;
 use itertools::izip;
 use log::{debug, info};
 use polars::prelude::*;
+use routers::Reachable;
 use routers_realtime::{bus::NATSSink, event::Payload};
 use routers_shard::{GeohashStrategy, ShardingStrategy};
 use std::{fmt::Write, path::PathBuf, time::Duration};
@@ -126,6 +127,7 @@ async fn main() -> anyhow::Result<()> {
 
     let flood = args.speed <= 0.0;
     let speed = if flood { f64::INFINITY } else { args.speed };
+    let realtime_s = if flood { 0.0 } else { timespan_s / speed };
 
     let mut sink = nats.buffer(BUFFERED_PUBLISH_SIZE);
 
@@ -146,7 +148,7 @@ async fn main() -> anyhow::Result<()> {
         pg.set_message("[flood-mode] speed=∞x".to_string());
     } else {
         pg.set_message(format!(
-            "[walk-mode] speed={speed}x (walltime={timespan_s:.1} s)"
+            "[walk-mode] speed={speed}x (walltime={timespan_s:.1} s, realtime={realtime_s:.1} s)"
         ));
     }
 

--- a/libs/routers_realtime/src/bus/nats.rs
+++ b/libs/routers_realtime/src/bus/nats.rs
@@ -2,15 +2,13 @@ use std::pin::Pin;
 use std::task::{Context as Ctx, Poll, ready};
 
 use anyhow::Context;
-use async_nats::jetstream::{self};
 use futures::future::BoxFuture;
 use futures::{FutureExt, Sink, Stream, StreamExt};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 pub struct NATSSink<T: Serialize> {
-    client: async_nats::Client, // kept for an explicit flush on shutdown
-    js: jetstream::Context,
+    client: async_nats::Client,
     subject_of: Box<dyn Fn(&T) -> String>,
     in_flight: Option<BoxFuture<'static, anyhow::Result<()>>>,
 
@@ -24,11 +22,8 @@ pub struct NATSStream<T: DeserializeOwned> {
 
 impl<T: Serialize> NATSSink<T> {
     pub fn new(client: async_nats::Client, subject_of: impl Fn(&T) -> String + 'static) -> Self {
-        let js = jetstream::new(client.clone());
-
         Self {
             client,
-            js,
             subject_of: Box::new(subject_of),
             in_flight: None,
             _phantom: std::marker::PhantomData,
@@ -65,13 +60,11 @@ impl<T: Serialize + Unpin> Sink<T> for NATSSink<T> {
         let payload: Vec<u8> = postcard::to_allocvec(&item).context("failed to serialize")?;
 
         let subject = this.subject_for(&item);
-        let js = this.js.clone();
+        let client = this.client.clone();
 
         this.in_flight = Some(
             async move {
-                // resolves once the message is handed to the connection buffer;
-                // the returned ack future is dropped (fire-and-forget).
-                let _ack = js.publish(subject, payload.into()).await?;
+                client.publish(subject, payload.into()).await?;
                 Ok::<(), anyhow::Error>(())
             }
             .boxed(),

--- a/libs/routers_realtime/src/event.rs
+++ b/libs/routers_realtime/src/event.rs
@@ -51,7 +51,7 @@ impl Storable for RawEvent {
     type Key = String;
 
     fn shard_id(&self) -> Self::ShardId {
-        GeohashStrategy::with_precision(5).locate(self.point)
+        GeohashStrategy::with_precision(4).locate(self.point)
     }
 
     fn key(&self) -> Self::Key {

--- a/libs/routers_transition/src/match/definition.rs
+++ b/libs/routers_transition/src/match/definition.rs
@@ -8,6 +8,7 @@ use routers_network::{Entry, Metadata, Network};
 
 pub const DEFAULT_SEARCH_DISTANCE: f64 = 50.0; // 50m
 
+#[derive(Clone, Debug)]
 pub struct MatchOptions<E: Entry, M: Metadata, N: Network<E, M>> {
     /// The distance the solver will use to search for candidates
     /// around every given input position.

--- a/libs/routers_transition/src/solver/variant.rs
+++ b/libs/routers_transition/src/solver/variant.rs
@@ -11,7 +11,7 @@ pub enum SolverImpl<E: Entry, M: Metadata, N: Network<E, M>> {
     Selective(SelectiveForwardSolver<E, M, N>),
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub enum SolverVariant {
     #[default]
     Fastest,


### PR DESCRIPTION
Renames the namespace to `routers` from `routers-dev`, which is instead now used for dependency infrastructure, like the instance of NATS and Redis/Valkey that's required.\

One can bring up the dev stack using `just infra dev bringup|teardown|patch`. One can also run `just infra dev grafana <port>` to be taken to the live throughput dashboard.