### PR TITLE
fix: Streaming Matcher Worker Pooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6578,6 +6578,7 @@ dependencies = [
  "routers_shard",
  "routers_transition",
  "serde",
+ "stream-partition",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7650,6 +7651,16 @@ checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
 dependencies = [
  "approx 0.5.1",
  "num-traits",
+]
+
+[[package]]
+name = "stream-partition"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4707315829201ca2d8d6a7c6c888b217ab222a644b5c06bef15af3ab93ace7e"
+dependencies = [
+ "futures",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/infrastructure/chart/templates/historian.yaml
+++ b/infrastructure/chart/templates/historian.yaml
@@ -31,6 +31,17 @@ spec:
               value: "events.raw.>"
             - name: RUST_LOG
               value: {{ .Values.historian.rustLog | quote }}
+            {{- range $name, $value := .Values.historian.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.infra.otlp.url }}
+            # Spans exported here become Prometheus series via the
+            # collector's spanmetrics pipeline; unset, telemetry degrades
+            # to plain structured logs.
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.infra.otlp.url | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.historian.resources | nindent 12 }}
 {{- end }}

--- a/infrastructure/chart/templates/matchers.yaml
+++ b/infrastructure/chart/templates/matchers.yaml
@@ -40,6 +40,10 @@ spec:
               value: "events.matched.{{ $shard }}"
             - name: RUST_LOG
               value: {{ $.Values.matcher.rustLog | quote }}
+            {{- range $name, $value := $.Values.matcher.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
             {{- if $.Values.infra.otlp.url }}
             # Spans exported here become Prometheus series via the
             # collector's spanmetrics pipeline; unset, telemetry degrades

--- a/infrastructure/chart/templates/orchestrators.yaml
+++ b/infrastructure/chart/templates/orchestrators.yaml
@@ -38,6 +38,10 @@ spec:
               value: "events.matched.{{ $shard }}"
             - name: RUST_LOG
               value: {{ $.Values.orchestrator.rustLog | quote }}
+            {{- range $name, $value := $.Values.orchestrator.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
             {{- if $.Values.infra.otlp.url }}
             # Spans exported here become Prometheus series via the
             # collector's spanmetrics pipeline; unset, telemetry degrades

--- a/infrastructure/chart/values-local-dev.yaml
+++ b/infrastructure/chart/values-local-dev.yaml
@@ -24,3 +24,6 @@ matcher:
 
 orchestrator:
   rustLog: info
+
+historian:
+  rustLog: info

--- a/infrastructure/chart/values.yaml
+++ b/infrastructure/chart/values.yaml
@@ -45,6 +45,9 @@ shardCache:
   pvc:
     claimName: routers-shards
 
+# Each service's `env` map is rendered verbatim into the container: keys are
+# the binaries' clap-derived env names (see `--help` of each bin), so a knob
+# added to a binary needs no template change to become deployable.
 matcher:
   image:
     repository: routers-matcher
@@ -52,17 +55,29 @@ matcher:
     pullPolicy: Never
   rustLog: debug
   env:
-    stateful: "1"
-    profileSampleN: "50"
-    concurrency: "4"
-    frontierK: "4"
-    costCeiling: "2000000"
+    # Worker tasks per matcher; vehicles are hash-pinned so per-vehicle
+    # ordering holds regardless of the count. Solves are CPU-bound, so this
+    # is sized to actually cover the node's cores under load.
+    WORKERS: "10"
+    # Deadline shedding: contexts older than this are dropped unmatched.
+    # Bounds commit staleness so a transient backlog cannot break the
+    # orchestrator's resume overlap and snowball into a restart storm.
+    SHED_AFTER: "1s"
+    # Full 50m reach for anchoring (35m dropped ~22% of points unanchored),
+    # but each layer keeps only the k best candidates by emission: boundary
+    # weighing is O(k²), so solve cost stays flat through dense grids
+    # instead of scaling with road density.
+    MAX_CANDIDATES: "16"
   resources:
     requests:
-      cpu: 500m
+      cpu: 1000m
       memory: 256Mi
+    # No CPU limit: matching is CPU-bound (per-boundary weighing fans across
+    # rayon), and a CFS cap freezes every worker and the rayon pool together
+    # in 100ms throttle windows — the same stall spiral the valkey nano
+    # preset caused. The request still guarantees scheduling; memory still
+    # bounds the pod.
     limits:
-      cpu: 4000m
       memory: 3072Mi
 
 orchestrator:
@@ -72,16 +87,35 @@ orchestrator:
     pullPolicy: Never
   rustLog: info
   env:
-    parallelism: "1"
-    historyMaxPoints: "5"
-    historyMaxAgeSecs: "300"
-    store: memory
+    # Concurrent workers per orchestrator. Each vehicle is pinned to one, so
+    # events and result-commits stay ordered per vehicle while the per-event
+    # Redis context fetch — the throughput bound — overlaps across vehicles.
+    # Sized against the fetch's stall tail (~5% of calls stall 50–100ms under
+    # load, lifting the mean to ~5ms): ceiling ≈ workers / mean-fetch, so 32
+    # holds ~6k evt/s per shard even with the tail unfixed. Workers are
+    # cheap — one Redis connection and a map shard each.
+    WORKERS: "32"
+    # Redis history entries fetched per event — also the resume overlap
+    # horizon: a vehicle may go this many events without a committed result
+    # before reconcile loses the overlap and restarts it. Sized to the
+    # historian's full retention so shed bursts and matcher turbulence stay
+    # recoverable; reconcile trims the trip to the true overlap either way,
+    # so resumes stay cheap.
+    CONTEXT_WINDOW: "25"
+    # Per-event matcher work budget: contexts carrying more fresh points
+    # than this are restarted over the newest points only. Keeps both the
+    # resume AND restart paths ~O(cap) boundaries, so there is no expensive
+    # mode for the system to collapse into under turbulence.
+    FRESH_CAP: "8"
   resources:
     requests:
       cpu: 500m
       memory: 256Mi
     limits:
-      memory: 512Mi
+      # Headroom for the per-vehicle trip map and the worker channels —
+      # trips accumulate over a run, and memory-limit reclaim stalls would
+      # masquerade as latency.
+      memory: 1024Mi
 
 historian:
   enabled: true
@@ -92,9 +126,16 @@ historian:
   replicas: 3
   rustLog: debug
   env:
-    eventsConsumer: historian
-    valkeyBatch: "64"
-    valkeyBatchTimeoutMs: "2"
+    # Events retained per vehicle stream (XADD MAXLEN).
+    HISTORY: "25"
+    # Redis batch size and flush deadline for archiving. Kept small on
+    # purpose: valkey is single-threaded, and a 1024-command pipeline
+    # monopolises its event loop for tens of ms — every orchestrator
+    # context fetch that arrives meanwhile queues behind it (measured as a
+    # 50–100ms tail on reads during flush windows). Smaller, more frequent
+    # batches trade a little XADD efficiency for smooth read latency.
+    BATCH_SIZE: "128"
+    BATCH_TIMEOUT: "20ms"
   resources:
     requests:
       cpu: 500m

--- a/infrastructure/chart/values.yaml
+++ b/infrastructure/chart/values.yaml
@@ -59,15 +59,6 @@ matcher:
     # ordering holds regardless of the count. Solves are CPU-bound, so this
     # is sized to actually cover the node's cores under load.
     WORKERS: "10"
-    # Deadline shedding: contexts older than this are dropped unmatched.
-    # Bounds commit staleness so a transient backlog cannot break the
-    # orchestrator's resume overlap and snowball into a restart storm.
-    SHED_AFTER: "1s"
-    # Full 50m reach for anchoring (35m dropped ~22% of points unanchored),
-    # but each layer keeps only the k best candidates by emission: boundary
-    # weighing is O(k²), so solve cost stays flat through dense grids
-    # instead of scaling with road density.
-    MAX_CANDIDATES: "16"
   resources:
     requests:
       cpu: 1000m

--- a/infrastructure/dev/Justfile
+++ b/infrastructure/dev/Justfile
@@ -9,7 +9,7 @@ bringup: repos
         --set-json 'promExporter.podMonitor.merge={"spec":{"podMetricsEndpoints":[{"port":"prom-metrics","interval":"1s"}]}}'
     helm upgrade --install valkey oci://registry-1.docker.io/bitnamicharts/valkey \
         -n {{ namespace }} --create-namespace \
-        --set auth.enabled=false
+        -f valkey-values.yaml
     helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
         -n {{ namespace }} --create-namespace \
         -f kube-prometheus-stack-values.yaml
@@ -65,7 +65,7 @@ patch: repos
         --set-json 'promExporter.podMonitor.merge={"spec":{"podMetricsEndpoints":[{"port":"prom-metrics","interval":"1s"}]}}'
     helm upgrade valkey oci://registry-1.docker.io/bitnamicharts/valkey \
         -n {{ namespace }} \
-        --set auth.enabled=false
+        -f valkey-values.yaml
     helm upgrade kube-prometheus-stack prometheus-community/kube-prometheus-stack \
         -n {{ namespace }} \
         -f kube-prometheus-stack-values.yaml

--- a/infrastructure/dev/otel-collector-values.yaml
+++ b/infrastructure/dev/otel-collector-values.yaml
@@ -70,8 +70,15 @@ config:
       histogram:
         unit: ms
         explicit:
+          # The sub-second buckets resolve compute spans; the tail out to
+          # 120s exists for the wait spans (`queue_wait`, `worker_wait`,
+          # `event_to_match`) — a backlogged run parks messages for tens of
+          # seconds, and a 5s cap censors exactly the quantiles that prove it.
           buckets:
-            [1ms, 2ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 5s]
+            [
+              1ms, 2ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms,
+              1s, 2500ms, 5s, 10s, 30s, 60s, 120s,
+            ]
       # Span attributes promoted to metric labels. Everything else on a span
       # stays out of Prometheus, so attribute freely in the services.
       dimensions:

--- a/infrastructure/dev/valkey-values.yaml
+++ b/infrastructure/dev/valkey-values.yaml
@@ -1,0 +1,27 @@
+# Valkey backs the pipeline's per-vehicle history: every raw event costs one
+# XREVRANGE on the orchestrator hot path, so valkey's latency is pipeline
+# latency. The bitnami chart's default `resourcesPreset: nano` caps the
+# primary at cpu=150m — under load CFS then freezes the (single-threaded)
+# event loop in ~100ms throttle windows and every in-flight command queues
+# behind the freeze: measured as a 50–100ms stall tail on reads (~14% of
+# calls at 6.8k reads/s) while actual execution stayed at ~7µs/call.
+# No CPU limit: valkey burns what it needs (~10–40% of a core at 10k evt/s);
+# the memory limit still bounds the pod.
+auth:
+  enabled: false
+
+primary:
+  resources:
+    requests:
+      cpu: 500m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
+replica:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      memory: 1Gi

--- a/libs/routers_realtime/Cargo.toml
+++ b/libs/routers_realtime/Cargo.toml
@@ -50,6 +50,7 @@ postcard = { workspace = true }
 async-nats = "0.38.0"
 redis = { version = "0.29", features = ["tokio-comp", "streams"] }
 polars = { version = "0.46", default-features = false, features = ["lazy", "csv", "strings", "dtype-full"] }
+stream-partition = "0.1.0"
 
 [lints]
 workspace = true

--- a/libs/routers_realtime/bin/historian.rs
+++ b/libs/routers_realtime/bin/historian.rs
@@ -5,6 +5,7 @@ use futures::StreamExt;
 use log::{error, info};
 use std::time::Duration;
 use tokio::time::{Instant, timeout_at};
+use tracing::{Instrument, info_span};
 use url::Url;
 
 use routers_realtime::{
@@ -44,7 +45,11 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env_logger::init();
+    // Spans, not just logs: the historian is the third consumer of the raw
+    // stream, so its `queue_wait` series doubles as a measure of the offered
+    // event rate, and `archive` covers the Redis write path the
+    // orchestrator's `context_fetch` later reads from.
+    let _telemetry = routers_realtime::telemetry::init("routers-historian");
     let args = Args::parse();
 
     info!("historian starting: {:?}", args);
@@ -83,7 +88,11 @@ async fn main() -> anyhow::Result<()> {
             continue;
         }
 
-        if let Err(e) = kv.write_many(&batch, args.history).await {
+        if let Err(e) = kv
+            .write_many(&batch, args.history)
+            .instrument(info_span!("archive", events = batch.len()))
+            .await
+        {
             error!("write error: {e}");
         } else {
             info!("archived {} event(s)", batch.len());

--- a/libs/routers_realtime/bin/historian.rs
+++ b/libs/routers_realtime/bin/historian.rs
@@ -45,10 +45,6 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Spans, not just logs: the historian is the third consumer of the raw
-    // stream, so its `queue_wait` series doubles as a measure of the offered
-    // event rate, and `archive` covers the Redis write path the
-    // orchestrator's `context_fetch` later reads from.
     let _telemetry = routers_realtime::telemetry::init("routers-historian");
     let args = Args::parse();
 

--- a/libs/routers_realtime/bin/matcher.rs
+++ b/libs/routers_realtime/bin/matcher.rs
@@ -1,18 +1,23 @@
-use std::path::PathBuf;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
+use std::{hash::DefaultHasher, path::PathBuf};
 
 use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId};
-use routers_network::Metadata;
+use routers_network::{Metadata, Network};
 use routers_realtime::{
     bus::{NATSSink, NATSStream},
     event::{MatchContext, MatchResult},
 };
-use routers_shard::{FileFetcher, Geohash, ShardLoader};
+use routers_shard::{FileFetcher, Geohash, ShardLoader, ShardedNetwork};
 use routers_transition::{
-    Continuation, MatchError, Matcher, candidate::RoutedPath, costing::CostingStrategies,
-    layer::generation::StandardGenerator, primitives::PredicateCache, weigh::AllCompute,
+    Continuation, MatchError, Matcher,
+    candidate::RoutedPath,
+    costing::{CostingStrategies, DefaultEmissionCost, DefaultTransitionCost},
+    layer::generation::StandardGenerator,
+    primitives::PredicateCache,
+    weigh::AllCompute,
 };
 
 use anyhow::Context;
@@ -20,6 +25,7 @@ use async_nats::{ConnectOptions, ServerAddr};
 use clap::Parser;
 use futures::{SinkExt, StreamExt};
 use log::{debug, error, info, warn};
+use tokio::sync::mpsc;
 use tracing::{Instrument, field, info_span};
 use url::Url;
 
@@ -42,6 +48,10 @@ struct Args {
     #[arg(short, env, long)]
     shard: Geohash,
 
+    /// The number of worker threads to use for matching
+    #[arg(short, env, long, default_value = "5")]
+    workers: usize,
+
     // The inbound NATS subject to subscribe to, for matching events.
     #[arg(short, env, long)]
     inbound_subject: String,
@@ -53,10 +63,38 @@ struct Args {
     /// The search distance to use for matching
     #[arg(long, env)]
     search_distance: Option<f64>,
+
+    /// The most candidates a layer may hold (the k cheapest by emission).
+    /// Bounds boundary weighing at k² pairs regardless of road density, so
+    /// solve cost stays flat through dense grids without shrinking the
+    /// search radius (which costs anchoring instead).
+    #[arg(long, env)]
+    max_candidates: Option<usize>,
+
+    /// Contexts older than this (wire send → pickup) are shed unmatched.
+    /// A stale context is worthless: matching it commits an outdated trip,
+    /// and the vehicle's next context is self-contained (window + trellis),
+    /// so nothing is lost by skipping — while matching it anyway is what
+    /// turns a transient backlog into a restart storm (stale commits break
+    /// the orchestrator's resume overlap, and restarts cost ~3× a resume).
+    /// In steady state nothing is old enough to shed; under overload the
+    /// queue drains at drop speed instead of compounding.
+    #[arg(long, env, value_parser = humantime::parse_duration, default_value = "1s")]
+    shed_after: Duration,
 }
 
 type E = OsmEntryId;
 type M = OsmEdgeMetadata;
+type Match<'a> = Matcher<
+    'a,
+    DefaultEmissionCost,
+    DefaultTransitionCost,
+    StandardGenerator<'a, E, M, DefaultEmissionCost>,
+    AllCompute<E, M, ShardedNetwork<E, M, Geohash>>,
+    E,
+    M,
+    ShardedNetwork<E, M, Geohash>,
+>;
 
 /// How a match attempt ended, as the `outcome`/`severity` labels the
 /// collector turns into the success-ratio series. Nominal failures are the
@@ -95,134 +133,215 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("could not connect to NATS")?;
 
-    let mut sink =
-        NATSSink::<MatchResult<E, M>>::new(client.clone(), move |_| args.outbound_subject.clone());
-
     let subscriber = client
         .subscribe(args.inbound_subject)
         .await
         .context("could not subscribe to NATS subject")?;
     let mut source = NATSStream::<MatchContext<E>>::new(subscriber);
 
-    // One long-lived matcher: the predicate cache and generator index stay
-    // warm across every vehicle and event.
-    let cache = Arc::new(PredicateCache::default());
-    let runtime = OsmEdgeMetadata::runtime(None);
-    let costing = CostingStrategies::default();
+    // One long-lived matcher, shared by every worker: the predicate cache
+    // and generator index stay warm across every vehicle and event. The
+    // matcher and its dependencies live for the life of the process, so we
+    // leak them once to get the `'static` borrows `tokio::spawn` requires.
+    let network: &'static Arc<ShardedNetwork<E, M, Geohash>> = Box::leak(Box::new(network));
+    let net: &'static ShardedNetwork<E, M, Geohash> = network;
+    let runtime: &'static _ = Box::leak(Box::new(OsmEdgeMetadata::runtime(None)));
+    let costing: &'static CostingStrategies<_, _, E> =
+        Box::leak(Box::new(CostingStrategies::default()));
 
-    let mut generator = StandardGenerator::new(network.as_ref(), &costing.emission);
+    let cache = Arc::new(PredicateCache::default());
+
+    let mut generator = StandardGenerator::new(net, &costing.emission);
     if let Some(distance) = args.search_distance {
         generator = generator.with_search_distance(distance);
     }
+    if let Some(k) = args.max_candidates {
+        generator = generator.with_max_candidates(k);
+    }
 
     let weigher = AllCompute::default().use_cache(cache);
-    let matcher = Matcher::new(network.as_ref(), &costing, generator, weigher, &runtime);
+    let matcher: &'static Match<'static> = Box::leak(Box::new(Matcher::new(
+        net, costing, generator, weigher, runtime,
+    )));
 
-    while let Some(MatchContext {
-        vehicle_id,
-        continuation,
-    }) = source.next().await
-    {
-        // One span per event: `outcome`/`severity` become the success-ratio
-        // labels, `continuation` splits every series by resume vs restart.
-        let span = info_span!(
-            "match_event",
-            outcome = field::Empty,
-            severity = field::Empty,
-            continuation = field::Empty,
-        );
+    let txs: Vec<_> = (0..args.workers)
+        .map(|_| {
+            // Stamped on dispatch so the channel residency below is
+            // measurable: `queue_wait` ends when the NATS stream yields, and
+            // `match_event` starts in the worker — this covers the hop
+            // between them, where a busy worker queues its vehicles. The
+            // second stamp is the context's wire send time (captured at
+            // dispatch, while the message is the stream's newest yield),
+            // which is what the shed deadline is measured against.
+            let (tx, mut rx) = mpsc::channel::<(
+                web_time::SystemTime,
+                Option<web_time::SystemTime>,
+                MatchContext<E>,
+            )>(1024);
 
-        async {
-            let span = tracing::Span::current();
+            // Each worker publishes through its own sink; the underlying
+            // NATS client is shared and cheap to clone.
+            let subject = args.outbound_subject.clone();
+            let mut sink =
+                NATSSink::<MatchResult<E, M>>::new(client.clone(), move |_| subject.clone());
 
-            // The orchestrator reconciled but cannot generate a layer, so both
-            // cases land here with points still to push: `Resume` hands back the
-            // trellis from the prior solve, `Restart` means no prior solve
-            // stands (first point, or the history diverged) and we begin anew.
-            let (mut trip, fresh) = match continuation {
-                Continuation::Resume { trip, fresh } => {
-                    span.record("continuation", "resume");
-                    debug!(
-                        "{vehicle_id}: resuming {} committed layer(s), {} fresh point(s)",
-                        trip.layers(),
-                        fresh.len()
+            let shed_after = args.shed_after;
+            tokio::spawn(async move {
+                while let Some((queued_at, sent_at, msg)) = rx.recv().await {
+                    routers_realtime::bus::span_between(
+                        "worker_wait",
+                        queued_at,
+                        routers_realtime::bus::wallclock(),
                     );
-                    (trip, fresh)
-                }
-                Continuation::Restart { fresh } => {
-                    span.record("continuation", "restart");
-                    debug!("{vehicle_id}: restarting over {} point(s)", fresh.len());
-                    (matcher.begin(), fresh)
-                }
-            };
 
-            info_span!("push", points = fresh.len()).in_scope(|| {
-                for point in fresh {
-                    match matcher.push(&mut trip, point) {
-                        Ok(_) => {}
-                        Err(MatchError::Unanchored(err)) => {
-                            // Zero-duration marker: the collector counts it.
-                            info_span!("point_drop", reason = "unanchored").in_scope(|| {});
-                            debug!("{vehicle_id}: dropped off-network point ({err})");
-                        }
-                        Err(err) => {
-                            info_span!("point_drop", reason = "push_error").in_scope(|| {});
-                            error!("{vehicle_id}: could not push point: {err}");
+                    // Past its deadline: shed rather than match (see
+                    // `--shed-after`). Zero-duration marker so the collector
+                    // counts the sheds.
+                    if let Some(sent_at) = sent_at
+                        && routers_realtime::bus::wallclock()
+                            .duration_since(sent_at)
+                            .is_ok_and(|age| age > shed_after)
+                    {
+                        info_span!("match_shed", reason = "stale").in_scope(|| {});
+                        debug!("{}: shed stale context", msg.vehicle_id);
+                        continue;
+                    }
+
+                    // One span per event: `outcome`/`severity` become the
+                    // success-ratio labels, `continuation` splits every
+                    // series by resume vs restart. `match_event` records
+                    // into it via `Span::current()`.
+                    let span = info_span!(
+                        "match_event",
+                        outcome = field::Empty,
+                        severity = field::Empty,
+                        continuation = field::Empty,
+                    );
+
+                    async {
+                        if let Some(result) = match_event(matcher, net, msg).await {
+                            sink.send(result)
+                                .instrument(info_span!("publish_result"))
+                                .await
+                                .context("could not emit result to sink")
+                                .ok();
                         }
                     }
+                    .instrument(span)
+                    .await;
                 }
             });
 
-            // Only a trip with at least one anchored layer is solvable; every
-            // fresh point rejecting (all off-network) leaves nothing to do.
-            if trip.is_empty() {
-                span.record("outcome", "no_anchor");
-                span.record("severity", "nominal");
-                warn!("{vehicle_id}: no anchored layers to solve");
-                return Ok(());
-            }
+            tx
+        })
+        .collect();
 
-            // A snapshot is only defined over a solved trip: solve first, and
-            // let a failure (e.g. a disconnected boundary) surface here, before
-            // any collapse is attempted.
-            if let Err(err) = info_span!("solve").in_scope(|| matcher.solve(&mut trip).map(|_| ()))
-            {
-                let (outcome, severity) = classify(&err);
-                span.record("outcome", outcome);
-                span.record("severity", severity);
-                error!("{vehicle_id}: unable to solve trip: {err}");
-                return Ok(());
-            }
+    while let Some(msg) = source.next().await {
+        // Only valid while this message is the stream's newest yield.
+        let sent_at = routers_realtime::bus::last_sent_at();
 
-            match info_span!("snapshot").in_scope(|| matcher.snapshot(&mut trip)) {
-                Ok(solution) => {
-                    let path = RoutedPath::new(solution, network.as_ref());
-                    span.record("outcome", "success");
-                    span.record("severity", "ok");
+        let mut h = DefaultHasher::new();
+        msg.vehicle_id.hash(&mut h);
 
-                    sink.send(MatchResult {
-                        path,
-                        vehicle_id,
-                        trip,
-                    })
-                    .instrument(info_span!("publish_result"))
-                    .await
-                    .context("could not emit result to sink")
-                }
-                Err(err) => {
-                    let (outcome, severity) = classify(&err);
-                    span.record("outcome", outcome);
-                    span.record("severity", severity);
-                    error!("{vehicle_id}: unable to match payload: {err}");
-                    Ok(())
-                }
-            }
-        }
-        .instrument(span)
-        .await?;
+        txs[h.finish() as usize % args.workers]
+            .send((routers_realtime::bus::wallclock(), sent_at, msg))
+            .await
+            .unwrap();
     }
+
+    error!("source terminated");
 
     loop {
         sleep(Duration::from_secs(1));
+    }
+}
+
+async fn match_event<'a>(
+    matcher: &Match<'a>,
+    network: &impl Network<E, M>,
+    MatchContext {
+        vehicle_id,
+        continuation,
+    }: MatchContext<E>,
+) -> Option<MatchResult<E, M>> {
+    let span = tracing::Span::current();
+
+    // The orchestrator reconciled but cannot generate a layer, so both
+    // cases land here with points still to push: `Resume` hands back the
+    // trellis from the prior solve, `Restart` means no prior solve
+    // stands (first point, or the history diverged) and we begin anew.
+    let (mut trip, fresh) = match continuation {
+        Continuation::Resume { trip, fresh } => {
+            span.record("continuation", "resume");
+            debug!(
+                "{vehicle_id}: resuming {} committed layer(s), {} fresh point(s)",
+                trip.layers(),
+                fresh.len()
+            );
+            (trip, fresh)
+        }
+        Continuation::Restart { fresh } => {
+            span.record("continuation", "restart");
+            debug!("{vehicle_id}: restarting over {} point(s)", fresh.len());
+            (matcher.begin(), fresh)
+        }
+    };
+
+    info_span!("push", points = fresh.len()).in_scope(|| {
+        for point in fresh {
+            match matcher.push(&mut trip, point) {
+                Ok(_) => {}
+                Err(MatchError::Unanchored(err)) => {
+                    // Zero-duration marker: the collector counts it.
+                    info_span!("point_drop", reason = "unanchored").in_scope(|| {});
+                    debug!("{vehicle_id}: dropped off-network point ({err})");
+                }
+                Err(err) => {
+                    info_span!("point_drop", reason = "push_error").in_scope(|| {});
+                    error!("{vehicle_id}: could not push point: {err}");
+                }
+            }
+        }
+    });
+
+    // Only a trip with at least one anchored layer is solvable; every
+    // fresh point rejecting (all off-network) leaves nothing to do.
+    if trip.is_empty() {
+        span.record("outcome", "no_anchor");
+        span.record("severity", "nominal");
+        warn!("{vehicle_id}: no anchored layers to solve");
+        return None;
+    }
+
+    // A snapshot is only defined over a solved trip: solve first, and
+    // let a failure (e.g. a disconnected boundary) surface here, before
+    // any collapse is attempted.
+    if let Err(err) = info_span!("solve").in_scope(|| matcher.solve(&mut trip).map(|_| ())) {
+        let (outcome, severity) = classify(&err);
+        span.record("outcome", outcome);
+        span.record("severity", severity);
+        error!("{vehicle_id}: unable to solve trip: {err}");
+        return None;
+    }
+
+    match info_span!("snapshot").in_scope(|| matcher.snapshot(&mut trip)) {
+        Ok(solution) => {
+            let path = RoutedPath::new(solution, network);
+            span.record("outcome", "success");
+            span.record("severity", "ok");
+
+            Some(MatchResult {
+                path,
+                vehicle_id,
+                trip,
+            })
+        }
+        Err(err) => {
+            let (outcome, severity) = classify(&err);
+            span.record("outcome", outcome);
+            span.record("severity", severity);
+            error!("{vehicle_id}: unable to match payload: {err}");
+            None
+        }
     }
 }

--- a/libs/routers_realtime/bin/matcher.rs
+++ b/libs/routers_realtime/bin/matcher.rs
@@ -1,7 +1,5 @@
-use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 
 use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId};
 use routers_network::Metadata;
@@ -11,17 +9,20 @@ use routers_realtime::{
 };
 use routers_shard::{FileFetcher, Geohash, ShardLoader, ShardedNetwork};
 use routers_transition::{
-    Continuation, MatchError, Matcher, candidate::RoutedPath, costing::CostingStrategies,
-    layer::generation::StandardGenerator, primitives::PredicateCache, weigh::AllCompute,
+    Continuation, MatchError, Matcher,
+    candidate::RoutedPath,
+    costing::{CostingStrategies, DefaultEmissionCost, DefaultTransitionCost},
+    layer::generation::StandardGenerator,
+    primitives::PredicateCache,
+    weigh::AllCompute,
 };
 
 use anyhow::Context;
 use async_nats::{ConnectOptions, ServerAddr};
 use clap::Parser;
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 use log::{debug, error, info, warn};
-use tokio::sync::mpsc;
-use tracing::{Instrument, field, info_span};
+use tracing::{field, info_span};
 use url::Url;
 
 #[derive(Parser, Debug)]
@@ -55,141 +56,136 @@ struct Args {
     #[arg(long, env)]
     search_distance: Option<f64>,
 
-    /// The number of concurrent workers. Each vehicle is pinned to one by
-    /// hash, so its contexts stay strictly ordered while the solves overlap
-    /// across vehicles. The matcher and its warm caches are shared by every
-    /// worker; only the per-context solve runs in parallel.
+    /// How many contexts to solve concurrently. Solving is CPU-bound and each
+    /// context is self-contained, so contexts fan out across a blocking pool
+    /// with no shared state to serialise on.
     #[arg(short, env, long, default_value = "5")]
     workers: usize,
-
-    /// Contexts older than this (wire send → pickup) are shed unmatched.
-    /// A stale context is worthless: matching it commits an outdated trip,
-    /// and the vehicle's next context is self-contained (window + trellis),
-    /// so nothing is lost by skipping — while matching it anyway is what
-    /// turns a transient backlog into a restart storm (stale commits break
-    /// the orchestrator's resume overlap, and restarts cost ~3× a resume).
-    /// In steady state nothing is old enough to shed; under overload the
-    /// queue drains at drop speed instead of compounding.
-    #[arg(long, env, value_parser = humantime::parse_duration, default_value = "1s")]
-    shed_after: Duration,
 }
 
 type E = OsmEntryId;
 type M = OsmEdgeMetadata;
 type Net = ShardedNetwork<E, M, Geohash>;
-type Match<'a> = Matcher<
-    'a,
-    routers_transition::costing::DefaultEmissionCost,
-    routers_transition::costing::DefaultTransitionCost,
-    StandardGenerator<'a, E, M, routers_transition::costing::DefaultEmissionCost>,
-    AllCompute<E, M, Net>,
-    E,
-    M,
-    Net,
->;
 
-/// How a match attempt ended, as the `outcome`/`severity` labels the
-/// collector turns into the success-ratio series. Nominal failures are the
-/// data's fault (a point off every road, a trace the network cannot bridge)
-/// and are expected in healthy operation; fatal ones are ours.
+/// Everything a solve needs, owned so the service can be shared (`Arc`) across
+/// the concurrent solves without leaking or juggling `'static` borrows. The
+/// network's spatial index and the predicate cache are the only heavy state,
+/// and both are shared; a per-solve [`Matcher`] is just a bundle of borrows
+/// into this and is free to build.
+struct Matching {
+    network: Arc<Net>,
+    runtime: <M as Metadata>::Runtime,
+    costing: CostingStrategies<DefaultEmissionCost, DefaultTransitionCost, E>,
+    cache: Arc<PredicateCache<E, M, Net>>,
+    search_distance: Option<f64>,
+}
+
+impl Matching {
+    /// Solve one context, recording its outcome onto a fresh `match_event`
+    /// span. Returns the result to publish, or `None` when there is nothing to
+    /// emit (no anchor, or a nominal/fatal solve failure).
+    fn solve(
+        &self,
+        MatchContext {
+            vehicle_id,
+            continuation,
+        }: MatchContext<E>,
+    ) -> Option<MatchResult<E, M>> {
+        let mut generator = StandardGenerator::new(self.network.as_ref(), &self.costing.emission);
+        if let Some(distance) = self.search_distance {
+            generator = generator.with_search_distance(distance);
+        }
+
+        let weigher = AllCompute::default().use_cache(self.cache.clone());
+        let matcher = Matcher::new(
+            self.network.as_ref(),
+            &self.costing,
+            generator,
+            weigher,
+            &self.runtime,
+        );
+
+        let span = info_span!(
+            "match_event",
+            outcome = field::Empty,
+            severity = field::Empty,
+            continuation = field::Empty,
+        );
+        let _entered = span.enter();
+
+        let (mut trip, fresh) = match continuation {
+            Continuation::Resume { trip, fresh } => {
+                span.record("continuation", "resume");
+                (trip, fresh)
+            }
+            Continuation::Restart { fresh } => {
+                span.record("continuation", "restart");
+                (matcher.begin(), fresh)
+            }
+        };
+
+        info_span!("push", points = fresh.len()).in_scope(|| {
+            for point in fresh {
+                match matcher.push(&mut trip, point) {
+                    Ok(_) => {}
+                    Err(MatchError::Unanchored(err)) => {
+                        info_span!("point_drop", reason = "unanchored")
+                            .in_scope(|| debug!("{vehicle_id}: dropped off-network point ({err})"));
+                    }
+                    Err(err) => {
+                        info_span!("point_drop", reason = "push_error")
+                            .in_scope(|| error!("{vehicle_id}: could not push point: {err}"));
+                    }
+                }
+            }
+        });
+
+        if trip.is_empty() {
+            span.record("outcome", "no_anchor");
+            span.record("severity", "nominal");
+            warn!("{vehicle_id}: no anchored layers to solve");
+            return None;
+        }
+
+        if let Err(err) = info_span!("solve").in_scope(|| matcher.solve(&mut trip)) {
+            let (outcome, severity) = classify(err);
+            span.record("outcome", outcome);
+            span.record("severity", severity);
+            error!("{vehicle_id}: unable to solve trip");
+            return None;
+        }
+
+        let solution = match info_span!("snapshot").in_scope(|| matcher.snapshot(&mut trip)) {
+            Ok(solution) => solution,
+            Err(err) => {
+                let (outcome, severity) = classify(err);
+                span.record("outcome", outcome);
+                span.record("severity", severity);
+                return None;
+            }
+        };
+
+        span.record("outcome", "success");
+        span.record("severity", "ok");
+
+        let path = RoutedPath::new(solution, self.network.as_ref());
+        Some(MatchResult {
+            path,
+            vehicle_id,
+            trip,
+        })
+    }
+}
+
+/// A match attempt's `outcome`/`severity` labels for the success-ratio series.
+/// Nominal failures are the data's fault (a point off every road, a trace the
+/// network cannot bridge) and expected in healthy operation; fatal ones are ours.
 fn classify(err: MatchError) -> (&'static str, &'static str) {
     match err {
         MatchError::Unanchored(_) => ("unanchored", "nominal"),
         MatchError::Disconnected(_) => ("disconnected", "nominal"),
         MatchError::TrellisError(_) | MatchError::SolveError(_) => ("internal", "fatal"),
     }
-}
-
-/// Run one context to completion, recording its outcome onto the current
-/// `match_event` span. Returns the result to publish, or `None` when there
-/// is nothing to emit (no anchor, or a nominal/fatal solve failure).
-///
-/// A free function rather than a closure so every worker can call the one
-/// shared, warm matcher (leaked to `'static`) without cloning it.
-fn attempt(
-    matcher: &Match<'static>,
-    network: &Net,
-    vehicle_id: String,
-    continuation: Continuation<E>,
-) -> Option<MatchResult<E, M>> {
-    let span = tracing::Span::current();
-
-    let (mut trip, fresh) = match continuation {
-        Continuation::Resume { trip, fresh } => {
-            span.record("continuation", "resume");
-            debug!(
-                "{vehicle_id}: resuming {} committed layer(s), {} fresh point(s)",
-                trip.layers(),
-                fresh.len()
-            );
-            (trip, fresh)
-        }
-        Continuation::Restart { fresh } => {
-            span.record("continuation", "restart");
-            debug!("{vehicle_id}: restarting over {} point(s)", fresh.len());
-            (matcher.begin(), fresh)
-        }
-    };
-
-    info_span!("push", points = fresh.len()).in_scope(|| {
-        for point in fresh {
-            match matcher.push(&mut trip, point) {
-                Ok(_) => { /* OK! */ }
-                Err(MatchError::Unanchored(err)) => {
-                    info_span!("point_drop", reason = "unanchored").in_scope(|| {
-                        debug!("{vehicle_id}: dropped off-network point ({err})");
-                    });
-                }
-                Err(err) => {
-                    info_span!("point_drop", reason = "push_error").in_scope(|| {
-                        error!("{vehicle_id}: could not push point: {err}");
-                    });
-                }
-            }
-        }
-    });
-
-    if trip.is_empty() {
-        span.record("outcome", "no_anchor");
-        span.record("severity", "nominal");
-        warn!("{vehicle_id}: no anchored layers to solve");
-        return None;
-    }
-
-    match info_span!("solve")
-        .in_scope(|| matcher.solve(&mut trip))
-        .map_err(classify)
-    {
-        Ok(path) => debug!("solved path: {path:?}"),
-        Err((outcome, severity)) => {
-            span.record("outcome", outcome);
-            span.record("severity", severity);
-            error!("{vehicle_id}: unable to solve trip: {outcome}");
-            return None;
-        }
-    }
-
-    let solution = match info_span!("snapshot")
-        .in_scope(|| matcher.snapshot(&mut trip))
-        .map_err(classify)
-    {
-        Ok(solution) => solution,
-        Err((outcome, severity)) => {
-            span.record("outcome", outcome);
-            span.record("severity", severity);
-            return None;
-        }
-    };
-
-    span.record("outcome", "success");
-    span.record("severity", "ok");
-
-    let path = RoutedPath::new(solution, network);
-    Some(MatchResult {
-        path,
-        vehicle_id,
-        trip,
-    })
 }
 
 #[tokio::main]
@@ -221,121 +217,37 @@ async fn main() -> anyhow::Result<()> {
         .subscribe(args.inbound_subject)
         .await
         .context("could not subscribe to NATS subject")?;
-    let mut source = NATSStream::<MatchContext<E>>::new(subscriber);
+    let source = NATSStream::<MatchContext<E>>::new(subscriber);
 
-    // One long-lived matcher, shared by every worker: the predicate cache and
-    // generator index stay warm across every vehicle and event. The matcher
-    // and its dependencies live for the life of the process, so we leak them
-    // once to get the `'static` borrows `tokio::spawn` requires.
-    let network: &'static Arc<Net> = Box::leak(Box::new(network));
-    let net: &'static Net = network.as_ref();
-    let runtime: &'static _ = Box::leak(Box::new(OsmEdgeMetadata::runtime(None)));
-    let costing: &'static CostingStrategies<_, _, E> =
-        Box::leak(Box::new(CostingStrategies::default()));
+    let sink = NATSSink::<MatchResult<E, M>>::new(client, move |_| args.outbound_subject.clone());
 
-    let cache = Arc::new(PredicateCache::default());
+    let matching = Arc::new(Matching {
+        network,
+        runtime: OsmEdgeMetadata::runtime(None),
+        costing: CostingStrategies::default(),
+        cache: Arc::new(PredicateCache::default()),
+        search_distance: args.search_distance,
+    });
 
-    let mut generator = StandardGenerator::new(net, &costing.emission);
-    if let Some(distance) = args.search_distance {
-        generator = generator.with_search_distance(distance);
-    }
-
-    let weigher = AllCompute::default().use_cache(cache);
-    let matcher: &'static Match<'static> = Box::leak(Box::new(Matcher::new(
-        net, costing, generator, weigher, runtime,
-    )));
-
-    // Vehicles are pinned to workers by hash: solves overlap across vehicles
-    // while each vehicle's contexts stay strictly ordered on one worker.
-    let mut handles = Vec::with_capacity(args.workers);
-    let mut txs = Vec::with_capacity(args.workers);
-
-    for _ in 0..args.workers {
-        // Stamped on dispatch so the channel residency is measurable, and the
-        // context's wire send time (captured while the message is the stream's
-        // newest yield) rides along so the shed deadline can be checked here.
-        let (tx, mut rx) = mpsc::channel::<(
-            web_time::SystemTime,
-            Option<web_time::SystemTime>,
-            MatchContext<E>,
-        )>(1024);
-        txs.push(tx);
-
-        // Each worker publishes through its own sink; the underlying NATS
-        // client is shared and cheap to clone.
-        let subject = args.outbound_subject.clone();
-        let mut sink =
-            NATSSink::<MatchResult<E, M>>::new(client.clone(), move |_| subject.clone());
-
-        let shed_after = args.shed_after;
-        handles.push(tokio::spawn(async move {
-            while let Some((queued_at, sent_at, msg)) = rx.recv().await {
-                routers_realtime::bus::span_between(
-                    "worker_wait",
-                    queued_at,
-                    routers_realtime::bus::wallclock(),
-                );
-
-                // Past its deadline: shed rather than match (see
-                // `--shed-after`). Zero-duration marker so the collector
-                // counts the sheds.
-                if let Some(sent_at) = sent_at
-                    && routers_realtime::bus::wallclock()
-                        .duration_since(sent_at)
-                        .is_ok_and(|age| age > shed_after)
-                {
-                    info_span!("match_shed", reason = "stale").in_scope(|| {});
-                    debug!("{}: shed stale context", msg.vehicle_id);
-                    continue;
-                }
-
-                let MatchContext {
-                    vehicle_id,
-                    continuation,
-                } = msg;
-
-                let span = info_span!(
-                    "match_event",
-                    outcome = field::Empty,
-                    severity = field::Empty,
-                    continuation = field::Empty,
-                );
-
-                if let Some(result) =
-                    span.in_scope(|| attempt(matcher, net, vehicle_id, continuation))
-                {
-                    sink.send(result)
-                        .instrument(info_span!(parent: &span, "publish_result"))
-                        .await
-                        .context("could not emit result to sink")
-                        .ok();
-                }
+    // Each context is solved on the blocking pool (solving is synchronous and
+    // CPU-bound); `buffer_unordered` keeps `workers` in flight at once. Results
+    // stream straight into the sink in completion order.
+    source
+        .map(|context| {
+            let matching = Arc::clone(&matching);
+            async move {
+                tokio::task::spawn_blocking(move || matching.solve(context))
+                    .await
+                    .ok()
+                    .flatten()
             }
-        }));
-    }
-
-    while let Some(msg) = source.next().await {
-        // Only valid while this message is the stream's newest yield.
-        let sent_at = routers_realtime::bus::last_sent_at();
-
-        let mut h = DefaultHasher::new();
-        msg.vehicle_id.hash(&mut h);
-        let worker = h.finish() as usize % args.workers;
-
-        txs[worker]
-            .send((routers_realtime::bus::wallclock(), sent_at, msg))
-            .await
-            .map_err(|_| anyhow::anyhow!("worker {worker} channel closed"))?;
-    }
+        })
+        .buffer_unordered(args.workers)
+        .filter_map(std::future::ready)
+        .map(Ok)
+        .forward(sink)
+        .await?;
 
     error!("source terminated");
-
-    // Dropping the senders lets each worker drain its queue and flush its
-    // sink before the process exits.
-    drop(txs);
-    for handle in handles {
-        handle.await.ok();
-    }
-
     Ok(())
 }

--- a/libs/routers_realtime/bin/orchestrator.rs
+++ b/libs/routers_realtime/bin/orchestrator.rs
@@ -31,6 +31,15 @@ enum Inbound {
     Result(MatchResult<E, M>),
 }
 
+/// An [`Inbound`] handed to a worker, tagged with the wall-clock stamps the
+/// dispatch loop captured: when it was queued (for channel-residency timing)
+/// and its wire send time (for end-to-end timing, and as the vehicle's origin).
+struct Dispatch {
+    queued_at: web_time::SystemTime,
+    sent_at: Option<web_time::SystemTime>,
+    inbound: Inbound,
+}
+
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
@@ -53,8 +62,7 @@ struct Args {
     outbound_subject: String,
 
     /// The NATS subject the matcher publishes results into. The orchestrator
-    /// commits each result's trip as the vehicle's resume state — the
-    /// matcher itself never touches a store.
+    /// commits each result's trip as the vehicle's resume state.
     #[arg(long = "results", env)]
     results_subject: String,
 
@@ -72,24 +80,21 @@ struct Args {
     #[arg(long, env, default_value = "2000")]
     jump_distance: f64,
 
-    /// The number of concurrent workers. Each vehicle is pinned to one by
-    /// hash, so its events and results stay strictly ordered while the
-    /// per-event Redis fetches overlap across vehicles — the fetch round
-    /// trip, not compute, is what bounds a single orchestrator's throughput.
-    /// The trip and origin maps shard along with the vehicles, so a worker
-    /// owns every vehicle it will ever see and the maps need no locks.
+    /// How many workers to fan vehicles across. Each vehicle is pinned to one
+    /// by hash, so its events and results stay ordered on a worker that owns
+    /// their trip state outright — the maps need no locks, and the per-event
+    /// Redis fetch (the throughput bound) overlaps across vehicles.
     #[arg(short, env, long, default_value = "8")]
     workers: usize,
 }
 
+/// A worker's view of the shared configuration and its own trip state, borrowed
+/// per event for [`try_create_context`](App::try_create_context).
 struct App<'a> {
     gap: chrono::TimeDelta,
-
     jump_distance: f64,
     context_window: usize,
-
     trips: &'a HashMap<String, Trip<E>>,
-
     kv: &'a mut RedisStore<RawEvent>,
 }
 
@@ -108,39 +113,31 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("could not connect to NATS")?;
 
-    let events_subscriber = client
-        .subscribe(args.inbound_subject)
-        .await
-        .context("could not subscribe to NATS event subject")?;
+    let events = NATSStream::<Payload>::new(
+        client
+            .subscribe(args.inbound_subject)
+            .await
+            .context("could not subscribe to NATS event subject")?,
+    )
+    .map(Inbound::Event);
 
-    let results_subscriber = client
-        .subscribe(args.results_subject)
-        .await
-        .context("could not subscribe to NATS results subject")?;
-
-    let events = NATSStream::<Payload>::new(events_subscriber).map(Inbound::Event);
-    let results = NATSStream::<MatchResult<E, M>>::new(results_subscriber).map(Inbound::Result);
+    let results = NATSStream::<MatchResult<E, M>>::new(
+        client
+            .subscribe(args.results_subject)
+            .await
+            .context("could not subscribe to NATS results subject")?,
+    )
+    .map(Inbound::Result);
 
     let mut source = futures::stream::select(events, results);
 
     let gap = chrono::Duration::from_std(args.gap).context("gap out of range")?;
 
-    // Vehicles are pinned to workers by hash: the per-event Redis fetches
-    // overlap across vehicles while each vehicle's events — and the results
-    // that commit its trips — stay strictly ordered on one worker. The trip
-    // and origin maps shard along with the vehicles, so a worker owns every
-    // vehicle it will ever see and the maps need no locks. Keeping a result
-    // on its vehicle's worker is also what protects the resume ratio: the
-    // commit lands before that vehicle's next event is reconciled.
     let mut handles = Vec::with_capacity(args.workers);
     let mut txs = Vec::with_capacity(args.workers);
 
     for _ in 0..args.workers {
-        let (tx, mut rx) = mpsc::channel::<(
-            web_time::SystemTime,
-            Option<web_time::SystemTime>,
-            Inbound,
-        )>(1024);
+        let (tx, mut rx) = mpsc::channel::<Dispatch>(1024);
         txs.push(tx);
 
         let mut kv = RedisStore::<RawEvent>::new(args.redis.clone())
@@ -154,18 +151,20 @@ async fn main() -> anyhow::Result<()> {
         let jump_distance = args.jump_distance;
 
         handles.push(tokio::spawn(async move {
-            // Each vehicle's trellis from its prior solve, as committed back by
-            // the matcher's results. Derived state, not a source of truth:
-            // losing it (restart, first sight) just means the next context says
-            // `Restart` and the matcher rebuilds from committed history.
+            // This worker's vehicles, and their state. `trips` is the trellis
+            // from each vehicle's last solve, committed back by the matcher and
+            // resumed from on its next event; `origins` is when each vehicle's
+            // newest event was published, for the end-to-end `event_to_match`
+            // span. Both are derived — losing them just forces a restart.
             let mut trips: HashMap<String, Trip<E>> = HashMap::new();
-
-            // When each vehicle's newest raw event was published (its wire
-            // stamp), so the matching result can be measured against it — the
-            // `event_to_match` span is the pipeline's end-to-end walltime.
             let mut origins: HashMap<String, web_time::SystemTime> = HashMap::new();
 
-            while let Some((queued_at, sent_at, inbound)) = rx.recv().await {
+            while let Some(Dispatch {
+                queued_at,
+                sent_at,
+                inbound,
+            }) = rx.recv().await
+            {
                 routers_realtime::bus::span_between(
                     "worker_wait",
                     queued_at,
@@ -193,11 +192,7 @@ async fn main() -> anyhow::Result<()> {
                             kv: &mut kv,
                         };
 
-                        match app
-                            .try_create_context(payload)
-                            .instrument(span.clone())
-                            .await
-                        {
+                        match app.try_create_context(payload).instrument(span.clone()).await {
                             Ok(ctx) => {
                                 if let Err(err) = sink
                                     .send(ctx)
@@ -207,13 +202,9 @@ async fn main() -> anyhow::Result<()> {
                                     error!("could not send match context: {err:#}");
                                 }
                             }
-                            Err(err) => {
-                                warn!("could not create match context: {err}");
-                            }
+                            Err(err) => warn!("could not create match context: {err}"),
                         }
                     }
-                    // Commit-action for a completed solve: the returned trip
-                    // becomes the state the vehicle's next context resumes from.
                     Inbound::Result(result) => {
                         let _span =
                             info_span!("commit_result", layers = result.trip.layers()).entered();
@@ -221,11 +212,7 @@ async fn main() -> anyhow::Result<()> {
                         if let (Some(origin), Some(matched_at)) =
                             (origins.remove(&result.vehicle_id), sent_at)
                         {
-                            routers_realtime::bus::span_between(
-                                "event_to_match",
-                                origin,
-                                matched_at,
-                            );
+                            routers_realtime::bus::span_between("event_to_match", origin, matched_at);
                         }
 
                         trips.insert(result.vehicle_id, result.trip);
@@ -236,11 +223,8 @@ async fn main() -> anyhow::Result<()> {
     }
 
     while let Some(inbound) = source.next().await {
-        // The wire stamp is an ambient slot valid only while this message is
-        // the stream's most recent yield, so it must be captured here — by the
-        // time a worker sees the message, later yields have overwritten it. For
-        // an event it becomes the vehicle's origin; for a result it is when the
-        // matcher published it.
+        // The wire stamp is only valid while this message is the stream's newest
+        // yield, so capture it here rather than in the worker.
         let sent_at = routers_realtime::bus::last_sent_at();
 
         let vehicle_id = match &inbound {
@@ -248,18 +232,21 @@ async fn main() -> anyhow::Result<()> {
             Inbound::Result(result) => &result.vehicle_id,
         };
 
-        let mut h = DefaultHasher::new();
-        vehicle_id.hash(&mut h);
-        let worker = h.finish() as usize % args.workers;
+        let mut hasher = DefaultHasher::new();
+        vehicle_id.hash(&mut hasher);
+        let worker = hasher.finish() as usize % args.workers;
 
         txs[worker]
-            .send((routers_realtime::bus::wallclock(), sent_at, inbound))
+            .send(Dispatch {
+                queued_at: routers_realtime::bus::wallclock(),
+                sent_at,
+                inbound,
+            })
             .await
             .map_err(|_| anyhow::anyhow!("worker {worker} channel closed"))?;
     }
 
-    // The stream has ended: dropping the senders lets each worker drain its
-    // queue and flush its sink before the process exits.
+    // Dropping the senders drains each worker before the process exits.
     drop(txs);
     for handle in handles {
         handle.await.ok();
@@ -268,7 +255,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-impl<'a> App<'a> {
+impl App<'_> {
     async fn try_create_context(
         &mut self,
         Payload {
@@ -278,9 +265,13 @@ impl<'a> App<'a> {
             ..
         }: Payload,
     ) -> Result<MatchContext<E>> {
-        // Fetched deeper than the window on purpose: the store may hold points
-        // *newer* than this event (see below), which are dropped before the
-        // window is taken.
+        // Fetch deeper than the window: the store may hold points newer than
+        // this event (the historian archives straight off the raw stream, so
+        // under backlog it runs ahead of us), and those are the vehicle's future
+        // relative to the event being matched. Dropping them keeps the
+        // gap/teleport cutoff below firing on data quality, not pipeline latency
+        // — otherwise a backlog discards committed history and forces the
+        // matcher's expensive restart path exactly when it is already behind.
         let mut entries = self
             .kv
             .get_many(&vehicle_id, self.context_window * 3)
@@ -288,19 +279,8 @@ impl<'a> App<'a> {
             .await
             .context("could not get entries from redis store")?;
 
-        // Context is strictly the event's past. The historian archives straight
-        // off the raw stream, so under any pipeline backlog the store runs
-        // *ahead* of this worker and the newest entries are the vehicle's future
-        // relative to the event being matched. Left in, the gap/teleport cutoffs
-        // below fire on pipeline latency rather than data quality, which
-        // discards committed history and forces the matcher onto its expensive
-        // restart path: a feedback loop that collapses throughput under exactly
-        // the load that caused the backlog.
         entries.retain(|event| event.timestamp <= timestamp);
-
-        // Normalise to newest-first regardless of the datasource's return order:
-        // the cutoff below walks back in time from the current event, discarding
-        // everything beyond the first gap or teleport.
+        // Newest-first, so the cutoff below walks back in time from this event.
         entries.sort_by_key(|event| std::cmp::Reverse(event.timestamp));
         entries.truncate(self.context_window);
         let fetched = entries.len();
@@ -322,16 +302,14 @@ impl<'a> App<'a> {
             })
             .collect::<Vec<_>>();
 
-        // A cutoff means a gap or teleport discarded committed history — a
-        // marker span makes the occurrences countable.
         let cut = fetched - context.len();
         if cut > 0 {
             info_span!("history_cut", reason = "gap_or_teleport").in_scope(|| {});
         }
 
-        // The matcher solves a directed trajectory, so it must receive the
-        // points in chronological order. The current payload may already be
-        // archived, so dedup by timestamp after sorting.
+        // The matcher solves a directed trajectory, so points must arrive
+        // chronologically; the current payload may already be archived, so
+        // dedup by timestamp after sorting.
         let mut history: Vec<RawEvent> = std::iter::once(RawEvent {
             vehicle_id: vehicle_id.clone(),
             point,
@@ -343,14 +321,11 @@ impl<'a> App<'a> {
         history.sort_by_key(|event| event.timestamp);
         history.dedup_by_key(|event| event.timestamp);
 
-        let points = history
-            .into_iter()
-            .map(|event| event.point)
-            .collect::<Vec<Point>>();
+        let points = history.into_iter().map(|event| event.point).collect::<Vec<Point>>();
 
-        // Reconcile the prior solve against the committed window: pure data work
-        // (trim and compare — never generating a layer), so it belongs here
-        // rather than on the matcher's hot path.
+        // Reconcile the prior solve against the window: pure data work (trim and
+        // compare, never generating a layer), so it belongs here and not on the
+        // matcher's hot path.
         let continuation = info_span!("reconcile")
             .in_scope(|| Continuation::reconcile(self.trips.get(&vehicle_id).cloned(), &points));
 

--- a/libs/routers_realtime/bin/orchestrator.rs
+++ b/libs/routers_realtime/bin/orchestrator.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::Duration;
 
 use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId};
@@ -15,7 +16,8 @@ use async_nats::{ConnectOptions, ServerAddr};
 use clap::Parser;
 use futures::{SinkExt, StreamExt};
 use geo::{Distance, Haversine, Point};
-use log::{debug, info};
+use log::{debug, error, info};
+use tokio::sync::mpsc;
 use tracing::{Instrument, field, info_span};
 use url::Url;
 
@@ -69,6 +71,23 @@ struct Args {
     /// and dropped along with everything older.
     #[arg(long, env, default_value = "2000")]
     jump: f64,
+
+    /// The number of concurrent workers. Each vehicle is pinned to one by
+    /// hash, so its events and results stay strictly ordered while the
+    /// per-event Redis fetches overlap across vehicles — the fetch round
+    /// trip, not compute, is what bounds a single orchestrator's throughput.
+    #[arg(short, env, long, default_value = "8")]
+    workers: usize,
+
+    /// The most fresh points a context may carry; a longer tail (a restart
+    /// over a wide window, or a resume across a long commit gap) is
+    /// restarted over just the newest points instead. Matcher work per
+    /// event is ~one boundary per fresh point, so this is the per-event
+    /// work budget — it decouples the resume overlap horizon (wide, cheap:
+    /// `--context-window`) from the matching cost (bounded, regardless of
+    /// how turbulent the pipeline has been).
+    #[arg(long, env, default_value = "8")]
+    fresh_cap: usize,
 }
 
 #[tokio::main]
@@ -86,9 +105,6 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("could not connect to NATS")?;
 
-    let mut sink =
-        NATSSink::<MatchContext<E>>::new(client.clone(), move |_| args.outbound_subject.clone());
-
     let subscriber = client
         .subscribe(args.inbound_subject)
         .await
@@ -103,149 +119,278 @@ async fn main() -> anyhow::Result<()> {
 
     let mut source = futures::stream::select(events, results);
 
-    let mut kv = RedisStore::<RawEvent>::new(args.redis)
-        .await
-        .context("could not connect to redis store")?;
-
     let gap = chrono::Duration::from_std(args.gap).context("gap out of range")?;
 
-    // Each vehicle's trellis from its prior solve, as committed back by the
-    // matcher's results. Derived state, not a source of truth: losing it
-    // (restart, first sight) just means the next context says `Restart` and
-    // the matcher rebuilds from the committed history.
-    let mut trips: HashMap<String, Trip<E>> = HashMap::new();
+    // Vehicles are pinned to workers by hash: the per-event Redis fetches
+    // overlap across vehicles while each vehicle's events — and the results
+    // that commit its trips — stay strictly ordered on one worker. The trip
+    // and origin maps shard along with the vehicles, so a worker owns every
+    // vehicle it will ever see and the maps need no locks. Keeping a result
+    // on its vehicle's worker is also what protects the resume ratio: the
+    // commit lands before that vehicle's next event is reconciled.
+    let mut handles = Vec::with_capacity(args.workers);
+    let mut txs = Vec::with_capacity(args.workers);
 
-    // When each vehicle's newest raw event was published (its wire stamp),
-    // so the matching result can be measured against it: the `event_to_match`
-    // span below is the pipeline's end-to-end walltime, replay's publish →
-    // the matcher's publish, taken entirely from message stamps.
-    let mut origins: HashMap<String, web_time::SystemTime> = HashMap::new();
+    for _ in 0..args.workers {
+        let (tx, mut rx) = mpsc::channel::<(
+            web_time::SystemTime,
+            Option<web_time::SystemTime>,
+            Inbound,
+        )>(1024);
+        txs.push(tx);
 
-    while let Some(inbound) = source.next().await {
-        let payload = match inbound {
-            Inbound::Event(payload) => {
-                if let Some(sent_at) = routers_realtime::bus::last_sent_at() {
-                    origins.insert(payload.vehicle_id.clone(), sent_at);
-                }
-                payload
-            }
-            // Commit-action for a completed solve: the returned trip becomes
-            // the state the vehicle's next context resumes from.
-            Inbound::Result(result) => {
-                let _span = info_span!("commit_result", layers = result.trip.layers()).entered();
-
-                // The result's own stamp is when the matcher published it; the
-                // origin is when replay published the event it answers.
-                if let (Some(origin), Some(matched_at)) = (
-                    origins.remove(&result.vehicle_id),
-                    routers_realtime::bus::last_sent_at(),
-                ) {
-                    routers_realtime::bus::span_between("event_to_match", origin, matched_at);
-                }
-
-                trips.insert(result.vehicle_id, result.trip);
-                continue;
-            }
-        };
-
-        // One span per event; the collector aggregates these into the
-        // orchestrator's throughput and latency series. `continuation` is
-        // recorded once reconciliation decides, and becomes a metric label.
-        let span = info_span!(
-            "orchestrate",
-            continuation = field::Empty,
-            fresh = field::Empty,
-            cut = field::Empty,
-        );
-
-        async {
-            let mut entries = kv
-                .get_many(&payload.vehicle_id, args.context_window)
-                .instrument(info_span!("context_fetch"))
-                .await
-                .context("could not get entries from redis store")?;
-
-            // Normalise to newest-first regardless of the datasource's return
-            // order: the cutoff below walks back in time from the current event,
-            // discarding everything beyond the first gap or teleport.
-            entries.sort_by_key(|event| std::cmp::Reverse(event.timestamp));
-            let fetched = entries.len();
-
-            let context = entries
-                .into_iter()
-                .inspect(|v| debug!("event: {:?}", v))
-                .scan(
-                    (payload.point, payload.timestamp),
-                    |(prev_p, prev_ts), event: RawEvent| {
-                        let duration = (*prev_ts - event.timestamp).abs();
-                        let distance = Haversine.distance(*prev_p, event.point);
-
-                        if duration <= gap && distance <= args.jump {
-                            *prev_p = event.point;
-                            *prev_ts = event.timestamp;
-                            Some(event)
-                        } else {
-                            None
-                        }
-                    },
-                )
-                .collect::<Vec<_>>();
-
-            // A cutoff means a gap or teleport discarded committed history —
-            // a marker span makes the occurrences countable.
-            let cut = fetched - context.len();
-            if cut > 0 {
-                info_span!("history_cut", reason = "gap_or_teleport").in_scope(|| {});
-            }
-
-            // The matcher solves a directed trajectory, so it must receive the
-            // points in chronological order. The current payload may already be
-            // archived, so dedup by timestamp after sorting.
-            let mut history: Vec<RawEvent> =
-                std::iter::once(payload.as_event()).chain(context).collect();
-            history.sort_by_key(|event| event.timestamp);
-            history.dedup_by_key(|event| event.timestamp);
-
-            let points = history
-                .into_iter()
-                .map(|event| event.point)
-                .collect::<Vec<Point>>();
-
-            // Reconcile the prior solve against the committed window: pure data
-            // work (trim and compare — never generating a layer), so it belongs
-            // here rather than on the matcher's hot path. The trip is cloned,
-            // not taken: a second event racing the first result still resumes
-            // from the same state, just with one more fresh point.
-            let continuation = info_span!("reconcile").in_scope(|| {
-                Continuation::reconcile(trips.get(&payload.vehicle_id).cloned(), &points)
-            });
-
-            let span = tracing::Span::current();
-            span.record("cut", cut);
-            match &continuation {
-                Continuation::Resume { fresh, .. } => {
-                    span.record("continuation", "resume");
-                    span.record("fresh", fresh.len());
-                }
-                Continuation::Restart { fresh } => {
-                    span.record("continuation", "restart");
-                    span.record("fresh", fresh.len());
-                }
-            }
-
-            sink.send(MatchContext {
-                vehicle_id: payload.vehicle_id,
-                continuation,
-            })
-            .instrument(info_span!("publish_context"))
+        let mut kv = RedisStore::<RawEvent>::new(args.redis.clone())
             .await
-            .context("could not send match context")
-        }
-        .instrument(span)
-        .await?;
+            .context("could not connect to redis store")?;
+
+        let subject = args.outbound_subject.clone();
+        let mut sink = NATSSink::<MatchContext<E>>::new(client.clone(), move |_| subject.clone());
+
+        let context_window = args.context_window;
+        let jump = args.jump;
+        let fresh_cap = args.fresh_cap;
+
+        handles.push(tokio::spawn(async move {
+            // Each vehicle's trellis from its prior solve, as committed back
+            // by the matcher's results. Derived state, not a source of truth:
+            // losing it (restart, first sight) just means the next context
+            // says `Restart` and the matcher rebuilds from committed history.
+            let mut trips: HashMap<String, Trip<E>> = HashMap::new();
+
+            // When each vehicle's newest raw event was published (its wire
+            // stamp), so the matching result can be measured against it: the
+            // `event_to_match` span below is the pipeline's end-to-end
+            // walltime, replay's publish → the matcher's publish, taken
+            // entirely from message stamps.
+            let mut origins: HashMap<String, web_time::SystemTime> = HashMap::new();
+
+            while let Some((queued_at, sent_at, inbound)) = rx.recv().await {
+                routers_realtime::bus::span_between(
+                    "worker_wait",
+                    queued_at,
+                    routers_realtime::bus::wallclock(),
+                );
+
+                let payload = match inbound {
+                    Inbound::Event(payload) => {
+                        if let Some(sent_at) = sent_at {
+                            origins.insert(payload.vehicle_id.clone(), sent_at);
+                        }
+                        payload
+                    }
+                    // Commit-action for a completed solve: the returned trip
+                    // becomes the state the vehicle's next context resumes
+                    // from.
+                    Inbound::Result(result) => {
+                        let _span =
+                            info_span!("commit_result", layers = result.trip.layers()).entered();
+
+                        if let (Some(origin), Some(matched_at)) =
+                            (origins.remove(&result.vehicle_id), sent_at)
+                        {
+                            routers_realtime::bus::span_between(
+                                "event_to_match",
+                                origin,
+                                matched_at,
+                            );
+                        }
+
+                        trips.insert(result.vehicle_id, result.trip);
+                        continue;
+                    }
+                };
+
+                // One span per event; the collector aggregates these into the
+                // orchestrator's throughput and latency series. `continuation`
+                // is recorded once reconciliation decides, and becomes a
+                // metric label.
+                let span = info_span!(
+                    "orchestrate",
+                    continuation = field::Empty,
+                    fresh = field::Empty,
+                    cut = field::Empty,
+                );
+
+                let orchestrated: anyhow::Result<()> = async {
+                    // Fetched deeper than the window on purpose: the store may
+                    // hold points *newer* than this event (see below), which
+                    // are dropped before the window is taken.
+                    let mut entries = kv
+                        .get_many(&payload.vehicle_id, context_window * 3)
+                        .instrument(info_span!("context_fetch"))
+                        .await
+                        .context("could not get entries from redis store")?;
+
+                    // Context is strictly the event's past. The historian
+                    // archives straight off the raw stream, so under any
+                    // pipeline backlog the store runs *ahead* of this worker
+                    // and the newest entries are the vehicle's future relative
+                    // to the event being matched. Left in, the gap/teleport
+                    // cutoffs below fire on pipeline latency rather than data
+                    // quality (at replay speed s, one wall-second of backlog
+                    // is s seconds — kilometres — of vehicle movement), which
+                    // discards committed history and forces the matcher onto
+                    // its expensive restart path: a feedback loop that
+                    // collapses throughput under exactly the load that caused
+                    // the backlog.
+                    entries.retain(|event| event.timestamp <= payload.timestamp);
+
+                    // Normalise to newest-first regardless of the
+                    // datasource's return order: the cutoff below walks back
+                    // in time from the current event, discarding everything
+                    // beyond the first gap or teleport.
+                    entries.sort_by_key(|event| std::cmp::Reverse(event.timestamp));
+                    entries.truncate(context_window);
+                    let fetched = entries.len();
+
+                    let context = entries
+                        .into_iter()
+                        .inspect(|v| debug!("event: {:?}", v))
+                        .scan(
+                            (payload.point, payload.timestamp),
+                            |(prev_p, prev_ts), event: RawEvent| {
+                                let duration = (*prev_ts - event.timestamp).abs();
+                                let distance = Haversine.distance(*prev_p, event.point);
+
+                                if duration <= gap && distance <= jump {
+                                    *prev_p = event.point;
+                                    *prev_ts = event.timestamp;
+                                    Some(event)
+                                } else {
+                                    None
+                                }
+                            },
+                        )
+                        .collect::<Vec<_>>();
+
+                    // A cutoff means a gap or teleport discarded committed
+                    // history — a marker span makes the occurrences countable.
+                    let cut = fetched - context.len();
+                    if cut > 0 {
+                        info_span!("history_cut", reason = "gap_or_teleport").in_scope(|| {});
+                    }
+
+                    // The matcher solves a directed trajectory, so it must
+                    // receive the points in chronological order. The current
+                    // payload may already be archived, so dedup by timestamp
+                    // after sorting.
+                    let mut history: Vec<RawEvent> =
+                        std::iter::once(payload.as_event()).chain(context).collect();
+                    history.sort_by_key(|event| event.timestamp);
+                    history.dedup_by_key(|event| event.timestamp);
+
+                    let points = history
+                        .into_iter()
+                        .map(|event| event.point)
+                        .collect::<Vec<Point>>();
+
+                    // Reconcile the prior solve against the committed window:
+                    // pure data work (trim and compare — never generating a
+                    // layer), so it belongs here rather than on the matcher's
+                    // hot path. The trip is cloned, not taken: a second event
+                    // racing the first result still resumes from the same
+                    // state, just with one more fresh point.
+                    let continuation = info_span!("reconcile").in_scope(|| {
+                        Continuation::reconcile(trips.get(&payload.vehicle_id).cloned(), &points)
+                    });
+
+                    // Enforce the per-event work budget: a context whose
+                    // fresh tail exceeds the cap costs the matcher one
+                    // boundary per point whether it resumes or restarts, so
+                    // ship the cheapest equivalent — a restart over just the
+                    // newest points. Marker span so the conversions are
+                    // countable.
+                    let continuation = match continuation {
+                        Continuation::Resume { fresh, .. } | Continuation::Restart { fresh }
+                            if fresh.len() > fresh_cap =>
+                        {
+                            info_span!("fresh_capped", reason = "over_budget").in_scope(|| {});
+                            Continuation::Restart {
+                                fresh: fresh[fresh.len() - fresh_cap..].to_vec(),
+                            }
+                        }
+                        continuation => continuation,
+                    };
+
+                    let span = tracing::Span::current();
+                    span.record("cut", cut);
+                    match &continuation {
+                        Continuation::Resume { fresh, .. } => {
+                            span.record("continuation", "resume");
+                            span.record("fresh", fresh.len());
+                        }
+                        Continuation::Restart { fresh } => {
+                            span.record("continuation", "restart");
+                            span.record("fresh", fresh.len());
+                        }
+                    }
+
+                    sink.send(MatchContext {
+                        vehicle_id: payload.vehicle_id,
+                        continuation,
+                    })
+                    .instrument(info_span!("publish_context"))
+                    .await
+                    .context("could not send match context")
+                }
+                .instrument(span)
+                .await;
+
+                // A failed event is logged and dropped rather than fatal: one
+                // bad fetch must not take down every vehicle on this worker.
+                if let Err(err) = orchestrated {
+                    error!("orchestration failed: {err:#}");
+                }
+            }
+        }));
     }
 
-    sink.close().await?;
+    // Accounts for the loop's time *between* iterations: awaiting the bus,
+    // which includes wire decode and stream polling. Against `queue_wait` it
+    // localises a backlog — waits growing while `recv_idle` stays near zero
+    // mean this loop is the bottleneck; waits growing while the loop sits
+    // mostly idle mean the messages are stuck upstream of it.
+    let mut idle_from = routers_realtime::bus::wallclock();
+
+    while let Some(inbound) = source.next().await {
+        routers_realtime::bus::span_between(
+            "recv_idle",
+            idle_from,
+            routers_realtime::bus::wallclock(),
+        );
+
+        // The wire stamp is an ambient slot valid only while this message is
+        // the stream's most recent yield, so it must be captured here — by
+        // the time a worker sees the message, later yields have overwritten
+        // it. For an event it becomes the vehicle's origin; for a result it
+        // is when the matcher published it.
+        let sent_at = routers_realtime::bus::last_sent_at();
+
+        let worker = {
+            let vehicle_id = match &inbound {
+                Inbound::Event(payload) => &payload.vehicle_id,
+                Inbound::Result(result) => &result.vehicle_id,
+            };
+
+            let mut h = DefaultHasher::new();
+            vehicle_id.hash(&mut h);
+            h.finish() as usize % args.workers
+        };
+
+        txs[worker]
+            .send((routers_realtime::bus::wallclock(), sent_at, inbound))
+            .await
+            .map_err(|_| anyhow::anyhow!("worker {worker} channel closed"))?;
+
+        idle_from = routers_realtime::bus::wallclock();
+    }
+
+    // The stream has ended: dropping the senders lets each worker drain its
+    // queue and flush its sink before the process exits.
+    drop(txs);
+    for handle in handles {
+        handle.await.ok();
+    }
 
     Ok(())
 }

--- a/libs/routers_realtime/bin/orchestrator.rs
+++ b/libs/routers_realtime/bin/orchestrator.rs
@@ -192,7 +192,11 @@ async fn main() -> anyhow::Result<()> {
                             kv: &mut kv,
                         };
 
-                        match app.try_create_context(payload).instrument(span.clone()).await {
+                        match app
+                            .try_create_context(payload)
+                            .instrument(span.clone())
+                            .await
+                        {
                             Ok(ctx) => {
                                 if let Err(err) = sink
                                     .send(ctx)
@@ -212,7 +216,11 @@ async fn main() -> anyhow::Result<()> {
                         if let (Some(origin), Some(matched_at)) =
                             (origins.remove(&result.vehicle_id), sent_at)
                         {
-                            routers_realtime::bus::span_between("event_to_match", origin, matched_at);
+                            routers_realtime::bus::span_between(
+                                "event_to_match",
+                                origin,
+                                matched_at,
+                            );
                         }
 
                         trips.insert(result.vehicle_id, result.trip);
@@ -265,13 +273,6 @@ impl App<'_> {
             ..
         }: Payload,
     ) -> Result<MatchContext<E>> {
-        // Fetch deeper than the window: the store may hold points newer than
-        // this event (the historian archives straight off the raw stream, so
-        // under backlog it runs ahead of us), and those are the vehicle's future
-        // relative to the event being matched. Dropping them keeps the
-        // gap/teleport cutoff below firing on data quality, not pipeline latency
-        // — otherwise a backlog discards committed history and forces the
-        // matcher's expensive restart path exactly when it is already behind.
         let mut entries = self
             .kv
             .get_many(&vehicle_id, self.context_window * 3)
@@ -280,11 +281,10 @@ impl App<'_> {
             .context("could not get entries from redis store")?;
 
         entries.retain(|event| event.timestamp <= timestamp);
-        // Newest-first, so the cutoff below walks back in time from this event.
         entries.sort_by_key(|event| std::cmp::Reverse(event.timestamp));
         entries.truncate(self.context_window);
-        let fetched = entries.len();
 
+        let fetched = entries.len();
         let context = entries
             .into_iter()
             .inspect(|v| debug!("event: {:?}", v))
@@ -307,9 +307,6 @@ impl App<'_> {
             info_span!("history_cut", reason = "gap_or_teleport").in_scope(|| {});
         }
 
-        // The matcher solves a directed trajectory, so points must arrive
-        // chronologically; the current payload may already be archived, so
-        // dedup by timestamp after sorting.
         let mut history: Vec<RawEvent> = std::iter::once(RawEvent {
             vehicle_id: vehicle_id.clone(),
             point,
@@ -321,11 +318,11 @@ impl App<'_> {
         history.sort_by_key(|event| event.timestamp);
         history.dedup_by_key(|event| event.timestamp);
 
-        let points = history.into_iter().map(|event| event.point).collect::<Vec<Point>>();
+        let points = history
+            .into_iter()
+            .map(|event| event.point)
+            .collect::<Vec<Point>>();
 
-        // Reconcile the prior solve against the window: pure data work (trim and
-        // compare, never generating a layer), so it belongs here and not on the
-        // matcher's hot path.
         let continuation = info_span!("reconcile")
             .in_scope(|| Continuation::reconcile(self.trips.get(&vehicle_id).cloned(), &points));
 

--- a/libs/routers_realtime/src/bus/mod.rs
+++ b/libs/routers_realtime/src/bus/mod.rs
@@ -3,4 +3,4 @@ mod trace;
 
 pub use nats::NATSSink;
 pub use nats::NATSStream;
-pub use trace::{last_sent_at, span_between};
+pub use trace::{last_sent_at, span_between, wallclock};

--- a/libs/routers_realtime/src/bus/nats.rs
+++ b/libs/routers_realtime/src/bus/nats.rs
@@ -9,7 +9,7 @@ use serde::de::DeserializeOwned;
 
 pub struct NATSSink<T: Serialize> {
     client: async_nats::Client,
-    subject_of: Box<dyn Fn(&T) -> String>,
+    subject_of: Box<dyn Fn(&T) -> String + Send + Sync>,
     in_flight: Option<BoxFuture<'static, anyhow::Result<()>>>,
 
     _phantom: std::marker::PhantomData<T>,
@@ -21,7 +21,10 @@ pub struct NATSStream<T: DeserializeOwned> {
 }
 
 impl<T: Serialize> NATSSink<T> {
-    pub fn new(client: async_nats::Client, subject_of: impl Fn(&T) -> String + 'static) -> Self {
+    pub fn new(
+        client: async_nats::Client,
+        subject_of: impl Fn(&T) -> String + Send + Sync + 'static,
+    ) -> Self {
         Self {
             client,
             subject_of: Box::new(subject_of),

--- a/libs/routers_realtime/src/bus/trace.rs
+++ b/libs/routers_realtime/src/bus/trace.rs
@@ -50,6 +50,13 @@ pub fn last_sent_at() -> Option<SystemTime> {
     }
 }
 
+/// The wall clock, for stamping the start of an interval later handed to
+/// [`span_between`] — e.g. when a message enters an in-process queue. Kept
+/// here so callers need not re-litigate the wasm clock lint themselves.
+pub fn wallclock() -> SystemTime {
+    now()
+}
+
 /// Emit a span covering an arbitrary wall-clock interval — the primitive
 /// behind cross-service walltime metrics: hand it two wire stamps and the
 /// collector's spanmetrics does the rest. A no-op without an OTLP provider,

--- a/libs/routers_realtime/src/bus/trace.rs
+++ b/libs/routers_realtime/src/bus/trace.rs
@@ -1,22 +1,11 @@
 //! Trace context over the NATS hop, carried in message headers so the event
 //! payloads stay untouched.
-//!
-//! On publish, the sink stamps the message with the W3C `traceparent` of the
-//! span it was sent under, plus the wall-clock send time. On receipt, the
-//! stream closes the loop by emitting a `queue_wait` span *backdated to the
-//! send time* — so the time a message spends sitting in NATS becomes an
-//! ordinary span, and therefore an ordinary latency histogram once the
-//! collector's spanmetrics aggregates it. No hand-kept metric registry, and
-//! no timestamps in the event structs.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use web_time::{SystemTime, UNIX_EPOCH};
 
-/// The stamp must be a real wall clock — it crosses process boundaries.
-/// `web_time` re-exports std on native targets, so the wasm lint still
-/// resolves to the disallowed method; these binaries are native-only.
 #[allow(clippy::disallowed_methods)]
 fn now() -> SystemTime {
     SystemTime::now()
@@ -28,21 +17,9 @@ use opentelemetry::trace::{Span, Tracer, TracerProvider};
 use opentelemetry::{Context, KeyValue, global};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-/// Millisecond wall-clock send time; `traceparent` alone carries no times,
-/// so queue wait needs this one extra header.
 const SENT_AT: &str = "x-routers-sent-at-ms";
-
-/// The send stamp of the most recently yielded message (ms since epoch;
-/// 0 = none seen). An ambient slot rather than part of the stream's item
-/// type, so consumers that don't care never see it. Sound because every
-/// service consumes messages one at a time: between a stream yielding an
-/// item and the loop body reading this, nothing else can have been yielded.
 static LAST_SENT_AT: AtomicU64 = AtomicU64::new(0);
 
-/// When the message most recently yielded by any [`NATSStream`] in this
-/// process was published, per its wire stamp. Lets a consumer correlate
-/// walltimes across services — e.g. the orchestrator measuring raw-event →
-/// matched-result — without the event structs carrying timestamps.
 pub fn last_sent_at() -> Option<SystemTime> {
     match LAST_SENT_AT.load(Ordering::Relaxed) {
         0 => None,
@@ -50,18 +27,10 @@ pub fn last_sent_at() -> Option<SystemTime> {
     }
 }
 
-/// The wall clock, for stamping the start of an interval later handed to
-/// [`span_between`] — e.g. when a message enters an in-process queue. Kept
-/// here so callers need not re-litigate the wasm clock lint themselves.
 pub fn wallclock() -> SystemTime {
     now()
 }
 
-/// Emit a span covering an arbitrary wall-clock interval — the primitive
-/// behind cross-service walltime metrics: hand it two wire stamps and the
-/// collector's spanmetrics does the rest. A no-op without an OTLP provider,
-/// and inverted intervals (skewed clocks, out-of-order arrival) are ignored
-/// rather than recorded as nonsense.
 pub fn span_between(name: &'static str, start: SystemTime, end: SystemTime) {
     if end < start {
         return;
@@ -113,9 +82,6 @@ pub(super) fn outbound() -> HeaderMap {
     headers
 }
 
-/// Record the queue wait of an inbound message: a span covering send → now,
-/// parented to the publisher's trace. A no-op (`~ns`) when no OTLP provider
-/// is installed.
 pub(super) fn inbound(subject: &str, headers: Option<&HeaderMap>) {
     let Some(headers) = headers else { return };
     let Some(sent_at) = headers

--- a/libs/routers_transition/src/layer/generation/impls/standard.rs
+++ b/libs/routers_transition/src/layer/generation/impls/standard.rs
@@ -27,6 +27,14 @@ where
     /// radial-boundary.
     pub search_distance: f64,
 
+    /// The most candidates a layer may hold; `None` admits every edge in
+    /// range. Boundary weighing is O(candidates²), so an unbounded layer in
+    /// a dense grid dominates solve cost — the cap keeps the k best
+    /// candidates by emission cost, bounding the boundary at k² pairs while
+    /// preserving the full search reach (a wider radius no longer costs
+    /// quadratically, only the selection).
+    pub max_candidates: Option<usize>,
+
     /// The emission heuristics required to generate the layers.
     ///
     /// This is required as a caching technique since the costs for a candidate
@@ -49,11 +57,17 @@ where
             map,
             emission,
             search_distance: DEFAULT_SEARCH_DISTANCE,
+            max_candidates: None,
         }
     }
 
     pub fn with_search_distance(mut self, search_distance: f64) -> Self {
         self.search_distance = search_distance;
+        self
+    }
+
+    pub fn with_max_candidates(mut self, max_candidates: usize) -> Self {
+        self.max_candidates = Some(max_candidates);
         self
     }
 }
@@ -65,7 +79,8 @@ where
     Emmis: EmissionStrategy + Send + Sync,
 {
     fn candidates(&self, origin: &Point, layer: LayerId) -> Vec<Candidate<E>> {
-        self.map
+        let mut candidates: Vec<Candidate<E>> = self
+            .map
             .nearest_nodes_projected(origin, self.search_distance)
             .enumerate()
             .map(|(node, (position, edge))| {
@@ -80,6 +95,17 @@ where
 
                 Candidate::new(edge.thin(), position, emission, location)
             })
-            .collect()
+            .collect();
+
+        // Keep the k cheapest by emission. Positional identity is restamped
+        // by `Trip::push_layer`, so dropping interior candidates is sound.
+        if let Some(k) = self.max_candidates
+            && candidates.len() > k
+        {
+            candidates.select_nth_unstable_by_key(k - 1, |candidate| candidate.emission);
+            candidates.truncate(k);
+        }
+
+        candidates
     }
 }

--- a/libs/routers_transition/src/layer/generation/impls/standard.rs
+++ b/libs/routers_transition/src/layer/generation/impls/standard.rs
@@ -27,14 +27,6 @@ where
     /// radial-boundary.
     pub search_distance: f64,
 
-    /// The most candidates a layer may hold; `None` admits every edge in
-    /// range. Boundary weighing is O(candidates²), so an unbounded layer in
-    /// a dense grid dominates solve cost — the cap keeps the k best
-    /// candidates by emission cost, bounding the boundary at k² pairs while
-    /// preserving the full search reach (a wider radius no longer costs
-    /// quadratically, only the selection).
-    pub max_candidates: Option<usize>,
-
     /// The emission heuristics required to generate the layers.
     ///
     /// This is required as a caching technique since the costs for a candidate
@@ -57,17 +49,11 @@ where
             map,
             emission,
             search_distance: DEFAULT_SEARCH_DISTANCE,
-            max_candidates: None,
         }
     }
 
     pub fn with_search_distance(mut self, search_distance: f64) -> Self {
         self.search_distance = search_distance;
-        self
-    }
-
-    pub fn with_max_candidates(mut self, max_candidates: usize) -> Self {
-        self.max_candidates = Some(max_candidates);
         self
     }
 }
@@ -79,8 +65,7 @@ where
     Emmis: EmissionStrategy + Send + Sync,
 {
     fn candidates(&self, origin: &Point, layer: LayerId) -> Vec<Candidate<E>> {
-        let mut candidates: Vec<Candidate<E>> = self
-            .map
+        self.map
             .nearest_nodes_projected(origin, self.search_distance)
             .enumerate()
             .map(|(node, (position, edge))| {
@@ -95,17 +80,6 @@ where
 
                 Candidate::new(edge.thin(), position, emission, location)
             })
-            .collect();
-
-        // Keep the k cheapest by emission. Positional identity is restamped
-        // by `Trip::push_layer`, so dropping interior candidates is sound.
-        if let Some(k) = self.max_candidates
-            && candidates.len() > k
-        {
-            candidates.select_nth_unstable_by_key(k - 1, |candidate| candidate.emission);
-            candidates.truncate(k);
-        }
-
-        candidates
+            .collect()
     }
 }


### PR DESCRIPTION
Instead of using serial traces for streaming matching; this employs a worker pool to instead have (default=8) workers to process the tasks within the matcher, and orchestrator. This allows for greater efficiencies when processing inbound data as traces which would take a long time no longer serially-block the entire pipeline.