### PR TITLE
fix: Simplify Transition Trait Bounds

### DIFF
--- a/libs/routers_transition/src/candidate/entry.rs
+++ b/libs/routers_transition/src/candidate/entry.rs
@@ -3,7 +3,7 @@ use crate::RoutingContext;
 use core::cmp::Ordering;
 use core::fmt::Debug;
 use core::ops::Add;
-use geo::{Distance, Haversine, LineLocatePoint, LineString, Point};
+use geo::{Bearing, Distance, Haversine, LineLocatePoint, LineString, Point};
 use pathfinding::num_traits::Zero;
 use routers_network::{Edge, Entry, Metadata, Network};
 
@@ -86,6 +86,21 @@ where
             .collect::<LineString>();
 
         edge.line_locate_point(&self.position)
+    }
+
+    /// Bearing of the candidate's edge (source endpoint → target endpoint).
+    /// `None` if either endpoint is missing from the map, or if the edge is
+    /// degenerate (endpoints under 1m apart) — in which case the bearing is
+    /// meaningless and callers should elide the associated turn from any
+    /// angular-complexity calculation rather than folding in a bogus value.
+    pub fn edge_heading<M, N>(&self, ctx: &RoutingContext<E, M, N>) -> Option<f64>
+    where
+        M: Metadata,
+        N: Network<E, M>,
+    {
+        let s = ctx.map.point(&self.edge.source)?;
+        let t = ctx.map.point(&self.edge.target)?;
+        (Haversine.distance(s, t) >= 1.0).then(|| Haversine.bearing(s, t))
     }
 
     /// Calculates the offset, in meters, of the candidate to it's edge by the [`VirtualTail`].

--- a/libs/routers_transition/src/candidate/entry.rs
+++ b/libs/routers_transition/src/candidate/entry.rs
@@ -88,11 +88,7 @@ where
         edge.line_locate_point(&self.position)
     }
 
-    /// Bearing of the candidate's edge (source endpoint → target endpoint).
-    /// `None` if either endpoint is missing from the map, or if the edge is
-    /// degenerate (endpoints under 1m apart) — in which case the bearing is
-    /// meaningless and callers should elide the associated turn from any
-    /// angular-complexity calculation rather than folding in a bogus value.
+    /// Get the bearing of the candidate's edge (source endpoint -> target endpoint).
     pub fn edge_heading<M, N>(&self, ctx: &RoutingContext<E, M, N>) -> Option<f64>
     where
         M: Metadata,
@@ -100,7 +96,13 @@ where
     {
         let s = ctx.map.point(&self.edge.source)?;
         let t = ctx.map.point(&self.edge.target)?;
-        (Haversine.distance(s, t) >= 1.0).then(|| Haversine.bearing(s, t))
+
+        // Consider degenerate case
+        if Haversine.distance(s, t) < 1.0 {
+            return None;
+        }
+
+        Some(Haversine.bearing(s, t))
     }
 
     /// Calculates the offset, in meters, of the candidate to it's edge by the [`VirtualTail`].

--- a/libs/routers_transition/src/costing/default.rs
+++ b/libs/routers_transition/src/costing/default.rs
@@ -177,29 +177,23 @@ pub mod costing {
         Costing, EmissionContext, EmissionStrategy, TransitionContext, TransitionStrategy,
     };
     use core::marker::PhantomData;
-    use routers_network::{Entry, Metadata, Network};
+    use routers_network::Entry;
 
-    pub struct CostingStrategies<Emmis, Trans, E, M, N>
+    pub struct CostingStrategies<Emmis, Trans, E>
     where
         E: Entry,
-        M: Metadata,
-        N: Network<E, M>,
         Emmis: EmissionStrategy,
         Trans: TransitionStrategy<E>,
     {
         pub emission: Emmis,
         pub transition: Trans,
 
-        _phantom: core::marker::PhantomData<E>,
-        _phantom2: core::marker::PhantomData<M>,
-        _phantom3: core::marker::PhantomData<N>,
+        _phantom: PhantomData<E>,
     }
 
-    impl<Emmis, Trans, E, M, N> CostingStrategies<Emmis, Trans, E, M, N>
+    impl<Emmis, Trans, E> CostingStrategies<Emmis, Trans, E>
     where
         E: Entry,
-        M: Metadata,
-        N: Network<E, M>,
         Emmis: EmissionStrategy,
         Trans: TransitionStrategy<E>,
     {
@@ -209,29 +203,22 @@ pub mod costing {
                 transition,
 
                 _phantom: PhantomData,
-                _phantom2: PhantomData,
-                _phantom3: PhantomData,
             }
         }
     }
 
-    impl<E, M, N> Default for CostingStrategies<DefaultEmissionCost, DefaultTransitionCost, E, M, N>
+    impl<E> Default for CostingStrategies<DefaultEmissionCost, DefaultTransitionCost, E>
     where
         E: Entry,
-        M: Metadata,
-        N: Network<E, M>,
     {
         fn default() -> Self {
             CostingStrategies::new(DefaultEmissionCost::default(), DefaultTransitionCost)
         }
     }
 
-    impl<Emmis, Trans, E, M, N> Costing<Emmis, Trans, E, M, N>
-        for CostingStrategies<Emmis, Trans, E, M, N>
+    impl<Emmis, Trans, E> Costing<Emmis, Trans, E> for CostingStrategies<Emmis, Trans, E>
     where
         E: Entry,
-        M: Metadata,
-        N: Network<E, M>,
         Trans: TransitionStrategy<E>,
         Emmis: EmissionStrategy,
     {

--- a/libs/routers_transition/src/costing/default.rs
+++ b/libs/routers_transition/src/costing/default.rs
@@ -67,7 +67,7 @@ pub mod emission {
 
 pub mod transition {
     use crate::*;
-    use routers_network::{Edge, Entry, Metadata, Network};
+    use routers_network::{Edge, Entry};
 
     /// Calculates the transition cost between two candidates.
     ///
@@ -121,11 +121,9 @@ pub mod transition {
     /// [amortize]: https://en.wikipedia.org/wiki/Amortized_analysis
     pub struct DefaultTransitionCost;
 
-    impl<'a, E, M, N> Strategy<TransitionContext<'a, E, M, N>> for DefaultTransitionCost
+    impl<'a, E> Strategy<TransitionContext<'a, E>> for DefaultTransitionCost
     where
         E: Entry,
-        M: Metadata,
-        N: Network<E, M>,
     {
         type Cost = f64;
 
@@ -133,7 +131,7 @@ pub mod transition {
         const BETA: f64 = 1.;
 
         #[inline]
-        fn calculate(&self, context: TransitionContext<'a, E, M, N>) -> Option<Self::Cost> {
+        fn calculate(&self, context: TransitionContext<'a, E>) -> Option<Self::Cost> {
             const EPSILON: f64 = 1e-6;
 
             // Find the transition lengths (shortest path, trip length)
@@ -187,7 +185,7 @@ pub mod costing {
         M: Metadata,
         N: Network<E, M>,
         Emmis: EmissionStrategy,
-        Trans: TransitionStrategy<E, M, N>,
+        Trans: TransitionStrategy<E>,
     {
         pub emission: Emmis,
         pub transition: Trans,
@@ -203,7 +201,7 @@ pub mod costing {
         M: Metadata,
         N: Network<E, M>,
         Emmis: EmissionStrategy,
-        Trans: TransitionStrategy<E, M, N>,
+        Trans: TransitionStrategy<E>,
     {
         pub fn new(emission: Emmis, transition: Trans) -> Self {
             Self {
@@ -234,7 +232,7 @@ pub mod costing {
         E: Entry,
         M: Metadata,
         N: Network<E, M>,
-        Trans: TransitionStrategy<E, M, N>,
+        Trans: TransitionStrategy<E>,
         Emmis: EmissionStrategy,
     {
         #[inline(always)]
@@ -243,7 +241,7 @@ pub mod costing {
         }
 
         #[inline(always)]
-        fn transition(&self, context: TransitionContext<E, M, N>) -> u32 {
+        fn transition(&self, context: TransitionContext<E>) -> u32 {
             self.transition.cost(context)
         }
     }

--- a/libs/routers_transition/src/costing/transition.rs
+++ b/libs/routers_transition/src/costing/transition.rs
@@ -148,43 +148,46 @@ where
     /// path are derived internally — the caller supplies the candidate IDs
     /// and the map-node sequence between them.
     pub fn new<M, N>(
-        routing_context: &'a RoutingContext<'a, E, M, N>,
-        (source_candidate, target_candidate): (&'a CandidateId, &'a CandidateId),
+        ctx: &'a RoutingContext<'a, E, M, N>,
+        (src, trg): (&'a CandidateId, &'a CandidateId),
         map_path: &'a [E],
     ) -> Option<Self>
     where
         M: Metadata,
         N: Network<E, M>,
     {
-        let source = routing_context.candidate(source_candidate)?;
-        let target = routing_context.candidate(target_candidate)?;
+        let source = ctx.candidate(src)?;
+        let target = ctx.candidate(trg)?;
 
         let headings = Headings {
-            source: source.edge_heading(routing_context),
-            target: target.edge_heading(routing_context),
+            source: source.edge_heading(ctx),
+            target: target.edge_heading(ctx),
         };
 
         let virtual_tails = VirtualTails {
-            source: source.offset(routing_context, VirtualTail::ToTarget),
-            target: target.offset(routing_context, VirtualTail::ToSource),
+            source: source.offset(ctx, VirtualTail::ToTarget),
+            target: target.offset(ctx, VirtualTail::ToSource),
         };
 
         Some(Self {
-            optimal_path: Trip::new_with_map(routing_context.map, map_path),
+            optimal_path: Trip::new_with_map(ctx.map, map_path),
+            candidates: ctx.candidates,
+            requested_resolution_method: ResolutionMethod::default(),
+
             source_position: source.position,
             target_position: target.position,
+
+            source_candidate: src,
+            target_candidate: trg,
+
             map_path,
-            source_candidate,
-            target_candidate,
-            candidates: routing_context.candidates,
-            requested_resolution_method: ResolutionMethod::default(),
             headings,
             virtual_tails,
         })
     }
 
     /// Overrides the [resolution method](ResolutionMethod) used when costing
-    /// the transition. Defaults to [`ResolutionMethod::Standard`].
+    /// the transition.
     pub fn with_resolution_method(mut self, method: ResolutionMethod) -> Self {
         self.requested_resolution_method = method;
         self

--- a/libs/routers_transition/src/costing/transition.rs
+++ b/libs/routers_transition/src/costing/transition.rs
@@ -68,11 +68,10 @@ where
     /// Candidate registry used to resolve candidates into full [`Candidate`] values.
     pub candidates: &'a Candidates<E>,
 
-    /// The length between the layer nodes
-    pub layer_width: f64,
-
     /// The requested [resolution method](ResolutionMethod) by which the transition costing function
-    /// should attempt to cost (resolve) the two candidates.
+    /// should attempt to cost (resolve) the two candidates. Defaults to
+    /// [`ResolutionMethod::Standard`]; override with
+    /// [`with_resolution_method`](Self::with_resolution_method).
     pub requested_resolution_method: ResolutionMethod,
 
     /// Edge bearings for source and target candidates.
@@ -152,8 +151,6 @@ where
         routing_context: &'a RoutingContext<'a, E, M, N>,
         (source_candidate, target_candidate): (&'a CandidateId, &'a CandidateId),
         map_path: &'a [E],
-        layer_width: f64,
-        requested_resolution_method: ResolutionMethod,
     ) -> Option<Self>
     where
         M: Metadata,
@@ -180,11 +177,17 @@ where
             source_candidate,
             target_candidate,
             candidates: routing_context.candidates,
-            layer_width,
-            requested_resolution_method,
+            requested_resolution_method: ResolutionMethod::default(),
             headings,
             virtual_tails,
         })
+    }
+
+    /// Overrides the [resolution method](ResolutionMethod) used when costing
+    /// the transition. Defaults to [`ResolutionMethod::Standard`].
+    pub fn with_resolution_method(mut self, method: ResolutionMethod) -> Self {
+        self.requested_resolution_method = method;
+        self
     }
 
     /// Obtains the source [candidate](Candidate) from the context.

--- a/libs/routers_transition/src/costing/transition.rs
+++ b/libs/routers_transition/src/costing/transition.rs
@@ -144,13 +144,13 @@ where
 {
     /// Builds the context, precomputing all network-derived values so the
     /// resulting struct is generic only over the entry type.
+    ///
+    /// Candidate positions and the [`Trip`] representation of the optimal
+    /// path are derived internally — the caller supplies the candidate IDs
+    /// and the map-node sequence between them.
     pub fn new<M, N>(
         routing_context: &'a RoutingContext<'a, E, M, N>,
-        source_candidate: &'a CandidateId,
-        target_candidate: &'a CandidateId,
-        source_position: Point,
-        target_position: Point,
-        optimal_path: Trip<E>,
+        (source_candidate, target_candidate): (&'a CandidateId, &'a CandidateId),
         map_path: &'a [E],
         layer_width: f64,
         requested_resolution_method: ResolutionMethod,
@@ -173,9 +173,9 @@ where
         };
 
         Some(Self {
-            optimal_path,
-            source_position,
-            target_position,
+            optimal_path: Trip::new_with_map(routing_context.map, map_path),
+            source_position: source.position,
+            target_position: target.position,
             map_path,
             source_candidate,
             target_candidate,
@@ -206,10 +206,6 @@ where
         (self.source_candidate(), self.target_candidate())
     }
 
-    /// Angular complexity of the full intra-transition geometry: the
-    /// candidate source position, the interior map nodes, and the candidate
-    /// target position. This is what cost heuristics should call so that the
-    /// turn at the candidate→edge joints participates in the score.
     pub fn angular_complexity(&self) -> f64 {
         self.optimal_path.angular_complexity_with_headings(
             self.headings.source,

--- a/libs/routers_transition/src/costing/transition.rs
+++ b/libs/routers_transition/src/costing/transition.rs
@@ -1,21 +1,37 @@
 use crate::ResolutionMethod;
-use crate::candidate::{Candidate, CandidateId};
+use crate::candidate::{Candidate, CandidateId, Candidates};
 use crate::{RoutingContext, Strategy, Trip, VirtualTail};
-use geo::{Bearing, Distance, Haversine, Point};
+use geo::{Distance, Haversine, Point};
 use routers_network::{Entry, Metadata, Network};
 
-pub trait TransitionStrategy<E, M, N>: for<'a> Strategy<TransitionContext<'a, E, M, N>> {}
-impl<T, N, E, M> TransitionStrategy<E, M, N> for T where
-    T: for<'a> Strategy<TransitionContext<'a, E, M, N>>
-{
+pub trait TransitionStrategy<E>: for<'a> Strategy<TransitionContext<'a, E>> {}
+impl<T, E> TransitionStrategy<E> for T where T: for<'a> Strategy<TransitionContext<'a, E>> {}
+
+/// Edge-level bearings for the source and target candidate edges.
+///
+/// A field is `None` when [`Candidate::edge_heading`] could not resolve
+/// a bearing where either the endpoint is missing from the map, or the edge
+/// is degenerate (endpoints small distance apart).
+#[derive(Clone, Copy, Debug)]
+pub struct Headings {
+    pub source: Option<f64>,
+    pub target: Option<f64>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct VirtualTails {
+    /// [`VirtualTail::ToTarget`] on the source candidate:
+    /// Effectively `distance(source_position, source.edge.target)`.
+    pub source: Option<f64>,
+    /// [`VirtualTail::ToSource`] on the target candidate:
+    /// Effectively `distance(target.edge.source, target_position)`.
+    pub target: Option<f64>,
 }
 
 #[derive(Clone, Debug)]
-pub struct TransitionContext<'a, E, M, N>
+pub struct TransitionContext<'a, E>
 where
-    M: Metadata + 'a,
     E: Entry + 'a,
-    N: Network<E, M>,
 {
     /// The optimal path travelled between the
     /// source candidate and target candidate, used
@@ -49,9 +65,8 @@ where
     /// position for which the path ends at.
     pub target_candidate: &'a CandidateId,
 
-    /// Further context to provide access to determine routing information,
-    /// such as node positions upon the map, and referencing other candidates.
-    pub routing_context: &'a RoutingContext<'a, E, M, N>,
+    /// Candidate registry used to resolve candidates into full [`Candidate`] values.
+    pub candidates: &'a Candidates<E>,
 
     /// The length between the layer nodes
     pub layer_width: f64,
@@ -59,6 +74,12 @@ where
     /// The requested [resolution method](ResolutionMethod) by which the transition costing function
     /// should attempt to cost (resolve) the two candidates.
     pub requested_resolution_method: ResolutionMethod,
+
+    /// Edge bearings for source and target candidates.
+    pub headings: Headings,
+
+    /// Per-candidate virtual-tail distances.
+    pub virtual_tails: VirtualTails,
 }
 
 pub struct TransitionLengths {
@@ -117,24 +138,67 @@ mod tests {
     }
 }
 
-impl<E, M, N> TransitionContext<'_, E, M, N>
+impl<'a, E> TransitionContext<'a, E>
 where
     E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
 {
+    /// Builds the context, precomputing all network-derived values so the
+    /// resulting struct is generic only over the entry type.
+    pub fn new<M, N>(
+        routing_context: &'a RoutingContext<'a, E, M, N>,
+        source_candidate: &'a CandidateId,
+        target_candidate: &'a CandidateId,
+        source_position: Point,
+        target_position: Point,
+        optimal_path: Trip<E>,
+        map_path: &'a [E],
+        layer_width: f64,
+        requested_resolution_method: ResolutionMethod,
+    ) -> Option<Self>
+    where
+        M: Metadata,
+        N: Network<E, M>,
+    {
+        let source = routing_context.candidate(source_candidate)?;
+        let target = routing_context.candidate(target_candidate)?;
+
+        let headings = Headings {
+            source: source.edge_heading(routing_context),
+            target: target.edge_heading(routing_context),
+        };
+
+        let virtual_tails = VirtualTails {
+            source: source.offset(routing_context, VirtualTail::ToTarget),
+            target: target.offset(routing_context, VirtualTail::ToSource),
+        };
+
+        Some(Self {
+            optimal_path,
+            source_position,
+            target_position,
+            map_path,
+            source_candidate,
+            target_candidate,
+            candidates: routing_context.candidates,
+            layer_width,
+            requested_resolution_method,
+            headings,
+            virtual_tails,
+        })
+    }
+
     /// Obtains the source [candidate](Candidate) from the context.
     pub fn source_candidate(&self) -> Candidate<E> {
-        self.routing_context
+        self.candidates
             .candidate(self.source_candidate)
-            .expect("source candidate not found in routing context")
+            .expect("source candidate not found")
     }
 
     /// Obtains the target [candidate](Candidate) from the context.
     pub fn target_candidate(&self) -> Candidate<E> {
-        self.routing_context
+        self.candidates
             .candidate(self.target_candidate)
-            .expect("target candidate not found in routing context")
+            .expect("target candidate not found")
     }
 
     /// Returns a [candidate](Candidate) pair of (source, target)
@@ -142,72 +206,32 @@ where
         (self.source_candidate(), self.target_candidate())
     }
 
+    /// Angular complexity of the full intra-transition geometry: the
+    /// candidate source position, the interior map nodes, and the candidate
+    /// target position. This is what cost heuristics should call so that the
+    /// turn at the candidate→edge joints participates in the score.
+    pub fn angular_complexity(&self) -> f64 {
+        self.optimal_path.angular_complexity_with_headings(
+            self.headings.source,
+            self.headings.target,
+            self.source_position,
+            self.target_position,
+        )
+    }
+
     /// Calculates the total offset, of both source and target positions within the context,
-    /// considering the resolution method requested
+    /// considering the resolution method requested.
     pub fn total_offset(&self, source: &Candidate<E>, target: &Candidate<E>) -> Option<f64> {
         match self.requested_resolution_method {
             ResolutionMethod::Standard => {
-                // Also validate that this isn't the only way we need to calculate the distances,
-                // since its perfectly possible to need the other way around (virt. tail) depending on which
-                // invariants are upheld upstream
-                let inner_offset = source.offset(self.routing_context, VirtualTail::ToTarget)?;
-                let outer_offset = target.offset(self.routing_context, VirtualTail::ToSource)?;
-
+                let inner_offset = self.virtual_tails.source?;
+                let outer_offset = self.virtual_tails.target?;
                 Some(inner_offset + outer_offset)
             }
             ResolutionMethod::DistanceOnly => {
                 Some(Haversine.distance(source.position, target.position))
             }
         }
-    }
-
-    /// Angular complexity of the full intra-transition geometry: the
-    /// candidate source position, the interior map nodes, and the candidate
-    /// target position. This is what cost heuristics should call so that the
-    /// turn at the candidate→edge joints participates in the score.
-    pub fn angular_complexity(&self) -> f64 {
-        let (source_c, target_c) = self.candidates();
-
-        let source_heading = self
-            .routing_context
-            .map
-            .point(&source_c.edge.source)
-            .and_then(|s| {
-                self.routing_context
-                    .map
-                    .point(&source_c.edge.target)
-                    .and_then(|t| {
-                        if Haversine.distance(s, t) < 1.0 {
-                            None
-                        } else {
-                            Some(Haversine.bearing(s, t))
-                        }
-                    })
-            });
-
-        let target_heading = self
-            .routing_context
-            .map
-            .point(&target_c.edge.source)
-            .and_then(|s| {
-                self.routing_context
-                    .map
-                    .point(&target_c.edge.target)
-                    .and_then(|t| {
-                        if Haversine.distance(s, t) < 1.0 {
-                            None
-                        } else {
-                            Some(Haversine.bearing(s, t))
-                        }
-                    })
-            });
-
-        self.optimal_path.angular_complexity_with_headings(
-            source_heading,
-            target_heading,
-            self.source_position,
-            self.target_position,
-        )
     }
 
     /// Returns the [`TransitionLengths`] of the context.

--- a/libs/routers_transition/src/costing/util.rs
+++ b/libs/routers_transition/src/costing/util.rs
@@ -44,12 +44,12 @@ where
     E: Entry,
     M: Metadata,
     N: Network<E, M>,
-    Transition: TransitionStrategy<E, M, N>,
+    Transition: TransitionStrategy<E>,
     Emission: EmissionStrategy,
 {
     /// The emission costing function, returning a u32 cost value.
     fn emission(&self, context: EmissionContext) -> u32;
 
     /// The transition costing function, returning a u32 cost value.
-    fn transition(&self, context: TransitionContext<E, M, N>) -> u32;
+    fn transition(&self, context: TransitionContext<E>) -> u32;
 }

--- a/libs/routers_transition/src/costing/util.rs
+++ b/libs/routers_transition/src/costing/util.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use routers_network::{Entry, Metadata, Network};
+use routers_network::Entry;
 
 const PRECISION: f64 = 100.0f64;
 
@@ -39,11 +39,9 @@ pub trait Strategy<Ctx> {
     }
 }
 
-pub trait Costing<Emission, Transition, E, M, N>
+pub trait Costing<Emission, Transition, E>
 where
     E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
     Transition: TransitionStrategy<E>,
     Emission: EmissionStrategy,
 {

--- a/libs/routers_transition/src/entity.rs
+++ b/libs/routers_transition/src/entity.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::*;
 
 use crate::definition::Layers;
@@ -62,10 +64,12 @@ where
     Transition: TransitionStrategy<E>,
 {
     pub(crate) map: &'a N,
-    pub(crate) heuristics: &'a CostingStrategies<Emission, Transition, E, M, N>,
+    pub(crate) heuristics: &'a CostingStrategies<Emission, Transition, E>,
 
     pub(crate) candidates: Candidates<E>,
     pub(crate) layers: Layers,
+
+    _phantom: PhantomData<M>,
 }
 
 impl<'a, Emmis, Trans, E, M, N> Transition<'a, Emmis, Trans, E, M, N>
@@ -89,7 +93,7 @@ where
     pub fn new(
         map: &'a N,
         linestring: LineString,
-        heuristics: &'a CostingStrategies<Emmis, Trans, E, M, N>,
+        heuristics: &'a CostingStrategies<Emmis, Trans, E>,
         generator: impl LayerGeneration<E>,
     ) -> Transition<'a, Emmis, Trans, E, M, N> {
         let points = linestring.into_points();
@@ -102,6 +106,7 @@ where
             candidates,
             layers,
             heuristics,
+            _phantom: PhantomData,
         }
     }
 

--- a/libs/routers_transition/src/entity.rs
+++ b/libs/routers_transition/src/entity.rs
@@ -59,7 +59,7 @@ where
     M: Metadata,
     N: Network<E, M>,
     Emission: EmissionStrategy,
-    Transition: TransitionStrategy<E, M, N>,
+    Transition: TransitionStrategy<E>,
 {
     pub(crate) map: &'a N,
     pub(crate) heuristics: &'a CostingStrategies<Emission, Transition, E, M, N>,
@@ -74,7 +74,7 @@ where
     M: Metadata,
     N: Network<E, M>,
     Emmis: EmissionStrategy + Send + Sync,
-    Trans: TransitionStrategy<E, M, N> + Send + Sync,
+    Trans: TransitionStrategy<E> + Send + Sync,
 {
     /// Creates a new transition graph from the input linestring and heuristics.
     ///

--- a/libs/routers_transition/src/primitives/resolve.rs
+++ b/libs/routers_transition/src/primitives/resolve.rs
@@ -48,6 +48,10 @@ where
         }
     }
 
+    pub fn candidates<'a>(&'a self) -> (&'a CandidateId, &'a CandidateId) {
+        (&self.source, &self.target)
+    }
+
     /// Consumes and modifies a reachable element to request the
     /// [`DistanceOnly`](ResolutionMethod::DistanceOnly) option.
     pub fn distance_only(self) -> Self {

--- a/libs/routers_transition/src/solver/methods.rs
+++ b/libs/routers_transition/src/solver/methods.rs
@@ -29,7 +29,7 @@ where
     ) -> Result<CollapsedPath<E>, MatchError>
     where
         Emmis: EmissionStrategy + Send + Sync,
-        Trans: TransitionStrategy<E, M, N> + Send + Sync;
+        Trans: TransitionStrategy<E> + Send + Sync;
 
     /// Creates a path from the source up the parent map until no more parents
     /// are found. This assumes there is only one relation between parent and children.

--- a/libs/routers_transition/src/solver/precompute_forward.rs
+++ b/libs/routers_transition/src/solver/precompute_forward.rs
@@ -7,7 +7,6 @@ use log::{debug, info};
 use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 
-use geo::{Distance, Haversine};
 use itertools::Itertools;
 use measure_time::debug_time;
 use pathfinding::num_traits::Zero;
@@ -77,21 +76,14 @@ where
             .filter_map(|target| self.get_reachable(context, source, &target))
             .filter_map(move |reachable| {
                 let path_vec = reachable.path_nodes().collect_vec();
-
-                let source = context.candidate(&reachable.source)?;
                 let target = context.candidate(&reachable.target)?;
-
-                let sl = transition.layers.layers.get(source.location.layer_id)?;
-                let tl = transition.layers.layers.get(target.location.layer_id)?;
-                let layer_width = Haversine.distance(sl.origin, tl.origin);
 
                 let transition_ctx = TransitionContext::new(
                     context,
                     (&reachable.source, &reachable.target),
                     &path_vec,
-                    layer_width,
-                    reachable.resolution_method,
-                )?;
+                )?
+                .with_resolution_method(reachable.resolution_method);
                 let transition_cost = transition.heuristics.transition(transition_ctx);
 
                 let cost = target.emission.saturating_add(transition_cost);

--- a/libs/routers_transition/src/solver/precompute_forward.rs
+++ b/libs/routers_transition/src/solver/precompute_forward.rs
@@ -77,7 +77,6 @@ where
             .filter_map(|target| self.get_reachable(context, source, &target))
             .filter_map(move |reachable| {
                 let path_vec = reachable.path_nodes().collect_vec();
-                let optimal_path = Trip::new_with_map(transition.map, &path_vec);
 
                 let source = context.candidate(&reachable.source)?;
                 let target = context.candidate(&reachable.target)?;
@@ -88,11 +87,7 @@ where
 
                 let transition_ctx = TransitionContext::new(
                     context,
-                    &reachable.source,
-                    &reachable.target,
-                    source.position,
-                    target.position,
-                    optimal_path,
+                    (&reachable.source, &reachable.target),
                     &path_vec,
                     layer_width,
                     reachable.resolution_method,

--- a/libs/routers_transition/src/solver/precompute_forward.rs
+++ b/libs/routers_transition/src/solver/precompute_forward.rs
@@ -66,7 +66,7 @@ where
     ) -> Vec<(Reachable<E>, CandidateEdge)>
     where
         Emmis: EmissionStrategy + Send + Sync,
-        Trans: TransitionStrategy<E, M, N> + Send + Sync,
+        Trans: TransitionStrategy<E> + Send + Sync,
         'b: 'a,
     {
         use rayon::prelude::{IntoParallelIterator, ParallelIterator};
@@ -86,20 +86,18 @@ where
                 let tl = transition.layers.layers.get(target.location.layer_id)?;
                 let layer_width = Haversine.distance(sl.origin, tl.origin);
 
-                let transition_cost = transition.heuristics.transition(TransitionContext {
-                    map_path: &path_vec,
-                    requested_resolution_method: reachable.resolution_method,
-
-                    source_candidate: &reachable.source,
-                    target_candidate: &reachable.target,
-                    routing_context: context,
-
-                    source_position: source.position,
-                    target_position: target.position,
-
-                    layer_width,
+                let transition_ctx = TransitionContext::new(
+                    context,
+                    &reachable.source,
+                    &reachable.target,
+                    source.position,
+                    target.position,
                     optimal_path,
-                });
+                    &path_vec,
+                    layer_width,
+                    reachable.resolution_method,
+                )?;
+                let transition_cost = transition.heuristics.transition(transition_ctx);
 
                 let cost = target.emission.saturating_add(transition_cost);
 
@@ -179,7 +177,7 @@ where
     ) -> Result<CollapsedPath<E>, MatchError>
     where
         Emmis: EmissionStrategy + Send + Sync,
-        Trans: TransitionStrategy<E, M, N> + Send + Sync,
+        Trans: TransitionStrategy<E> + Send + Sync,
     {
         let (start, end) = {
             // Compute cost ~= free

--- a/libs/routers_transition/src/solver/precompute_forward.rs
+++ b/libs/routers_transition/src/solver/precompute_forward.rs
@@ -78,12 +78,9 @@ where
                 let path_vec = reachable.path_nodes().collect_vec();
                 let target = context.candidate(&reachable.target)?;
 
-                let transition_ctx = TransitionContext::new(
-                    context,
-                    (&reachable.source, &reachable.target),
-                    &path_vec,
-                )?
-                .with_resolution_method(reachable.resolution_method);
+                let transition_ctx =
+                    TransitionContext::new(context, reachable.candidates(), &path_vec)?
+                        .with_resolution_method(reachable.resolution_method);
                 let transition_cost = transition.heuristics.transition(transition_ctx);
 
                 let cost = target.emission.saturating_add(transition_cost);

--- a/libs/routers_transition/src/solver/selective_forward.rs
+++ b/libs/routers_transition/src/solver/selective_forward.rs
@@ -1,6 +1,6 @@
 use crate::{
     CollapseError, CollapsedPath, Costing, MatchError, PredicateCache, Reachable, Solver,
-    TransitionContext, Trip,
+    TransitionContext,
     candidate::{CandidateEdge, CandidateId},
     costing::{EmissionStrategy, TransitionStrategy},
     entity::Transition,
@@ -108,7 +108,6 @@ where
                 .into_iter()
                 .filter_map(move |mut reachable| {
                     let path_vec = reachable.path_nodes().collect_vec();
-                    let optimal_path = Trip::new_with_map(context.map, &path_vec);
 
                     let source = context.candidate(&reachable.source)?;
                     let target = context.candidate(&reachable.target)?;
@@ -119,11 +118,7 @@ where
 
                     let transition_ctx = TransitionContext::new(
                         context,
-                        &reachable.source,
-                        &reachable.target,
-                        source.position,
-                        target.position,
-                        optimal_path,
+                        (&reachable.source, &reachable.target),
                         &path_vec,
                         layer_width,
                         reachable.resolution_method,

--- a/libs/routers_transition/src/solver/selective_forward.rs
+++ b/libs/routers_transition/src/solver/selective_forward.rs
@@ -72,7 +72,7 @@ where
     ) -> Vec<(CandidateId, CandidateEdge)>
     where
         Emmis: EmissionStrategy + Send + Sync,
-        Trans: TransitionStrategy<E, M, N> + Send + Sync,
+        Trans: TransitionStrategy<E> + Send + Sync,
         'b: 'a,
     {
         let successors = transition.candidates.next_layer(source);
@@ -117,20 +117,18 @@ where
                     let tl = transition.layers.layers.get(target.location.layer_id)?;
                     let layer_width = Haversine.distance(sl.origin, tl.origin);
 
-                    let transition_cost = transition.heuristics.transition(TransitionContext {
-                        map_path: &path_vec,
-                        requested_resolution_method: reachable.resolution_method,
-
-                        source_candidate: &reachable.source,
-                        target_candidate: &reachable.target,
-                        routing_context: context,
-
-                        source_position: source.position,
-                        target_position: target.position,
-
-                        layer_width,
+                    let transition_ctx = TransitionContext::new(
+                        context,
+                        &reachable.source,
+                        &reachable.target,
+                        source.position,
+                        target.position,
                         optimal_path,
-                    });
+                        &path_vec,
+                        layer_width,
+                        reachable.resolution_method,
+                    )?;
+                    let transition_cost = transition.heuristics.transition(transition_ctx);
 
                     let cost = target.emission.saturating_add(transition_cost);
                     #[cfg(debug_assertions)]
@@ -242,7 +240,7 @@ where
     ) -> Result<CollapsedPath<E>, MatchError>
     where
         Emmis: EmissionStrategy + Send + Sync,
-        Trans: TransitionStrategy<E, M, N> + Send + Sync,
+        Trans: TransitionStrategy<E> + Send + Sync,
     {
         let (start, end) = {
             // Compute cost ~= free

--- a/libs/routers_transition/src/solver/selective_forward.rs
+++ b/libs/routers_transition/src/solver/selective_forward.rs
@@ -14,7 +14,6 @@ use core::cell::RefCell;
 use rustc_hash::FxHashMap;
 use std::{marker::PhantomData, sync::Arc};
 
-use geo::{Distance, Haversine};
 use itertools::Itertools;
 use measure_time::debug_time;
 use pathfinding::{num_traits::Zero, prelude::*};
@@ -108,21 +107,14 @@ where
                 .into_iter()
                 .filter_map(move |mut reachable| {
                     let path_vec = reachable.path_nodes().collect_vec();
-
-                    let source = context.candidate(&reachable.source)?;
                     let target = context.candidate(&reachable.target)?;
-
-                    let sl = transition.layers.layers.get(source.location.layer_id)?;
-                    let tl = transition.layers.layers.get(target.location.layer_id)?;
-                    let layer_width = Haversine.distance(sl.origin, tl.origin);
 
                     let transition_ctx = TransitionContext::new(
                         context,
                         (&reachable.source, &reachable.target),
                         &path_vec,
-                        layer_width,
-                        reachable.resolution_method,
-                    )?;
+                    )?
+                    .with_resolution_method(reachable.resolution_method);
                     let transition_cost = transition.heuristics.transition(transition_ctx);
 
                     let cost = target.emission.saturating_add(transition_cost);

--- a/libs/routers_transition/src/solver/selective_forward.rs
+++ b/libs/routers_transition/src/solver/selective_forward.rs
@@ -109,12 +109,10 @@ where
                     let path_vec = reachable.path_nodes().collect_vec();
                     let target = context.candidate(&reachable.target)?;
 
-                    let transition_ctx = TransitionContext::new(
-                        context,
-                        (&reachable.source, &reachable.target),
-                        &path_vec,
-                    )?
-                    .with_resolution_method(reachable.resolution_method);
+                    let transition_ctx =
+                        TransitionContext::new(context, reachable.candidates(), &path_vec)?
+                            .with_resolution_method(reachable.resolution_method);
+
                     let transition_cost = transition.heuristics.transition(transition_ctx);
 
                     let cost = target.emission.saturating_add(transition_cost);

--- a/libs/routers_transition/src/solver/variant.rs
+++ b/libs/routers_transition/src/solver/variant.rs
@@ -56,7 +56,7 @@ impl<E: Entry, M: Metadata, N: Network<E, M>> Solver<E, M, N> for SolverImpl<E, 
     ) -> Result<CollapsedPath<E>, MatchError>
     where
         Emmis: EmissionStrategy + Send + Sync,
-        Trans: TransitionStrategy<E, M, N> + Send + Sync,
+        Trans: TransitionStrategy<E> + Send + Sync,
     {
         match self {
             SolverImpl::Precompute(precompute) => precompute.solve(transition, runtime),


### PR DESCRIPTION
The transition crate had some transitive dependencies on metadata and network traits due to the structure of the crate itself, which via. some pre-computation and better injection techniques we can omit. This will make future refactoring a lot simpler, since we have less bounds to uphold, so mocking is simpler, etc.