### PR TITLE
fix(release): manually bump versions past poisoned release-plz history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6458,7 +6458,7 @@ dependencies = [
 
 [[package]]
 name = "routers"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "codspeed-criterion-compat",
  "geo",
@@ -6553,7 +6553,7 @@ dependencies = [
 
 [[package]]
 name = "routers_realtime"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -6589,7 +6589,7 @@ dependencies = [
 
 [[package]]
 name = "routers_rpc"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "buffa",
  "clap",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "routers_shard"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "routers_transition"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "approx 0.5.1",
  "codspeed-criterion-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,16 @@ routers_viewer = { path = "libs/routers_viewer" }
 schema = { path = "schema", package = "routers_schema", version = "0.1.1" }
 routers_codec = { path = "libs/routers_codec", version = "0.1.7" }
 routers_geo = { path = "libs/routers_geo", version = "0.1.4" }
-routers_rpc = { path = "libs/routers_rpc", version = "0.1.4" }
+routers_rpc = { path = "libs/routers_rpc", version = "0.1.5" }
 routers_tiles = { path = "libs/routers_tiles", version = "0.1.3" }
 routers_network = { path = "libs/routers_network", version = "0.1.5" }
-routers_shard = { path = "libs/routers_shard", version = "0.1.1" }
-routers_realtime = { path = "libs/routers_realtime", version = "0.2.0" }
+routers_shard = { path = "libs/routers_shard", version = "0.1.2" }
+routers_realtime = { path = "libs/routers_realtime", version = "0.3.0" }
 routers_tz = { path = "libs/routers_tz", version = "0.1.2" }
 routers_tz_types = { path = "libs/routers_tz_types", version = "0.1.0" }
 routers_trellis = { path = "libs/routers_trellis", version = "0.2.0" }
-routers_transition = { path = "libs/routers_transition", version = "0.1.1" }
-routers = { path = ".", version = "0.3.0" }
+routers_transition = { path = "libs/routers_transition", version = "0.2.0" }
+routers = { path = ".", version = "0.4.0" }
 
 # Optimisation Crates
 rayon = "1.10.0"
@@ -156,7 +156,7 @@ opt-level = 3
 name = "routers"
 description = "Rust-Based Routing Tooling for System-Agnostic Maps."
 readme = "README.md"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 include = ["src/**/*", "readme.md"]

--- a/libs/routers_realtime/Cargo.toml
+++ b/libs/routers_realtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routers_realtime"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "A Demonstration for Real-Time Map Matching"
 license = "GPL-3.0-or-later"

--- a/libs/routers_rpc/Cargo.toml
+++ b/libs/routers_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routers_rpc"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "GPL-3.0-or-later"
 description = "gRPC Endpoints for Routers"

--- a/libs/routers_shard/Cargo.toml
+++ b/libs/routers_shard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routers_shard"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "GPL-3.0-or-later"
 description = "Sharding Primitives for Routers"

--- a/libs/routers_transition/Cargo.toml
+++ b/libs/routers_transition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "routers_transition"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 description = "Map-Matching Transition Graph"


### PR DESCRIPTION
## Problem

`release-plz release-pr` fails on main:

```
error: failed to select a version for the requirement `routers_transition = "^0.2.0"`
candidate versions found which didn't match: 0.1.1
```

Commits `7ee1794` and `fa6dee2` landed a self-contradictory workspace manifest: the workspace dep declared `routers_transition = 0.2.0` while the crate was still `0.1.1` (corrected in `c87c947`). `cargo package` fails outright at those two commits.

To version crates that changed since the last release (`46e5451`), release-plz walks history running `cargo package` at candidate commits to locate the published copy — and aborts fatally when it reaches the poisoned window. Since `46e5451` is the immediate parent of `7ee1794`, every changed crate hits this wall.

## Fix

Manually bump every publishable crate changed since the last release. The `release` job doesn't do the history walk (it just publishes versions absent from the registry), so it will publish and tag these from a healthy commit. After that, all registry versions map to commits after `c87c947`, and release-plz's history walk terminates before the poisoned window — permanently.

| Crate | From | To | Basis |
|---|---|---|---|
| routers_shard | 0.1.1 | 0.1.2 | fixes only |
| routers_transition | 0.1.1 | 0.2.0 | feat: streaming model (#183 follow-ups) |
| routers_rpc | 0.1.4 | 0.1.5 | fixes only |
| routers_realtime | 0.2.0 | 0.3.0 | feats: streaming matcher, prometheus tracing |
| routers | 0.3.0 | 0.4.0 | feats in window |

Verified locally: `cargo package -p <crate> --list` succeeds for all five, and `cargo update --workspace` refreshed the lockfile.

Note: changelogs are not updated here — release-plz normally writes them, and this bypasses it for one release. Also note `routers 0.4.0` will trigger the container build matrix on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)