### PR TITLE
fix: Walk over Shards instead of Cloning

### DIFF
--- a/libs/routers_shard/src/composite/mod.rs
+++ b/libs/routers_shard/src/composite/mod.rs
@@ -3,13 +3,6 @@
 //! Represents a unified network composed of multiple shards, based on
 //! a particular sharding strategy and cell window.
 //!
-//! The composite is a *view*, not a copy: nodes, metadata, and both
-//! spatial indices are served straight from the member shards (each
-//! [`ShardedNetwork`] already carries them), deduplicated on the fly at
-//! query time. Only the routing graph is merged eagerly — routes and
-//! adjacency must cross shard boundaries, and the path solver needs one
-//! graph to walk. Everything else follows the slim-index rule: don't
-//! store what can be looked up.
 
 mod network;
 
@@ -34,10 +27,6 @@ where
     S: ShardId,
 {
     shards: Vec<Arc<ShardedNetwork<E, M, S>>>,
-
-    /// The merged routing graph — the one eager duplication this type
-    /// keeps (see the module docs). Shared boundary edges collapse here,
-    /// so it is also the authority for edge weights and counts.
     graph: GraphStructure<E>,
 }
 

--- a/libs/routers_shard/src/composite/mod.rs
+++ b/libs/routers_shard/src/composite/mod.rs
@@ -3,6 +3,13 @@
 //! Represents a unified network composed of multiple shards, based on
 //! a particular sharding strategy and cell window.
 //!
+//! The composite is a *view*, not a copy: nodes, metadata, and both
+//! spatial indices are served straight from the member shards (each
+//! [`ShardedNetwork`] already carries them), deduplicated on the fly at
+//! query time. Only the routing graph is merged eagerly — routes and
+//! adjacency must cross shard boundaries, and the path solver needs one
+//! graph to walk. Everything else follows the slim-index rule: don't
+//! store what can be looked up.
 
 mod network;
 
@@ -10,10 +17,9 @@ use core::hash::BuildHasherDefault;
 use std::sync::Arc;
 
 use petgraph::prelude::DiGraphMap;
-use rstar::RTree;
-use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
+use rustc_hash::FxHasher;
 
-use routers_network::{DirectionAwareEdgeId, Entry, Metadata, Node, edge::Weight};
+use routers_network::{DirectionAwareEdgeId, Entry, Metadata, edge::Weight};
 
 use crate::network::ShardedNetwork;
 use crate::strategy::ShardId;
@@ -29,14 +35,10 @@ where
 {
     shards: Vec<Arc<ShardedNetwork<E, M, S>>>,
 
+    /// The merged routing graph — the one eager duplication this type
+    /// keeps (see the module docs). Shared boundary edges collapse here,
+    /// so it is also the authority for edge weights and counts.
     graph: GraphStructure<E>,
-    hash: FxHashMap<E, Node<E>>,
-
-    /// Spatial index over all unique nodes across all shards.
-    index: RTree<Node<E>>,
-
-    /// Spatial index over unique edges, in all shards.
-    index_edge: RTree<crate::network::EdgeRef<E>>,
 }
 
 impl<E, M, S> MultiShardNetwork<E, M, S>
@@ -47,17 +49,11 @@ where
 {
     pub fn new(shards: Vec<Arc<ShardedNetwork<E, M, S>>>) -> Self {
         let mut graph: GraphStructure<E> = GraphStructure::new();
-        let mut hash: FxHashMap<E, Node<E>> = FxHashMap::default();
-
-        let mut nodes_seen: FxHashSet<E> = FxHashSet::default();
-        let mut nodes: Vec<Node<E>> = Vec::new();
 
         for shard in &shards {
-            for (id, node) in &shard.hash {
-                if nodes_seen.insert(*id) {
-                    nodes.push(*node);
-                    hash.insert(*id, *node);
-                }
+            // Nodes first so isolated nodes (no incident edges) still count.
+            for node in shard.graph.nodes() {
+                graph.add_node(node);
             }
 
             for (src, dst, &(weight, edge_id)) in shard.graph.all_edges() {
@@ -65,24 +61,7 @@ where
             }
         }
 
-        let edges: Vec<crate::network::EdgeRef<E>> = graph
-            .all_edges()
-            .filter_map(|(s, t, _)| {
-                let src_pos = hash.get(&s)?.position;
-                let tgt_pos = hash.get(&t)?.position;
-                Some(crate::network::EdgeRef::new(s, t, src_pos, tgt_pos))
-            })
-            .collect();
-        let (index, index_edge) =
-            rayon::join(|| RTree::bulk_load(nodes), || RTree::bulk_load(edges));
-
-        Self {
-            shards,
-            graph,
-            hash,
-            index,
-            index_edge,
-        }
+        Self { shards, graph }
     }
 
     /// Number of shards composed into this network.
@@ -91,7 +70,7 @@ where
     }
 
     pub fn num_nodes(&self) -> usize {
-        self.hash.len()
+        self.graph.node_count()
     }
 
     pub fn num_edges(&self) -> usize {

--- a/libs/routers_shard/src/composite/network.rs
+++ b/libs/routers_shard/src/composite/network.rs
@@ -89,10 +89,6 @@ where
     where
         E: 'a,
     {
-        // Query every shard's slim edge index and dedupe boundary edges
-        // (present in up to two shards) as they stream past — no composite
-        // edge index exists to duplicate them into. The merged graph stays
-        // the authority for weights and direction.
         let mut seen: FxHashSet<(E, E)> = FxHashSet::default();
 
         Box::new(
@@ -129,8 +125,6 @@ where
     where
         E: 'a,
     {
-        // As with edges: shard indices queried in turn, boundary nodes
-        // deduplicated in flight.
         let mut seen: FxHashSet<E> = FxHashSet::default();
 
         Box::new(
@@ -167,9 +161,6 @@ where
     where
         E: 'a,
     {
-        // Nearest within each shard, then nearest of those: correct
-        // because every candidate set is a superset partition of the
-        // composite's nodes.
         self.shards
             .iter()
             .filter_map(|s| s.index.nearest_neighbor(point))

--- a/libs/routers_shard/src/composite/network.rs
+++ b/libs/routers_shard/src/composite/network.rs
@@ -2,6 +2,7 @@ use core::fmt::Debug;
 
 use geo::Point;
 use rstar::AABB;
+use rustc_hash::FxHashSet;
 
 use routers_network::{
     DataPlane, DirectionAwareEdgeId, Discovery, Edge, Entry, Metadata, Node, Route, Scan,
@@ -46,7 +47,7 @@ where
     }
 
     fn point(&self, id: &E) -> Option<Point> {
-        self.hash.get(id).map(|n| n.position)
+        self.node(id).map(|n| n.position)
     }
 
     fn edges_outof<'a>(&'a self, id: E) -> Box<dyn Iterator<Item = GraphEdge<E>> + 'a> {
@@ -67,8 +68,8 @@ where
 
     fn fatten(&self, edge: &Edge<E>) -> Option<Edge<Node<E>>> {
         Some(Edge {
-            source: *self.hash.get(&edge.source)?,
-            target: *self.hash.get(&edge.target)?,
+            source: *self.node(&edge.source)?,
+            target: *self.node(&edge.target)?,
             id: DirectionAwareEdgeId::new(Node::new(Point::new(0., 0.), edge.id.index())),
             weight: edge.weight,
         })
@@ -88,12 +89,23 @@ where
     where
         E: 'a,
     {
+        // Query every shard's slim edge index and dedupe boundary edges
+        // (present in up to two shards) as they stream past — no composite
+        // edge index exists to duplicate them into. The merged graph stays
+        // the authority for weights and direction.
+        let mut seen: FxHashSet<(E, E)> = FxHashSet::default();
+
         Box::new(
-            self.index_edge
-                .locate_in_envelope_intersecting(&aabb)
+            self.shards
+                .iter()
+                .flat_map(move |shard| shard.index_edge.locate_in_envelope_intersecting(&aabb))
                 .filter_map(move |&EdgeRef { source, target, .. }| {
-                    let source = *self.hash.get(&source)?;
-                    let target = *self.hash.get(&target)?;
+                    if !seen.insert((source, target)) {
+                        return None;
+                    }
+
+                    let source = *self.node(&source)?;
+                    let target = *self.node(&target)?;
 
                     let &(weight, id) = self.graph.edge_weight(*source, *target)?;
 
@@ -117,11 +129,20 @@ where
     where
         E: 'a,
     {
-        Box::new(self.index.locate_in_envelope(&aabb))
+        // As with edges: shard indices queried in turn, boundary nodes
+        // deduplicated in flight.
+        let mut seen: FxHashSet<E> = FxHashSet::default();
+
+        Box::new(
+            self.shards
+                .iter()
+                .flat_map(move |shard| shard.index.locate_in_envelope(&aabb))
+                .filter(move |node| seen.insert(node.id)),
+        )
     }
 
     fn node(&self, id: &E) -> Option<&Node<E>> {
-        self.hash.get(id)
+        self.shards.iter().find_map(|s| s.hash.get(id))
     }
 
     fn edge(&self, source: &E, target: &E) -> Option<Edge<E>> {
@@ -146,7 +167,18 @@ where
     where
         E: 'a,
     {
-        self.index.nearest_neighbor(point)
+        // Nearest within each shard, then nearest of those: correct
+        // because every candidate set is a superset partition of the
+        // composite's nodes.
+        self.shards
+            .iter()
+            .filter_map(|s| s.index.nearest_neighbor(point))
+            .min_by(|a, b| {
+                let d2 = |n: &Node<E>| {
+                    (n.position.x() - point.x()).powi(2) + (n.position.y() - point.y()).powi(2)
+                };
+                d2(a).total_cmp(&d2(b))
+            })
     }
 }
 
@@ -164,10 +196,7 @@ where
             |(_, _, w)| w.0,
             |_| 0 as Weight,
         )?;
-        let route = path
-            .iter()
-            .filter_map(|v| self.hash.get(v).copied())
-            .collect();
+        let route = path.iter().filter_map(|v| self.node(v).copied()).collect();
         Some((cost, route))
     }
 }


### PR DESCRIPTION
The shard structure would originally clone the data between the shards which made it impossible for us to future-extend the infrastructure in order to add and remove shards dynamically, it also meant we'd clone the data at least once, which had really high memory usage. 

In a deployed environment, the performance loss of iterating over each is significantly smaller than a 2x memory reduction; so I decided it makes more sense to just walk over the subshards to obtain relevant data rather than cloning on setup.