### PR TITLE
feat: Snapshot Diff Viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7322,6 +7322,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
+ "similar",
  "tokio",
  "walkers",
  "wkt",

--- a/benches/snapshots/map_match__LAX_LYNWOOD_coords.snap
+++ b/benches/snapshots/map_match__LAX_LYNWOOD_coords.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d2bc26b6079ab3f3653131a4e785a1901984157d906ec6118347a1bcfc8d606
-size 26654
+oid sha256:f153d6c56a8a3b750747ca280c1d882d11b6bf6625d22a6e0587d07db07fe3b8
+size 22738

--- a/benches/snapshots/map_match__LAX_LYNWOOD_nodes.snap
+++ b/benches/snapshots/map_match__LAX_LYNWOOD_nodes.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6cd49d8b2962810a1aceacc9bfbaa16b5be35a98a7ccd99d94b6b9488b786f54
-size 13263
+oid sha256:991dfae8d96f48ddd73f8d0fd6eaf5d4661912793dab6723ffff13aa67d5f0fd
+size 11326

--- a/benches/snapshots/map_match__VENTURA_HWY_coords.snap
+++ b/benches/snapshots/map_match__VENTURA_HWY_coords.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8e22e03620b43900fa0337e82f62f0e1a47c61c32a73628d6b36db5475a4545
-size 25862
+oid sha256:785bf009ed3d8aa844e7234db62b2878c763a1efbb09477ac8d16ea77d77edb9
+size 23112

--- a/benches/snapshots/map_match__VENTURA_HWY_nodes.snap
+++ b/benches/snapshots/map_match__VENTURA_HWY_nodes.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4cfe4134aabe936fc44c128abdc73fb0d9876ae6ebfe924b546b29a54414841
-size 12172
+oid sha256:27064d236a488532883006c89f362e00565d035f71b41df4673e8a38f8cb9928
+size 10889

--- a/benches/snapshots/map_match__target_benchmark-2.snap
+++ b/benches/snapshots/map_match__target_benchmark-2.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d60e8c6b1b907828531f5257beebbfa0bd6fb9beef6578d270662d69fdfafa91
-size 1288931
+oid sha256:70182a890f9469fe9c91364aa465a498a4edd01630d4ae00a862e962026898f9
+size 1098357

--- a/benches/snapshots/map_match__target_benchmark.snap
+++ b/benches/snapshots/map_match__target_benchmark.snap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56100a4440c9309d0a9bca174c6ed8fe1710ac4af8fa02699d43cfa9e194162c
-size 2490117
+oid sha256:3f373310c1373a30e0b8235baea29f5c48d90a157770c7525ec01f03f4ac7462
+size 2217160

--- a/libs/routers_transition/src/candidate/route.rs
+++ b/libs/routers_transition/src/candidate/route.rs
@@ -61,6 +61,15 @@ where
         let interpolated = {
             let mut elements = Vec::new();
 
+            // Include initial edge source
+            if let Some(first) = matched.first() {
+                if let Some(fat) = network.fatten(&first.edge) {
+                    if let Some(pe) = PathElement::from_edge_source(fat, network) {
+                        elements.push(pe);
+                    }
+                }
+            }
+
             for (i, reachable) in collapsed_path.interpolated.iter().enumerate() {
                 let current = &matched[i];
 
@@ -72,7 +81,7 @@ where
                 if let ResolutionMethod::Standard = reachable.resolution_method {
                     // Add target of current candidate edge
                     if let Some(fat) = network.fatten(&current.edge) {
-                        if let Some(pe) = PathElement::from_fat(fat, network) {
+                        if let Some(pe) = PathElement::from_edge_target(fat, network) {
                             elements.push(pe);
                         }
                     }
@@ -80,10 +89,7 @@ where
                     // Add intermediate edges
                     for edge in &reachable.path {
                         if let Some(fat) = network.fatten(edge) {
-                            if let Some(pe) = PathElement::from_fat(fat, network) {
-                                elements.push(pe);
-                            }
-                            if let Some(pe) = PathElement::from_fat(fat, network) {
+                            if let Some(pe) = PathElement::from_edge_source(fat, network) {
                                 elements.push(pe);
                             }
                         }
@@ -92,7 +98,7 @@ where
                     // Add source of next candidate edge
                     if let Some(next) = matched.get(i + 1) {
                         if let Some(fat) = network.fatten(&next.edge) {
-                            if let Some(pe) = PathElement::from_fat(fat, network) {
+                            if let Some(pe) = PathElement::from_edge_source(fat, network) {
                                 elements.push(pe);
                             }
                         }
@@ -184,9 +190,17 @@ where
         })
     }
 
-    pub fn from_fat(edge: Edge<Node<E>>, network: &impl Network<E, M>) -> Option<Self> {
+    pub fn from_edge_source(edge: Edge<Node<E>>, network: &impl Network<E, M>) -> Option<Self> {
         Some(PathElement {
             point: edge.source.position.0,
+            metadata: network.metadata(edge.id())?.clone(),
+            edge,
+        })
+    }
+
+    pub fn from_edge_target(edge: Edge<Node<E>>, network: &impl Network<E, M>) -> Option<Self> {
+        Some(PathElement {
+            point: edge.target.position.0,
             metadata: network.metadata(edge.id())?.clone(),
             edge,
         })

--- a/libs/routers_viewer/Cargo.toml
+++ b/libs/routers_viewer/Cargo.toml
@@ -39,6 +39,9 @@ pathfinding = "4.14.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+# Snapshot diffing (snapdiff bin)
+similar = "2"
+
 [dev-dependencies]
 routers_fixtures = { workspace = true }
 

--- a/libs/routers_viewer/src/app.rs
+++ b/libs/routers_viewer/src/app.rs
@@ -6,10 +6,7 @@ use egui::{Color32, CursorIcon, SidePanel};
 use geo::Coord;
 use routers_codec::osm::OsmNetwork;
 use routers_fixtures::{LOS_ANGELES, LOS_ANGELES_SAVED, fixture};
-use walkers::{
-    HttpTiles, MapMemory, Plugin, lon_lat,
-    sources::{Mapbox, MapboxStyle, OpenStreetMap},
-};
+use walkers::{MapMemory, Plugin, lon_lat};
 
 use crate::{
     ColourFactory, Component, Context, Input, Map, MatchCache, Matcher, Regular, Results, Stack,
@@ -19,7 +16,6 @@ use crate::{
 
 const FIXTURE_NETWORK: &'static str = "fixture-network";
 const SAVED_FIXTURE_NETWORK: &'static str = "saved-fixture-network";
-const MAPBOX_API_KEY: &'static str = "mapbox-api-key";
 
 pub struct Application {
     network: OsmNetwork,
@@ -33,11 +29,6 @@ impl Application {
         let storage = ctx
             .storage
             .context("was not compiled with storage feature")?;
-
-        let api_key = storage
-            .get_string(MAPBOX_API_KEY)
-            .context("could not find mapbox API key")
-            .ok();
 
         let default_path = fixture!(LOS_ANGELES).clone();
         let pbf_path = storage
@@ -60,18 +51,7 @@ impl Application {
         let network = OsmNetwork::from_pbf_and_save(&pbf_path, &save_path)
             .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-        let egui_ctx = ctx.egui_ctx.clone();
-        let tiles = match api_key {
-            Some(key) => HttpTiles::new(
-                Mapbox {
-                    style: MapboxStyle::Light,
-                    high_resolution: true,
-                    access_token: key,
-                },
-                egui_ctx,
-            ),
-            None => HttpTiles::new(OpenStreetMap, egui_ctx),
-        };
+        let tiles = crate::tile_source(ctx.storage, ctx.egui_ctx.clone());
 
         Ok(Self {
             map: Map::new(tiles, MapMemory::default(), lon_lat(151.12, -33.52)),

--- a/libs/routers_viewer/src/bin/snapdiff/app.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/app.rs
@@ -4,8 +4,7 @@ use std::rc::Rc;
 use egui::{Color32, RichText, ScrollArea, SidePanel};
 use geo::LineString;
 use routers_viewer::{
-    ColourFactory, Component, Context, Map, Regular, SharedMapMemory,
-    plugins::LineStringPlugin,
+    ColourFactory, Component, Context, Map, Regular, SharedMapMemory, plugins::LineStringPlugin,
 };
 use walkers::{MapMemory, Plugin, lon_lat};
 
@@ -152,11 +151,7 @@ impl SnapDiffApp {
         ui.label(RichText::new(text).small());
     }
 
-    fn pane_header(
-        ui: &mut egui::Ui,
-        title: String,
-        entries: &[(Color32, f32, &str)],
-    ) {
+    fn pane_header(ui: &mut egui::Ui, title: String, entries: &[(Color32, f32, &str)]) {
         ui.horizontal(|ui| {
             ui.label(RichText::new(title).strong());
             ui.add_space(12.0);
@@ -206,9 +201,7 @@ impl eframe::App for SnapDiffApp {
                         ui.selectable_label(selected, Self::fixture_row_text(fixture));
 
                     if let Some(error) = &fixture.error {
-                        response = response.on_hover_text(
-                            RichText::new(error).color(Color32::RED),
-                        );
+                        response = response.on_hover_text(RichText::new(error).color(Color32::RED));
                     }
 
                     if response.clicked() {

--- a/libs/routers_viewer/src/bin/snapdiff/app.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/app.rs
@@ -1,0 +1,277 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use egui::{Color32, RichText, ScrollArea, SidePanel};
+use geo::LineString;
+use routers_viewer::{
+    ColourFactory, Component, Context, Map, Regular, SharedMapMemory,
+    plugins::LineStringPlugin,
+};
+use walkers::{MapMemory, Plugin, lon_lat};
+
+use crate::diff::{FixtureDiff, Status};
+
+const BASE_LINE: Color32 = Color32::from_rgba_premultiplied(110, 110, 110, 200);
+const BASE_SPAN: Color32 = Color32::from_rgba_premultiplied(220, 50, 50, 230);
+const HEAD_LINE: Color32 = Color32::from_rgba_premultiplied(0, 100, 255, 200);
+const HEAD_SPAN: Color32 = Color32::from_rgba_premultiplied(255, 140, 0, 230);
+
+pub struct SnapDiffApp {
+    base_label: String,
+    fixtures: Vec<FixtureDiff>,
+    selected: Option<usize>,
+    changed_only: bool,
+    memory: SharedMapMemory,
+    base_map: Map,
+    head_map: Map,
+}
+
+impl SnapDiffApp {
+    pub fn new(
+        ctx: &eframe::CreationContext<'_>,
+        base_label: String,
+        mut fixtures: Vec<FixtureDiff>,
+    ) -> Self {
+        // Severity-first: modified by magnitude, then added/removed, unchanged last.
+        fixtures.sort_by(|a, b| {
+            let rank = |f: &FixtureDiff| match f.status {
+                Status::Modified => 0,
+                Status::Added => 1,
+                Status::Removed => 2,
+                Status::Unchanged => 3,
+            };
+            rank(a)
+                .cmp(&rank(b))
+                .then(b.magnitude_m.total_cmp(&a.magnitude_m))
+                .then(a.name.cmp(&b.name))
+        });
+
+        let tiles = Rc::new(RefCell::new(routers_viewer::tile_source(
+            ctx.storage,
+            ctx.egui_ctx.clone(),
+        )));
+        let memory: SharedMapMemory = Rc::new(RefCell::new(MapMemory::default()));
+
+        let home = lon_lat(151.12, -33.52);
+        let base_map = Map::with_shared(tiles.clone(), memory.clone(), home);
+        let head_map = Map::with_shared(tiles, memory.clone(), home);
+
+        let selected = fixtures.iter().position(|f| f.status.changed());
+
+        let app = Self {
+            base_label,
+            fixtures,
+            selected,
+            changed_only: true,
+            memory,
+            base_map,
+            head_map,
+        };
+
+        if let Some(idx) = app.selected {
+            app.fit_to(idx);
+        }
+
+        app
+    }
+
+    /// Centre both panes on the union bbox of the fixture's base+head lines.
+    fn fit_to(&self, idx: usize) {
+        let Some(fixture) = self.fixtures.get(idx) else {
+            return;
+        };
+
+        let coords = fixture
+            .base
+            .iter()
+            .chain(fixture.head.iter())
+            .flat_map(|l| l.0.iter());
+
+        let mut min = (f64::INFINITY, f64::INFINITY);
+        let mut max = (f64::NEG_INFINITY, f64::NEG_INFINITY);
+        for c in coords {
+            min = (min.0.min(c.x), min.1.min(c.y));
+            max = (max.0.max(c.x), max.1.max(c.y));
+        }
+
+        if !min.0.is_finite() {
+            return;
+        }
+
+        let span = (max.0 - min.0).max(max.1 - min.1).max(1e-4);
+        let zoom = ((360.0 / span).log2() - 0.5).clamp(2.0, 19.0);
+
+        let mut memory = self.memory.borrow_mut();
+        memory.center_at(lon_lat((min.0 + max.0) / 2.0, (min.1 + max.1) / 2.0));
+        let _ = memory.set_zoom(zoom);
+    }
+
+    /// The full line plus a thicker overlay per changed span. Spans are padded
+    /// by one point each side so a single moved point still draws a segment.
+    fn pane_plugins(
+        line: Option<&LineString<f64>>,
+        spans: &[std::ops::Range<usize>],
+        line_colour: Color32,
+        span_colour: Color32,
+    ) -> Vec<Box<dyn Plugin + 'static>> {
+        let Some(line) = line else {
+            return Vec::new();
+        };
+
+        let mut plugins: Vec<Box<dyn Plugin + 'static>> = Vec::new();
+
+        plugins.push(Box::new(
+            LineStringPlugin::new(line.0.clone())
+                .color(line_colour)
+                .stroke_width(3.0),
+        ));
+
+        for span in spans {
+            let start = span.start.saturating_sub(1);
+            let end = (span.end + 1).min(line.0.len());
+            if end - start >= 2 {
+                plugins.push(Box::new(
+                    LineStringPlugin::new(line.0[start..end].to_vec())
+                        .color(span_colour)
+                        .stroke_width(5.0),
+                ));
+            }
+        }
+
+        plugins
+    }
+
+    /// A line-swatch legend entry: a short stroke in the plugin's colour and
+    /// width, followed by what that stroke means on the map.
+    fn legend_entry(ui: &mut egui::Ui, colour: Color32, width: f32, text: &str) {
+        let (rect, _) = ui.allocate_exact_size(egui::vec2(18.0, 12.0), egui::Sense::hover());
+        ui.painter().line_segment(
+            [rect.left_center(), rect.right_center()],
+            egui::Stroke::new(width, colour),
+        );
+        ui.label(RichText::new(text).small());
+    }
+
+    fn pane_header(
+        ui: &mut egui::Ui,
+        title: String,
+        entries: &[(Color32, f32, &str)],
+    ) {
+        ui.horizontal(|ui| {
+            ui.label(RichText::new(title).strong());
+            ui.add_space(12.0);
+            for (colour, width, text) in entries {
+                Self::legend_entry(ui, *colour, *width, text);
+                ui.add_space(8.0);
+            }
+        });
+    }
+
+    fn fixture_row_text(fixture: &FixtureDiff) -> String {
+        let mut text = format!("{}  {}", fixture.status.badge(), fixture.name);
+        if fixture.status == Status::Modified {
+            text.push_str(&format!(
+                "   Δ{:.0}m  +{}/−{}",
+                fixture.magnitude_m, fixture.points_added, fixture.points_removed
+            ));
+        }
+        text
+    }
+}
+
+impl eframe::App for SnapDiffApp {
+    fn update(&mut self, ctx: &egui::Context, _: &mut eframe::Frame) {
+        let context = Context {
+            scheme: ColourFactory::get_scheme(ctx.theme()),
+            layout: Box::new(Regular),
+        };
+
+        SidePanel::left("fixtures").show(ctx, |ui| {
+            ui.heading("Snapshot Diff");
+            ui.label(RichText::new(&self.base_label).monospace().weak());
+            ui.separator();
+
+            ui.checkbox(&mut self.changed_only, "Changed only");
+            ui.separator();
+
+            let mut clicked = None;
+            ScrollArea::vertical().show(ui, |ui| {
+                for (idx, fixture) in self.fixtures.iter().enumerate() {
+                    if self.changed_only && !fixture.status.changed() {
+                        continue;
+                    }
+
+                    let selected = self.selected == Some(idx);
+                    let mut response =
+                        ui.selectable_label(selected, Self::fixture_row_text(fixture));
+
+                    if let Some(error) = &fixture.error {
+                        response = response.on_hover_text(
+                            RichText::new(error).color(Color32::RED),
+                        );
+                    }
+
+                    if response.clicked() {
+                        clicked = Some(idx);
+                    }
+                }
+            });
+
+            if let Some(idx) = clicked {
+                self.selected = Some(idx);
+                self.fit_to(idx);
+            }
+
+            if let Some(fixture) = self.selected.and_then(|i| self.fixtures.get(i))
+                && let Some(error) = &fixture.error
+            {
+                ui.separator();
+                ui.colored_label(Color32::RED, error);
+            }
+        });
+
+        let fixture = self.selected.and_then(|i| self.fixtures.get(i));
+
+        if let Some(fixture) = fixture {
+            self.base_map.set_plugins(Self::pane_plugins(
+                fixture.base.as_ref(),
+                &fixture.base_spans,
+                BASE_LINE,
+                BASE_SPAN,
+            ));
+            self.head_map.set_plugins(Self::pane_plugins(
+                fixture.head.as_ref(),
+                &fixture.head_spans,
+                HEAD_LINE,
+                HEAD_SPAN,
+            ));
+        }
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.columns(2, |columns| {
+                columns[0].vertical(|ui| {
+                    Self::pane_header(
+                        ui,
+                        format!("BASE — {}", self.base_label),
+                        &[
+                            (BASE_LINE, 3.0, "matched path (base)"),
+                            (BASE_SPAN, 5.0, "removed / changed vs head"),
+                        ],
+                    );
+                    self.base_map.draw(&context, ui);
+                });
+                columns[1].vertical(|ui| {
+                    Self::pane_header(
+                        ui,
+                        "HEAD — working tree".to_owned(),
+                        &[
+                            (HEAD_LINE, 3.0, "matched path (head)"),
+                            (HEAD_SPAN, 5.0, "added / changed vs base"),
+                        ],
+                    );
+                    self.head_map.draw(&context, ui);
+                });
+            });
+        });
+    }
+}

--- a/libs/routers_viewer/src/bin/snapdiff/diff.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/diff.rs
@@ -68,8 +68,7 @@ impl FixtureDiff {
         let head_line = head.map(|s| s.line_string);
 
         let magnitude_m = match (&base_line, &head_line) {
-            (Some(b), Some(h)) => magnitude(b, &base_spans, h)
-                .max(magnitude(h, &head_spans, b)),
+            (Some(b), Some(h)) => magnitude(b, &base_spans, h).max(magnitude(h, &head_spans, b)),
             _ => 0.0,
         };
 
@@ -196,7 +195,11 @@ mod tests {
         assert_eq!(d.points_removed, 1);
         assert_eq!(d.points_added, 1);
         // 0.5° of latitude ≈ 55.6 km.
-        assert!((d.magnitude_m - 55_600.0).abs() < 1_000.0, "{}", d.magnitude_m);
+        assert!(
+            (d.magnitude_m - 55_600.0).abs() < 1_000.0,
+            "{}",
+            d.magnitude_m
+        );
     }
 
     #[test]

--- a/libs/routers_viewer/src/bin/snapdiff/diff.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/diff.rs
@@ -1,0 +1,212 @@
+use std::ops::Range;
+
+use geo::{Distance, Haversine, LineString, Point};
+use similar::{Algorithm, DiffOp, capture_diff_slices};
+
+use crate::parse::Snapshot;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    Added,
+    Removed,
+    Modified,
+    Unchanged,
+}
+
+impl Status {
+    pub fn badge(self) -> &'static str {
+        match self {
+            Status::Added => "A",
+            Status::Removed => "R",
+            Status::Modified => "M",
+            Status::Unchanged => "=",
+        }
+    }
+
+    pub fn changed(self) -> bool {
+        self != Status::Unchanged
+    }
+}
+
+pub struct FixtureDiff {
+    /// Display name, e.g. `LAX_LYNWOOD` from `map_match__LAX_LYNWOOD_coords.snap`.
+    pub name: String,
+    pub status: Status,
+    pub base: Option<LineString<f64>>,
+    pub head: Option<LineString<f64>>,
+    /// Point-index ranges in `base` that were removed or replaced.
+    pub base_spans: Vec<Range<usize>>,
+    /// Point-index ranges in `head` that were inserted or replaced.
+    pub head_spans: Vec<Range<usize>>,
+    pub points_removed: usize,
+    pub points_added: usize,
+    /// How far the geometry moved: the largest haversine distance (metres)
+    /// from any changed point to the nearest point on the other side's line.
+    pub magnitude_m: f64,
+    /// A parse failure on either side; the fixture is still listed.
+    pub error: Option<String>,
+}
+
+impl FixtureDiff {
+    pub fn compute(name: String, base: Option<Snapshot>, head: Option<Snapshot>) -> Self {
+        let status = match (&base, &head) {
+            (None, Some(_)) => Status::Added,
+            (Some(_), None) => Status::Removed,
+            (Some(b), Some(h)) if b.lines == h.lines => Status::Unchanged,
+            _ => Status::Modified,
+        };
+
+        let (base_spans, head_spans) = match (&base, &head) {
+            (Some(b), Some(h)) if status == Status::Modified => changed_spans(&b.lines, &h.lines),
+            _ => Default::default(),
+        };
+
+        let points_removed = base_spans.iter().map(Range::len).sum();
+        let points_added = head_spans.iter().map(Range::len).sum();
+
+        let base_line = base.map(|s| s.line_string);
+        let head_line = head.map(|s| s.line_string);
+
+        let magnitude_m = match (&base_line, &head_line) {
+            (Some(b), Some(h)) => magnitude(b, &base_spans, h)
+                .max(magnitude(h, &head_spans, b)),
+            _ => 0.0,
+        };
+
+        Self {
+            name,
+            status,
+            base: base_line,
+            head: head_line,
+            base_spans,
+            head_spans,
+            points_removed,
+            points_added,
+            magnitude_m,
+            error: None,
+        }
+    }
+
+    pub fn parse_error(name: String, error: String) -> Self {
+        Self {
+            name,
+            status: Status::Modified,
+            base: None,
+            head: None,
+            base_spans: Vec::new(),
+            head_spans: Vec::new(),
+            points_removed: 0,
+            points_added: 0,
+            magnitude_m: 0.0,
+            error: Some(error),
+        }
+    }
+}
+
+/// Sequence-diff the coordinate lines of both snapshots, returning the
+/// contiguous changed ranges on each side.
+fn changed_spans(base: &[String], head: &[String]) -> (Vec<Range<usize>>, Vec<Range<usize>>) {
+    let mut base_spans = Vec::new();
+    let mut head_spans = Vec::new();
+
+    for op in capture_diff_slices(Algorithm::Myers, base, head) {
+        match op {
+            DiffOp::Equal { .. } => {}
+            DiffOp::Delete {
+                old_index, old_len, ..
+            } => base_spans.push(old_index..old_index + old_len),
+            DiffOp::Insert {
+                new_index, new_len, ..
+            } => head_spans.push(new_index..new_index + new_len),
+            DiffOp::Replace {
+                old_index,
+                old_len,
+                new_index,
+                new_len,
+            } => {
+                base_spans.push(old_index..old_index + old_len);
+                head_spans.push(new_index..new_index + new_len);
+            }
+        }
+    }
+
+    (base_spans, head_spans)
+}
+
+/// Max over changed points in `from` of the haversine distance to the nearest
+/// point of `to` — a metres-scale answer to "how far did the match move?".
+fn magnitude(from: &LineString<f64>, spans: &[Range<usize>], to: &LineString<f64>) -> f64 {
+    if to.0.is_empty() {
+        return 0.0;
+    }
+
+    spans
+        .iter()
+        .flat_map(|r| &from.0[r.start..r.end.min(from.0.len())])
+        .map(|c| {
+            to.0.iter()
+                .map(|o| Haversine.distance(Point::from(*c), Point::from(*o)))
+                .fold(f64::INFINITY, f64::min)
+        })
+        .fold(0.0, f64::max)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse::parse_coords_snap;
+
+    fn snap(coords: &[(f64, f64)]) -> Snapshot {
+        let body: String = coords
+            .iter()
+            .map(|(lon, lat)| format!("{lon} {lat}\n"))
+            .collect();
+        parse_coords_snap(&format!("---\nsource: x\n---\n{body}")).unwrap()
+    }
+
+    #[test]
+    fn identical_is_unchanged() {
+        let d = FixtureDiff::compute(
+            "t".into(),
+            Some(snap(&[(1.0, 1.0), (2.0, 2.0)])),
+            Some(snap(&[(1.0, 1.0), (2.0, 2.0)])),
+        );
+        assert_eq!(d.status, Status::Unchanged);
+        assert!(d.base_spans.is_empty() && d.head_spans.is_empty());
+    }
+
+    #[test]
+    fn missing_sides_are_added_removed() {
+        let a = FixtureDiff::compute("t".into(), None, Some(snap(&[(1.0, 1.0)])));
+        assert_eq!(a.status, Status::Added);
+        let r = FixtureDiff::compute("t".into(), Some(snap(&[(1.0, 1.0)])), None);
+        assert_eq!(r.status, Status::Removed);
+    }
+
+    #[test]
+    fn single_point_shift_yields_one_span_each_side() {
+        let d = FixtureDiff::compute(
+            "t".into(),
+            Some(snap(&[(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)])),
+            Some(snap(&[(1.0, 1.0), (2.0, 2.5), (3.0, 3.0)])),
+        );
+        assert_eq!(d.status, Status::Modified);
+        assert_eq!(d.base_spans, vec![1..2]);
+        assert_eq!(d.head_spans, vec![1..2]);
+        assert_eq!(d.points_removed, 1);
+        assert_eq!(d.points_added, 1);
+        // 0.5° of latitude ≈ 55.6 km.
+        assert!((d.magnitude_m - 55_600.0).abs() < 1_000.0, "{}", d.magnitude_m);
+    }
+
+    #[test]
+    fn insertion_only_touches_head_spans() {
+        let d = FixtureDiff::compute(
+            "t".into(),
+            Some(snap(&[(1.0, 1.0), (3.0, 3.0)])),
+            Some(snap(&[(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)])),
+        );
+        assert_eq!(d.base_spans, Vec::<Range<usize>>::new());
+        assert_eq!(d.head_spans, vec![1..2]);
+    }
+}

--- a/libs/routers_viewer/src/bin/snapdiff/git.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/git.rs
@@ -40,7 +40,12 @@ pub fn resolve_base(root: &Path, base: &str, merge_base: bool) -> Result<String>
     let verify = |name: &str| {
         git(
             Some(root),
-            &["rev-parse", "--verify", "--quiet", &format!("{name}^{{commit}}")],
+            &[
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                &format!("{name}^{{commit}}"),
+            ],
         )
     };
 

--- a/libs/routers_viewer/src/bin/snapdiff/git.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/git.rs
@@ -33,11 +33,27 @@ pub fn repo_root() -> Result<PathBuf> {
 /// Resolve the base ref to a commit SHA. With `merge_base`, resolves to
 /// `merge-base(<base>, HEAD)` — the fork point, mirroring what a PR diff
 /// shows — rather than the ref's tip.
+///
+/// Falls back to the remote-tracking ref (`origin/<base>`) when the local
+/// branch doesn't exist, as in git worktrees and CI checkouts.
 pub fn resolve_base(root: &Path, base: &str, merge_base: bool) -> Result<String> {
-    let sha = if merge_base {
-        git(Some(root), &["merge-base", base, "HEAD"])?
+    let verify = |name: &str| {
+        git(
+            Some(root),
+            &["rev-parse", "--verify", "--quiet", &format!("{name}^{{commit}}")],
+        )
+    };
+
+    let base = if verify(base).is_ok() {
+        base.to_owned()
     } else {
-        git(Some(root), &["rev-parse", base])?
+        format!("origin/{base}")
+    };
+
+    let sha = if merge_base {
+        git(Some(root), &["merge-base", &base, "HEAD"])?
+    } else {
+        git(Some(root), &["rev-parse", &base])?
     };
     Ok(sha.trim().to_owned())
 }

--- a/libs/routers_viewer/src/bin/snapdiff/git.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/git.rs
@@ -1,0 +1,70 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context as _, Result, bail};
+
+fn git(root: Option<&Path>, args: &[&str]) -> Result<String> {
+    let mut cmd = Command::new("git");
+    if let Some(root) = root {
+        cmd.current_dir(root);
+    }
+
+    let output = cmd
+        .args(args)
+        .output()
+        .context("failed to spawn git — is it installed?")?;
+
+    if !output.status.success() {
+        bail!(
+            "`git {}` failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+pub fn repo_root() -> Result<PathBuf> {
+    let out = git(None, &["rev-parse", "--show-toplevel"])?;
+    Ok(PathBuf::from(out.trim()))
+}
+
+/// Resolve the base ref to a commit SHA. With `merge_base`, resolves to
+/// `merge-base(<base>, HEAD)` — the fork point, mirroring what a PR diff
+/// shows — rather than the ref's tip.
+pub fn resolve_base(root: &Path, base: &str, merge_base: bool) -> Result<String> {
+    let sha = if merge_base {
+        git(Some(root), &["merge-base", base, "HEAD"])?
+    } else {
+        git(Some(root), &["rev-parse", base])?
+    };
+    Ok(sha.trim().to_owned())
+}
+
+/// Relative paths of all files under `dir_rel` at the given commit. Includes
+/// fixtures deleted in the working tree so they can surface as Removed.
+pub fn list_files_at(root: &Path, sha: &str, dir_rel: &str) -> Result<Vec<String>> {
+    let out = git(
+        Some(root),
+        &["ls-tree", "-r", "--name-only", sha, "--", dir_rel],
+    )?;
+    Ok(out.lines().map(str::to_owned).collect())
+}
+
+/// Contents of `path_rel` at the given commit, or `None` if the file did not
+/// exist there (i.e. the fixture is new on this branch).
+///
+/// `--filters` applies checkout filters — the snapshots are git-lfs tracked,
+/// so a plain `git show` would return the LFS pointer, not the payload.
+pub fn read_file_at(root: &Path, sha: &str, path_rel: &str) -> Result<Option<String>> {
+    match git(
+        Some(root),
+        &["cat-file", "--filters", &format!("{sha}:{path_rel}")],
+    ) {
+        Ok(content) => Ok(Some(content)),
+        Err(e) if e.to_string().contains("does not exist") => Ok(None),
+        Err(e) if e.to_string().contains("could not get object info") => Ok(None),
+        Err(e) => Err(e),
+    }
+}

--- a/libs/routers_viewer/src/bin/snapdiff/main.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/main.rs
@@ -182,15 +182,24 @@ mod tests {
         assert!(label.starts_with("main @ "), "{label}");
         assert!(!fixtures.is_empty());
         for f in &fixtures {
-            println!("{} {:?} Δ{:.1}m +{}/−{}", f.name, f.status, f.magnitude_m, f.points_added, f.points_removed);
+            println!(
+                "{} {:?} Δ{:.1}m +{}/−{}",
+                f.name, f.status, f.magnitude_m, f.points_added, f.points_removed
+            );
         }
         assert!(fixtures.iter().all(|f| f.error.is_none()));
     }
 
     #[test]
     fn fixture_names_strip_bench_prefix_and_suffix() {
-        assert_eq!(fixture_name("map_match__LAX_LYNWOOD_coords.snap"), "LAX_LYNWOOD");
-        assert_eq!(fixture_name("map_match__VENTURA_HWY_coords.snap"), "VENTURA_HWY");
+        assert_eq!(
+            fixture_name("map_match__LAX_LYNWOOD_coords.snap"),
+            "LAX_LYNWOOD"
+        );
+        assert_eq!(
+            fixture_name("map_match__VENTURA_HWY_coords.snap"),
+            "VENTURA_HWY"
+        );
         assert_eq!(fixture_name("plain_coords.snap"), "plain");
     }
 }

--- a/libs/routers_viewer/src/bin/snapdiff/main.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/main.rs
@@ -1,0 +1,196 @@
+//! Visual diff for benchmark snapshot changes.
+//!
+//! Compares `benches/snapshots/*_coords.snap` in the working tree against a
+//! base git ref (default: `merge-base(main, HEAD)`) and renders both matched
+//! geometries on side-by-side synced map panes. See `.claude/SPEC.md`.
+//!
+//! ```sh
+//! gh pr checkout 183
+//! cargo run -p routers_viewer --bin snapdiff
+//! cargo run -p routers_viewer --bin snapdiff -- --base origin/main
+//! ```
+
+#![warn(clippy::all, rust_2018_idioms)]
+
+mod app;
+mod diff;
+mod git;
+mod parse;
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result};
+
+use crate::app::SnapDiffApp;
+use crate::diff::FixtureDiff;
+use crate::parse::{Snapshot, parse_coords_snap};
+
+const COORDS_SUFFIX: &str = "_coords.snap";
+const USAGE: &str = "\
+snapdiff — visual diff of benchmark coordinate snapshots against a base ref
+
+USAGE:
+    snapdiff [--base <ref>] [--no-merge-base] [--snapshots <dir>]
+
+OPTIONS:
+    --base <ref>        Base git ref to compare against [default: main]
+    --no-merge-base     Compare against the ref's tip, not merge-base(<ref>, HEAD)
+    --snapshots <dir>   Snapshot dir relative to the repo root [default: benches/snapshots]
+";
+
+struct Args {
+    base: String,
+    merge_base: bool,
+    snapshots: String,
+}
+
+fn parse_args() -> Result<Args> {
+    let mut args = Args {
+        base: "main".to_owned(),
+        merge_base: true,
+        snapshots: "benches/snapshots".to_owned(),
+    };
+
+    let mut iter = std::env::args().skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--base" => args.base = iter.next().context("--base requires a ref")?,
+            "--no-merge-base" => args.merge_base = false,
+            "--snapshots" => args.snapshots = iter.next().context("--snapshots requires a dir")?,
+            "--help" | "-h" => {
+                print!("{USAGE}");
+                std::process::exit(0);
+            }
+            other => anyhow::bail!("unknown argument {other:?}\n\n{USAGE}"),
+        }
+    }
+
+    Ok(args)
+}
+
+/// `map_match__LAX_LYNWOOD_coords.snap` → `LAX_LYNWOOD`.
+fn fixture_name(file: &str) -> String {
+    let stem = file.strip_suffix(COORDS_SUFFIX).unwrap_or(file);
+    match stem.split_once("__") {
+        Some((_, name)) => name.to_owned(),
+        None => stem.to_owned(),
+    }
+}
+
+fn parse_side(name: &str, side: &str, content: Option<String>) -> Result<Option<Snapshot>> {
+    content
+        .map(|c| parse_coords_snap(&c).with_context(|| format!("{name} ({side})")))
+        .transpose()
+}
+
+fn load(args: &Args) -> Result<(String, Vec<FixtureDiff>)> {
+    let root = git::repo_root()?;
+    let sha = git::resolve_base(&root, &args.base, args.merge_base)?;
+    let base_label = format!("{} @ {}", args.base, &sha[..sha.len().min(9)]);
+
+    // Union of fixtures at the base commit and in the working tree, so both
+    // added and removed fixtures are listed.
+    let mut files: BTreeSet<String> = git::list_files_at(&root, &sha, &args.snapshots)?
+        .into_iter()
+        .filter_map(|p| Some(PathBuf::from(p).file_name()?.to_string_lossy().into_owned()))
+        .collect();
+
+    let snapshot_dir = root.join(&args.snapshots);
+    if let Ok(entries) = std::fs::read_dir(&snapshot_dir) {
+        for entry in entries.flatten() {
+            files.insert(entry.file_name().to_string_lossy().into_owned());
+        }
+    }
+
+    files.retain(|f| f.ends_with(COORDS_SUFFIX));
+    anyhow::ensure!(
+        !files.is_empty(),
+        "no *_coords.snap fixtures found under {}",
+        snapshot_dir.display()
+    );
+
+    let fixtures = files
+        .into_iter()
+        .map(|file| {
+            let name = fixture_name(&file);
+            let rel_path = format!("{}/{}", args.snapshots, file);
+
+            let base_txt = git::read_file_at(&root, &sha, &rel_path)?;
+            let head_txt = match std::fs::read_to_string(snapshot_dir.join(&file)) {
+                Ok(content) => Some(content),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+                Err(e) => return Err(e).context(rel_path),
+            };
+
+            let base = parse_side(&name, "base", base_txt);
+            let head = parse_side(&name, "head", head_txt);
+
+            Ok(match (base, head) {
+                (Ok(base), Ok(head)) => FixtureDiff::compute(name, base, head),
+                (Err(e), _) | (_, Err(e)) => FixtureDiff::parse_error(name, format!("{e:#}")),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok((base_label, fixtures))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+
+    let args = parse_args()?;
+    let (base_label, fixtures) = load(&args)?;
+
+    let changed = fixtures.iter().filter(|f| f.status.changed()).count();
+    log::info!(
+        "{} fixtures, {changed} changed (base: {base_label})",
+        fixtures.len()
+    );
+
+    let native_options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default()
+            .with_title("routers — snapshot diff")
+            .with_inner_size([1500.0, 950.0])
+            .with_min_inner_size([600.0, 400.0]),
+        ..Default::default()
+    };
+
+    // Share the "routers" storage namespace so the Mapbox API key configured
+    // in the main viewer applies here too.
+    eframe::run_native(
+        "routers",
+        native_options,
+        Box::new(move |ctx| Ok(Box::new(SnapDiffApp::new(ctx, base_label, fixtures)))),
+    )
+    .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_working_tree_against_main() {
+        let args = Args {
+            base: "main".to_owned(),
+            merge_base: true,
+            snapshots: "benches/snapshots".to_owned(),
+        };
+        let (label, fixtures) = load(&args).unwrap();
+        assert!(label.starts_with("main @ "), "{label}");
+        assert!(!fixtures.is_empty());
+        for f in &fixtures {
+            println!("{} {:?} Δ{:.1}m +{}/−{}", f.name, f.status, f.magnitude_m, f.points_added, f.points_removed);
+        }
+        assert!(fixtures.iter().all(|f| f.error.is_none()));
+    }
+
+    #[test]
+    fn fixture_names_strip_bench_prefix_and_suffix() {
+        assert_eq!(fixture_name("map_match__LAX_LYNWOOD_coords.snap"), "LAX_LYNWOOD");
+        assert_eq!(fixture_name("map_match__VENTURA_HWY_coords.snap"), "VENTURA_HWY");
+        assert_eq!(fixture_name("plain_coords.snap"), "plain");
+    }
+}

--- a/libs/routers_viewer/src/bin/snapdiff/main.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/main.rs
@@ -173,6 +173,16 @@ mod tests {
 
     #[test]
     fn loads_working_tree_against_main() {
+        // CI checkouts are a shallow detached HEAD with no `main` ref (local
+        // or remote-tracking) — this test only makes sense on a dev checkout.
+        let can_resolve = git::repo_root()
+            .and_then(|root| git::resolve_base(&root, "main", true))
+            .is_ok();
+        if !can_resolve {
+            eprintln!("skipping: no resolvable `main`/`origin/main` in this checkout");
+            return;
+        }
+
         let args = Args {
             base: "main".to_owned(),
             merge_base: true,

--- a/libs/routers_viewer/src/bin/snapdiff/parse.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/parse.rs
@@ -80,20 +80,28 @@ mod tests {
 
     #[test]
     fn parses_real_snapshots() {
-        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../benches/snapshots");
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../benches/snapshots");
 
         let mut seen = 0;
         for entry in std::fs::read_dir(dir).unwrap() {
             let path = entry.unwrap().path();
-            if !path.file_name().unwrap().to_string_lossy().ends_with("_coords.snap") {
+            if !path
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .ends_with("_coords.snap")
+            {
                 continue;
             }
             let content = std::fs::read_to_string(&path).unwrap();
             let parsed = parse_coords_snap(&content).unwrap_or_else(|e| {
                 panic!("failed to parse {}: {e}", path.display());
             });
-            assert!(!parsed.line_string.0.is_empty(), "{} was empty", path.display());
+            assert!(
+                !parsed.line_string.0.is_empty(),
+                "{} was empty",
+                path.display()
+            );
             seen += 1;
         }
         assert!(seen > 0, "no *_coords.snap fixtures found");

--- a/libs/routers_viewer/src/bin/snapdiff/parse.rs
+++ b/libs/routers_viewer/src/bin/snapdiff/parse.rs
@@ -1,0 +1,101 @@
+use anyhow::{Result, bail};
+use geo::{Coord, LineString};
+
+/// A parsed `*_coords.snap` insta snapshot.
+pub struct Snapshot {
+    /// Raw payload lines (one `"<lon> <lat>"` token per matched point) —
+    /// these are what the sequence diff runs over, keeping the diff aligned
+    /// with what the snapshot file itself shows.
+    pub lines: Vec<String>,
+    pub line_string: LineString<f64>,
+}
+
+/// Parse an insta snapshot: skip the YAML frontmatter delimited by `---`
+/// lines, then read one `lon lat` coordinate per line.
+pub fn parse_coords_snap(content: &str) -> Result<Snapshot> {
+    let mut lines = content.lines();
+
+    if lines.next().map(str::trim) != Some("---") {
+        bail!("not an insta snapshot: missing `---` frontmatter opener");
+    }
+
+    for line in lines.by_ref() {
+        if line.trim() == "---" {
+            let payload: Vec<String> = lines
+                .filter(|l| !l.trim().is_empty())
+                .map(|l| l.trim().to_owned())
+                .collect();
+
+            let mut coords = Vec::with_capacity(payload.len());
+            for (idx, line) in payload.iter().enumerate() {
+                let mut parts = line.split_whitespace();
+                let (Some(lon), Some(lat)) = (parts.next(), parts.next()) else {
+                    bail!("line {}: expected `lon lat`, got {line:?}", idx + 1);
+                };
+                if parts.next().is_some() {
+                    bail!("line {}: trailing tokens in {line:?}", idx + 1);
+                }
+
+                coords.push(Coord {
+                    x: lon.parse::<f64>()?,
+                    y: lat.parse::<f64>()?,
+                });
+            }
+
+            return Ok(Snapshot {
+                lines: payload,
+                line_string: LineString::new(coords),
+            });
+        }
+    }
+
+    bail!("not an insta snapshot: frontmatter never closed");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_frontmatter_and_coords() {
+        let snap = "---\nsource: benches/map_match.rs\nexpression: coords\n---\n-118.392994 33.950463\n-118.392994 33.950624\n";
+        let parsed = parse_coords_snap(snap).unwrap();
+        assert_eq!(parsed.lines.len(), 2);
+        assert_eq!(parsed.line_string.0[0].x, -118.392994);
+        assert_eq!(parsed.line_string.0[1].y, 33.950624);
+    }
+
+    #[test]
+    fn empty_payload_is_ok() {
+        let parsed = parse_coords_snap("---\nsource: x\n---\n").unwrap();
+        assert!(parsed.lines.is_empty());
+    }
+
+    #[test]
+    fn rejects_malformed_lines() {
+        assert!(parse_coords_snap("---\nsource: x\n---\nnot-a-coord\n").is_err());
+        assert!(parse_coords_snap("---\nsource: x\n---\n-118.0 33.0 5.0\n").is_err());
+        assert!(parse_coords_snap("no frontmatter").is_err());
+    }
+
+    #[test]
+    fn parses_real_snapshots() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../benches/snapshots");
+
+        let mut seen = 0;
+        for entry in std::fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if !path.file_name().unwrap().to_string_lossy().ends_with("_coords.snap") {
+                continue;
+            }
+            let content = std::fs::read_to_string(&path).unwrap();
+            let parsed = parse_coords_snap(&content).unwrap_or_else(|e| {
+                panic!("failed to parse {}: {e}", path.display());
+            });
+            assert!(!parsed.line_string.0.is_empty(), "{} was empty", path.display());
+            seen += 1;
+        }
+        assert!(seen > 0, "no *_coords.snap fixtures found");
+    }
+}

--- a/libs/routers_viewer/src/components/map.rs
+++ b/libs/routers_viewer/src/components/map.rs
@@ -1,23 +1,42 @@
 use std::cell::RefCell;
+use std::rc::Rc;
 
 use egui::Response;
 use walkers::{HttpTiles, MapMemory, Plugin, Position, Projector};
 
 use crate::{Component, Context, plugins::PluginBox};
 
+/// Handles shared between multiple `Map` instances. Two maps constructed over
+/// the same memory render with identical pan/zoom (synced panes); sharing
+/// tiles reuses one download pipeline and cache.
+pub type SharedMapMemory = Rc<RefCell<MapMemory>>;
+pub type SharedTiles = Rc<RefCell<HttpTiles>>;
+
 pub struct Map {
     position: Position,
-    tiles: RefCell<HttpTiles>,
-    map_memory: RefCell<MapMemory>,
+    tiles: SharedTiles,
+    map_memory: SharedMapMemory,
     plugins: RefCell<Vec<Box<dyn Plugin + 'static>>>,
 }
 
 impl Map {
     pub fn new(tiles: HttpTiles, map_memory: MapMemory, position: Position) -> Self {
+        Self::with_shared(
+            Rc::new(RefCell::new(tiles)),
+            Rc::new(RefCell::new(map_memory)),
+            position,
+        )
+    }
+
+    pub fn with_shared(
+        tiles: SharedTiles,
+        map_memory: SharedMapMemory,
+        position: Position,
+    ) -> Self {
         Self {
             position,
-            tiles: RefCell::new(tiles),
-            map_memory: RefCell::new(map_memory),
+            tiles,
+            map_memory,
             plugins: RefCell::new(Vec::new()),
         }
     }

--- a/libs/routers_viewer/src/components/mod.rs
+++ b/libs/routers_viewer/src/components/mod.rs
@@ -6,7 +6,7 @@ mod shell;
 mod stack;
 
 pub use input::Input;
-pub use map::Map;
+pub use map::{Map, SharedMapMemory, SharedTiles};
 pub use matcher::{MatchCache, MatchOutput, Matcher};
 pub use results::Results;
 pub use shell::Shell;

--- a/libs/routers_viewer/src/lib.rs
+++ b/libs/routers_viewer/src/lib.rs
@@ -6,5 +6,5 @@ pub use utils::*;
 
 pub mod app;
 pub mod components;
-pub(crate) mod plugins;
+pub mod plugins;
 pub mod utils;

--- a/libs/routers_viewer/src/plugins/linestring.rs
+++ b/libs/routers_viewer/src/plugins/linestring.rs
@@ -32,21 +32,29 @@ impl Plugin for LineStringPlugin {
     fn run(
         self: Box<Self>,
         ui: &mut egui::Ui,
-        _response: &egui::Response,
+        response: &egui::Response,
         projector: &Projector,
         _map_memory: &MapMemory,
     ) {
-        if self.coords.len() < 2 {
-            return;
-        }
-
-        let pts: Vec<_> = self
+        let mut pts: Vec<_> = self
             .coords
             .iter()
             .map(|c| projector.project(lon_lat(c.x, c.y)).to_pos2())
             .collect();
 
+        // Zero-length segments (consecutive duplicate coordinates are common
+        // in matched output) give the tessellator degenerate normals, which
+        // render as spike artefacts.
+        pts.dedup_by(|a, b| (*a - *b).length_sq() < 0.01);
+
+        if pts.len() < 2 {
+            return;
+        }
+
+        // Clip to the map widget: the ui's clip rect spans the whole panel,
+        // so an unclipped stroke bleeds over neighbouring panes.
         ui.painter()
+            .with_clip_rect(response.rect.intersect(ui.clip_rect()))
             .line(pts, Stroke::new(self.stroke_width, self.color));
     }
 }

--- a/libs/routers_viewer/src/utils/mod.rs
+++ b/libs/routers_viewer/src/utils/mod.rs
@@ -6,8 +6,8 @@ mod state;
 mod tiles;
 
 pub use colour::{BaseColour, ColourFactory, ColourScheme};
-pub use tiles::{MAPBOX_API_KEY, tile_source};
 pub use component::{Component, Context};
 pub use dimensions::{Layout, Regular, Size};
 pub use match_data::{MatchCandidate, MatchData, MatchLayer};
 pub use state::{CursorState, DrawState, ResultState, SelectionState, State};
+pub use tiles::{MAPBOX_API_KEY, tile_source};

--- a/libs/routers_viewer/src/utils/mod.rs
+++ b/libs/routers_viewer/src/utils/mod.rs
@@ -3,8 +3,10 @@ mod component;
 mod dimensions;
 mod match_data;
 mod state;
+mod tiles;
 
 pub use colour::{BaseColour, ColourFactory, ColourScheme};
+pub use tiles::{MAPBOX_API_KEY, tile_source};
 pub use component::{Component, Context};
 pub use dimensions::{Layout, Regular, Size};
 pub use match_data::{MatchCandidate, MatchData, MatchLayer};

--- a/libs/routers_viewer/src/utils/tiles.rs
+++ b/libs/routers_viewer/src/utils/tiles.rs
@@ -1,0 +1,24 @@
+use walkers::{
+    HttpTiles,
+    sources::{Mapbox, MapboxStyle, OpenStreetMap},
+};
+
+pub const MAPBOX_API_KEY: &str = "mapbox-api-key";
+
+/// Build the tile source shared by all viewer binaries: Mapbox when an API key
+/// is present in eframe storage, OpenStreetMap otherwise.
+pub fn tile_source(storage: Option<&dyn eframe::Storage>, egui_ctx: egui::Context) -> HttpTiles {
+    let api_key = storage.and_then(|s| s.get_string(MAPBOX_API_KEY));
+
+    match api_key {
+        Some(key) => HttpTiles::new(
+            Mapbox {
+                style: MapboxStyle::Light,
+                high_resolution: true,
+                access_token: key,
+            },
+            egui_ctx,
+        ),
+        None => HttpTiles::new(OpenStreetMap, egui_ctx),
+    }
+}


### PR DESCRIPTION
Builds using the routers_viewer crate to create a small app (invoked using `cargo run -p routers_viewer --bin snapdiff`) that shows the difference between the HEAD commit (right) and base commit of the branches PR (left). Colour key on the top of the app. All snapshots are listed on the left-hand side, with a summary of the additions (+) and deletions (-), along with the change in distances (haversine) indicated with a delta symbol.

<img width="3482" height="2356" alt="Wednesday 07PM - Zed (routers — route rs)@2x" src="https://github.com/user-attachments/assets/4274a2d6-3b1f-4058-84e0-7e0592b4ac19" />

This revealed a route interpolation bug that resulted from pasting the edge's source instead of it's target, which created routes that looped in on themselves. This was fixed in af70c73bc589694c8d6d72bc28e55fdbaf477be6