### PR TITLE
feat: Associated Trait Typing for Network

### DIFF
--- a/benches/map_match.rs
+++ b/benches/map_match.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use routers::Match;
 use routers::transition::*;
 
-use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId, OsmNetwork};
+use routers_codec::osm::{OsmEdgeMetadata, OsmNetwork};
 use routers_network::{Entry, Metadata, Network};
 
 use criterion::{BatchSize, black_box, criterion_main};
@@ -71,7 +71,7 @@ fn target_benchmark(c: &mut criterion::Criterion) {
     group.significance_level(0.1).sample_size(30);
 
     MATCH_CASES.into_iter().for_each(|ga| {
-        let cache = Arc::new(PredicateCache::<OsmEntryId, OsmEdgeMetadata, OsmNetwork>::default());
+        let cache = Arc::new(PredicateCache::<OsmNetwork>::default());
         let graph = OsmNetwork::from_pbf(fixture!(ga.source_file)).expect("Graph must be created");
 
         let costing = DefaultEmissionCost::default();
@@ -186,7 +186,7 @@ fn target_benchmark(c: &mut criterion::Criterion) {
                     b.iter_batched(
                         || {
                             Arc::new(
-                                PredicateCache::<OsmEntryId, OsmEdgeMetadata, OsmNetwork>::default(
+                                PredicateCache::<OsmNetwork>::default(
                                 ),
                             )
                         },
@@ -211,9 +211,9 @@ fn target_benchmark(c: &mut criterion::Criterion) {
     group.finish();
 }
 
-fn bench_match<E: Entry, M: Metadata, N: Network<E, M>>(
-    graph: &dyn Match<E, M, N>,
-    opts: MatchOptions<E, M, N>,
+fn bench_match<N: Network>(
+    graph: &dyn Match<N>,
+    opts: MatchOptions<N>,
     coordinates: LineString<f64>,
 ) -> (LineString, Vec<i64>) {
     let result = graph

--- a/benches/map_match.rs
+++ b/benches/map_match.rs
@@ -184,12 +184,7 @@ fn target_benchmark(c: &mut criterion::Criterion) {
                 format!("selective_forward_solver:match:cold: {}", sc.name),
                 |b| {
                     b.iter_batched(
-                        || {
-                            Arc::new(
-                                PredicateCache::<OsmNetwork>::default(
-                                ),
-                            )
-                        },
+                        || Arc::new(PredicateCache::<OsmNetwork>::default()),
                         |cold_cache| {
                             let opts = MatchOptions::new()
                                 .with_runtime(runtime.clone())

--- a/conformance/src/matcher/routers.rs
+++ b/conformance/src/matcher/routers.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use geo::{Coord, LineString};
 use routers::primitives::PredicateCache;
 use routers::{Match, MatchOptions};
-use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId, OsmNetwork};
+use routers_codec::osm::OsmNetwork;
 
 use crate::config::RoutersConfig;
 use crate::matcher::{MatchResult, Matcher};
@@ -13,7 +13,7 @@ use crate::trace::GpsTrace;
 
 pub struct RoutersMatcher {
     graph: OsmNetwork,
-    cache: Arc<PredicateCache<OsmEntryId, OsmEdgeMetadata, OsmNetwork>>,
+    cache: Arc<PredicateCache<OsmNetwork>>,
 
     search_distance: f64,
 }
@@ -29,7 +29,7 @@ impl RoutersMatcher {
         let graph = OsmNetwork::from_pbf(&pbf_path)
             .map_err(|e| anyhow::anyhow!("loading OSM network from {}: {e}", pbf_path.display()))?;
 
-        let cache = Arc::new(PredicateCache::<OsmEntryId, OsmEdgeMetadata, OsmNetwork>::default());
+        let cache = Arc::new(PredicateCache::<OsmNetwork>::default());
 
         Ok(Self {
             graph,
@@ -45,7 +45,7 @@ impl Matcher for RoutersMatcher {
     }
 
     fn match_trace(&self, trace: &GpsTrace) -> Result<MatchResult> {
-        let opts = MatchOptions::<OsmEntryId, OsmEdgeMetadata, OsmNetwork>::new()
+        let opts = MatchOptions::<OsmNetwork>::new()
             .with_search_distance(Some(self.search_distance))
             .with_cache(self.cache.clone());
 

--- a/examples/map_match_advanced.rs
+++ b/examples/map_match_advanced.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use geo::LineString;
 use routers::{Match, MatchOptions, primitives::PredicateCache};
-use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId, OsmNetwork};
+use routers_codec::osm::{OsmEdgeMetadata, OsmNetwork};
 use routers_network::Metadata;
 
 use routers_fixtures::{SYDNEY, SYDNEY_SAVED, SYNDEY_TRIP, fixture};
@@ -29,7 +29,7 @@ fn main() {
 
     println!("Initialisation time: {}ms", now.elapsed().as_millis());
 
-    let cache = Arc::new(PredicateCache::<OsmEntryId, OsmEdgeMetadata, OsmNetwork>::default());
+    let cache = Arc::new(PredicateCache::<OsmNetwork>::default());
     let runtime = OsmEdgeMetadata::default_runtime();
 
     let match_times = (0..1_000)

--- a/libs/routers_codec/src/osm/graph.rs
+++ b/libs/routers_codec/src/osm/graph.rs
@@ -339,14 +339,11 @@ impl Default for OsmNetwork {
     }
 }
 
-impl Discovery<OsmEntryId> for OsmNetwork {
+impl Discovery for OsmNetwork {
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = Edge<Node<OsmEntryId>>> + Send + 'a>
-    where
-        OsmEntryId: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = Edge<Node<OsmEntryId>>> + Send + 'a> {
         Box::new(
             self.index_edge
                 .locate_in_envelope_intersecting(&aabb)
@@ -357,10 +354,7 @@ impl Discovery<OsmEntryId> for OsmNetwork {
     fn nodes_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Node<OsmEntryId>> + Send + 'a>
-    where
-        OsmEntryId: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = &'a Node<OsmEntryId>> + Send + 'a> {
         Box::new(self.index.locate_in_envelope(&aabb))
     }
 
@@ -380,16 +374,13 @@ impl Discovery<OsmEntryId> for OsmNetwork {
     }
 }
 
-impl Scan<OsmEntryId> for OsmNetwork {
-    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<OsmEntryId>>
-    where
-        OsmEntryId: 'a,
-    {
+impl Scan for OsmNetwork {
+    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<OsmEntryId>> {
         self.index.nearest_neighbor(point)
     }
 }
 
-impl Route<OsmEntryId> for OsmNetwork {
+impl Route for OsmNetwork {
     fn route_nodes(
         &self,
         start_node: OsmEntryId,
@@ -420,6 +411,7 @@ impl Debug for OsmNetwork {
 
 impl routers_network::DataPlane for OsmNetwork {
     type Entry = OsmEntryId;
+    type Runtime = <OsmEdgeMetadata as routers_network::Metadata>::Runtime;
     type Meta = OsmEdgeMetadata;
 
     fn metadata(&self, id: &OsmEntryId) -> Option<&OsmEdgeMetadata> {

--- a/libs/routers_network/src/mock.rs
+++ b/libs/routers_network/src/mock.rs
@@ -107,14 +107,11 @@ impl Debug for MockNetwork {
     }
 }
 
-impl Discovery<MockEntryId> for MockNetwork {
+impl Discovery for MockNetwork {
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = Edge<Node<MockEntryId>>> + Send + 'a>
-    where
-        MockEntryId: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = Edge<Node<MockEntryId>>> + Send + 'a> {
         Box::new(
             self.edge_index
                 .locate_in_envelope_intersecting(&aabb)
@@ -125,10 +122,7 @@ impl Discovery<MockEntryId> for MockNetwork {
     fn nodes_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Node<MockEntryId>> + Send + 'a>
-    where
-        MockEntryId: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = &'a Node<MockEntryId>> + Send + 'a> {
         Box::new(self.node_index.locate_in_envelope(&aabb))
     }
 
@@ -148,16 +142,13 @@ impl Discovery<MockEntryId> for MockNetwork {
     }
 }
 
-impl Scan<MockEntryId> for MockNetwork {
-    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<MockEntryId>>
-    where
-        MockEntryId: 'a,
-    {
+impl Scan for MockNetwork {
+    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<MockEntryId>> {
         self.node_index.nearest_neighbor(point)
     }
 }
 
-impl Route<MockEntryId> for MockNetwork {
+impl Route for MockNetwork {
     fn route_nodes(
         &self,
         start_node: MockEntryId,
@@ -182,6 +173,7 @@ impl Route<MockEntryId> for MockNetwork {
 
 impl DataPlane for MockNetwork {
     type Entry = MockEntryId;
+    type Runtime = ();
     type Meta = MockMetadata;
 
     fn metadata(&self, id: &MockEntryId) -> Option<&MockMetadata> {

--- a/libs/routers_network/src/traits/data_plane.rs
+++ b/libs/routers_network/src/traits/data_plane.rs
@@ -6,14 +6,14 @@
 //! [`Route`](crate::Route), [`Scan`](crate::Scan) and
 //! [`Discovery`](crate::Discovery) traits.
 //!
-//! **Associated types vs. generics.** `DataPlane` exposes its `Entry` and
+//! **Associated types, not generics.** `DataPlane` exposes its `Entry` and
 //! `Metadata` types as associated types (`type Entry`, `type Meta`) rather
 //! than trait-level generics. This means downstream consumers — viewers,
 //! exporters — can bound on `N: DataPlane` alone and pick the concrete
-//! `N::Entry` / `N::Meta` off the type, instead of threading `<E, M, N>`
-//! through every signature. The full [`Network`](crate::Network) trait is
-//! still parameterised on `<E, M>` for backwards compatibility; the two
-//! styles bridge via the blanket impl in `network.rs`.
+//! `N::Entry` / `N::Meta` / `N::Runtime` off the type, instead of threading
+//! `<E, M, N>` through every signature. The full [`Network`](crate::Network)
+//! trait follows the same style, inheriting these associated types via the
+//! blanket impl in `network.rs`.
 
 use alloc::sync::Arc;
 use core::fmt::Debug;
@@ -33,7 +33,13 @@ pub type GraphEdge<E> = (E, E, EdgeData<E>);
 /// (shortest path).
 pub trait DataPlane: Debug + Send + Sync {
     type Entry: Entry;
-    type Meta: Metadata;
+    /// The runtime configuration type of this plane's metadata.
+    ///
+    /// Declared here (and tied to `Meta` by the bound below) so consumers can
+    /// bound and name `N::Runtime` without reaching into the [`Metadata`]
+    /// trait themselves.
+    type Runtime: Clone + Debug + Send + Sync;
+    type Meta: Metadata<Runtime = Self::Runtime>;
 
     fn metadata(&self, id: &Self::Entry) -> Option<&Self::Meta>;
 
@@ -68,6 +74,7 @@ where
     T: DataPlane,
 {
     type Entry = <T as DataPlane>::Entry;
+    type Runtime = <T as DataPlane>::Runtime;
     type Meta = <T as DataPlane>::Meta;
 
     fn metadata(&self, id: &Self::Entry) -> Option<&Self::Meta> {

--- a/libs/routers_network/src/traits/discovery.rs
+++ b/libs/routers_network/src/traits/discovery.rs
@@ -3,24 +3,20 @@ use alloc::sync::Arc;
 use geo::{Destination, Geodesic, Point};
 use rstar::AABB;
 
-use crate::{Edge, Entry, Node};
+use crate::{DataPlane, Edge, Node};
 
-pub trait Discovery<E: Entry> {
+pub trait Discovery: DataPlane {
     /// Returns an iterator of edges which fall within the given AABB.
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a>
-    where
-        E: 'a;
+    ) -> Box<dyn Iterator<Item = Edge<Node<Self::Entry>>> + Send + 'a>;
 
     /// Returns an iterator of nodes which fall within the given AABB.
     fn nodes_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Node<E>> + Send + 'a>
-    where
-        E: 'a;
+    ) -> Box<dyn Iterator<Item = &'a Node<Self::Entry>> + Send + 'a>;
 
     /// A function which returns an unsorted iterator of [`Node`] references which are within
     /// the provided `distance` of the input [point](Point).
@@ -36,10 +32,7 @@ pub trait Discovery<E: Entry> {
         &'a self,
         point: &Point,
         distance: f64,
-    ) -> Box<dyn Iterator<Item = &'a Node<E>> + Send + 'a>
-    where
-        E: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = &'a Node<Self::Entry>> + Send + 'a> {
         let aabb = square_box(point, distance);
         self.nodes_in_box(aabb)
     }
@@ -58,50 +51,40 @@ pub trait Discovery<E: Entry> {
         &'a self,
         point: &Point,
         distance: f64,
-    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a>
-    where
-        E: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = Edge<Node<Self::Entry>>> + Send + 'a> {
         let aabb = square_box(point, distance);
         self.edges_in_box(aabb)
     }
 
-    fn node(&self, id: &E) -> Option<&Node<E>>;
-    fn edge(&self, source: &E, target: &E) -> Option<Edge<E>>;
+    fn node(&self, id: &Self::Entry) -> Option<&Node<Self::Entry>>;
+    fn edge(&self, source: &Self::Entry, target: &Self::Entry) -> Option<Edge<Self::Entry>>;
 }
 
 // Forward through `Arc<T>` so shard-managed networks can be held behind
 // an `Arc` without losing trait-method access.
-impl<T, E> Discovery<E> for Arc<T>
+impl<T> Discovery for Arc<T>
 where
-    T: Discovery<E>,
-    E: Entry,
+    T: Discovery,
 {
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a>
-    where
-        E: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = Edge<Node<Self::Entry>>> + Send + 'a> {
         (**self).edges_in_box(aabb)
     }
 
     fn nodes_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Node<E>> + Send + 'a>
-    where
-        E: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = &'a Node<Self::Entry>> + Send + 'a> {
         (**self).nodes_in_box(aabb)
     }
 
-    fn node(&self, id: &E) -> Option<&Node<E>> {
+    fn node(&self, id: &Self::Entry) -> Option<&Node<Self::Entry>> {
         (**self).node(id)
     }
 
-    fn edge(&self, source: &E, target: &E) -> Option<Edge<E>> {
+    fn edge(&self, source: &Self::Entry, target: &Self::Entry) -> Option<Edge<Self::Entry>> {
         (**self).edge(source, target)
     }
 }

--- a/libs/routers_network/src/traits/entry.rs
+++ b/libs/routers_network/src/traits/entry.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 /// TODO: Description
 pub trait Entry:
-    Default + Serialize + Copy + Clone + PartialEq + Eq + Ord + Hash + Debug + Send + Sync
+    Default + Serialize + Copy + Clone + PartialEq + Eq + Ord + Hash + Debug + Send + Sync + 'static
 {
     fn identifier(&self) -> i64;
 }

--- a/libs/routers_network/src/traits/network.rs
+++ b/libs/routers_network/src/traits/network.rs
@@ -4,29 +4,23 @@
 //! Pick the bound that matches your needs:
 //!
 //! - `N: DataPlane` is looser; just data access, no routing.
-//! - `N: Network<E, M>` is equivalent to `DataPlane + Scan + Route` with exposed identity types.
+//! - `N: Network` is equivalent to `DataPlane + Scan + Route`, with the
+//!   identity types exposed as associated types (`N::Entry`, `N::Meta`,
+//!   `N::Runtime`).
 
 use core::fmt::Debug;
 
-use crate::{DataPlane, Entry, Metadata, Route, Scan};
+use crate::{DataPlane, Route, Scan};
 
 // Re-exported so existing callers of `network::GraphEdge` keep working
 // after the type moved into the data-plane module.
 pub use crate::traits::data_plane::{EdgeData, GraphEdge};
 
 /// Routing-aware network — data plane + nearest-neighbour + shortest path.
-pub trait Network<E, M>:
-    DataPlane<Entry = E, Meta = M> + Scan<E> + Route<E> + Debug + Send + Sync
-where
-    E: Entry,
-    M: Metadata,
-{
-}
+///
+/// The identity types live on [`DataPlane`] as associated types, so a
+/// `N: Network` consumer names them as `N::Entry`, `N::Meta` and
+/// `N::Runtime`.
+pub trait Network: DataPlane + Scan + Route + Debug + Send + Sync {}
 
-impl<T, E, M> Network<E, M> for T
-where
-    T: DataPlane<Entry = E, Meta = M> + Scan<E> + Route<E> + Debug + Send + Sync,
-    E: Entry,
-    M: Metadata,
-{
-}
+impl<T> Network for T where T: DataPlane + Scan + Route + Debug + Send + Sync {}

--- a/libs/routers_network/src/traits/route.rs
+++ b/libs/routers_network/src/traits/route.rs
@@ -2,22 +2,27 @@ use alloc::sync::Arc;
 
 use geo::Point;
 
-use crate::{Entry, Node, Scan, edge::Weight};
+use crate::{Node, Scan, edge::Weight};
 #[cfg(feature = "tracing")]
 use tracing::Level;
 
-pub trait Route<E>: Scan<E>
-where
-    E: Entry,
-{
+pub trait Route: Scan {
     // Note to self, allow changing the strategy by making this a provider not just an attachment trait
     /// TODO: Routes ...
-    fn route_nodes(&self, start_node: E, finish_node: E) -> Option<(Weight, Vec<Node<E>>)>;
+    fn route_nodes(
+        &self,
+        start_node: Self::Entry,
+        finish_node: Self::Entry,
+    ) -> Option<(Weight, Vec<Node<Self::Entry>>)>;
 
     /// Finds the optimal route between a start and end point.
     /// Returns the weight and routing node vector.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all, level = Level::INFO))]
-    fn route_points(&self, start: &Point, finish: &Point) -> Option<(Weight, Vec<Node<E>>)> {
+    fn route_points(
+        &self,
+        start: &Point,
+        finish: &Point,
+    ) -> Option<(Weight, Vec<Node<Self::Entry>>)> {
         let start_node = self.nearest_node(start)?;
         let finish_node = self.nearest_node(finish)?;
 
@@ -25,12 +30,15 @@ where
     }
 }
 
-impl<T, E> Route<E> for Arc<T>
+impl<T> Route for Arc<T>
 where
-    T: Route<E>,
-    E: Entry,
+    T: Route,
 {
-    fn route_nodes(&self, start: E, finish: E) -> Option<(Weight, Vec<Node<E>>)> {
+    fn route_nodes(
+        &self,
+        start: Self::Entry,
+        finish: Self::Entry,
+    ) -> Option<(Weight, Vec<Node<Self::Entry>>)> {
         (**self).route_nodes(start, finish)
     }
 }

--- a/libs/routers_network/src/traits/scan.rs
+++ b/libs/routers_network/src/traits/scan.rs
@@ -2,18 +2,13 @@ use alloc::sync::Arc;
 
 use geo::{Haversine, InterpolatableLine, Line, LineLocatePoint, Point};
 
-use crate::{Discovery, Edge, Entry, Node};
+use crate::{Discovery, Edge, Node};
 
 /// Trait containing utility functions to find nodes on a root structure.
-pub trait Scan<E>: Discovery<E>
-where
-    E: Entry,
-{
+pub trait Scan: Discovery {
     /// Searches for, and returns a reference to nearest node from the origin [point](Point).
     /// This node may not exist, and therefore the return type is optional.
-    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<E>>
-    where
-        E: 'a;
+    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<Self::Entry>>;
 
     /// Returns an iterator over [`Projected`] nodes on each edge within the specified `distance`.
     /// It does so using the [`Scan::nearest_edges`] function.
@@ -28,10 +23,7 @@ where
         &'a self,
         point: &'a Point,
         distance: f64,
-    ) -> Box<dyn Iterator<Item = (Point, Edge<Node<E>>)> + Send + 'a>
-    where
-        E: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = (Point, Edge<Node<Self::Entry>>)> + Send + 'a> {
         // Total overhead of this function is negligible.
         Box::new(
             self.edges_at_distance(point, distance)
@@ -50,15 +42,11 @@ where
     }
 }
 
-impl<T, E> Scan<E> for Arc<T>
+impl<T> Scan for Arc<T>
 where
-    T: Scan<E>,
-    E: Entry,
+    T: Scan,
 {
-    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<E>>
-    where
-        E: 'a,
-    {
+    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<Self::Entry>> {
         (**self).nearest_node(point)
     }
 }

--- a/libs/routers_realtime/bin/matcher.rs
+++ b/libs/routers_realtime/bin/matcher.rs
@@ -76,7 +76,7 @@ struct Matching {
     network: Arc<Net>,
     runtime: <M as Metadata>::Runtime,
     costing: CostingStrategies<DefaultEmissionCost, DefaultTransitionCost, E>,
-    cache: Arc<PredicateCache<E, M, Net>>,
+    cache: Arc<PredicateCache<Net>>,
     search_distance: Option<f64>,
 }
 

--- a/libs/routers_rpc/examples/server.rs
+++ b/libs/routers_rpc/examples/server.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 
 use alloc::sync::Arc;
 use dotenv::dotenv;
-use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId, OsmNetwork};
+use routers_codec::osm::OsmNetwork;
 use routers_fixtures::{LOS_ANGELES, LOS_ANGELES_SAVED, fixture};
 use routers_rpc::Tracer;
 use routers_rpc::services::RPCAdapter;
@@ -12,7 +12,7 @@ use schema::connect::routers::api::r#match::v1::MatchServiceExt;
 use schema::connect::routers::api::optimise::v1::OptimiseServiceExt;
 use schema::connect::routers::api::scan::v1::ScanServiceExt;
 
-type OsmRPCAdapter = RPCAdapter<OsmNetwork, OsmEntryId, OsmEdgeMetadata>;
+type OsmRPCAdapter = RPCAdapter<OsmNetwork>;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn core::error::Error>> {

--- a/libs/routers_rpc/src/services/matcher.rs
+++ b/libs/routers_rpc/src/services/matcher.rs
@@ -89,11 +89,10 @@ impl<Ctx> Util<Ctx> {
 }
 
 #[allow(refining_impl_trait)]
-impl<T, E, M> MatchService for RPCAdapter<T, E, M>
+impl<T> MatchService for RPCAdapter<T>
 where
-    T: Network<E, M> + Send + Sync + 'static,
-    M: Metadata + MatchSdk + Send + Sync + 'static,
-    E: Entry + Send + Sync + 'static,
+    T: Network + Send + Sync + 'static,
+    T::Meta: MatchSdk,
 {
     #[cfg_attr(feature="telemetry", tracing::instrument(skip_all, level = Level::INFO))]
     async fn r#match(
@@ -108,7 +107,7 @@ where
             .options
             .as_option()
             .and_then(|opts| opts.costing_method.as_option())
-            .and_then(M::trip_context);
+            .and_then(<T::Meta>::trip_context);
 
         let solver = optimise_for(
             owned
@@ -117,7 +116,7 @@ where
                 .map(|o| o.optimise_for)
                 .unwrap_or_default(),
         );
-        let runtime = M::runtime(context);
+        let runtime = <T::Meta>::runtime(context);
 
         let opts = MatchOptions::new()
             .with_runtime(runtime.clone())
@@ -131,7 +130,7 @@ where
             .map_err(ConnectError::internal)?;
 
         Ok(MatchResponse {
-            matches: Util::<M::Runtime>::process::<E, M>(result, runtime),
+            matches: Util::<T::Runtime>::process::<T::Entry, T::Meta>(result, runtime),
             ..Default::default()
         }
         .into())
@@ -150,7 +149,7 @@ where
             .options
             .as_option()
             .and_then(|opts| opts.costing_method.as_option())
-            .and_then(M::trip_context);
+            .and_then(<T::Meta>::trip_context);
 
         let solver = optimise_for(
             owned
@@ -159,7 +158,7 @@ where
                 .map(|o| o.optimise_for)
                 .unwrap_or_default(),
         );
-        let runtime = M::runtime(context);
+        let runtime = <T::Meta>::runtime(context);
 
         let opts = MatchOptions::new()
             .with_runtime(runtime.clone())
@@ -173,7 +172,7 @@ where
             .map_err(ConnectError::internal)?;
 
         Ok(SnapResponse {
-            matches: Util::<M::Runtime>::process::<E, M>(result, runtime),
+            matches: Util::<T::Runtime>::process::<T::Entry, T::Meta>(result, runtime),
             ..Default::default()
         }
         .into())

--- a/libs/routers_rpc/src/services/mod.rs
+++ b/libs/routers_rpc/src/services/mod.rs
@@ -1,18 +1,14 @@
 use alloc::sync::Arc;
 use routers_codec::osm::OsmNetwork;
-use std::{marker::PhantomData, path::PathBuf};
+use std::path::PathBuf;
 
-pub struct RPCAdapter<T, E, M> {
+pub struct RPCAdapter<T> {
     pub(crate) inner: Arc<T>,
-    _marker: PhantomData<(E, M)>,
 }
 
-impl<T, E, M> RPCAdapter<T, E, M> {
+impl<T> RPCAdapter<T> {
     pub fn new(inner: Arc<T>) -> Self {
-        Self {
-            inner,
-            _marker: PhantomData,
-        }
+        Self { inner }
     }
 }
 

--- a/libs/routers_rpc/src/services/optimise.rs
+++ b/libs/routers_rpc/src/services/optimise.rs
@@ -1,7 +1,7 @@
 use buffa::view::OwnedView;
 use connectrpc::{ConnectError, RequestContext, ServiceResult};
 use geo::Point;
-use routers_network::{Entry, Metadata, Network};
+use routers_network::Network;
 use schema::connect::routers::api::optimise::v1::OptimiseService;
 use schema::proto::routers::api::optimise::v1::{__buffa::view::RouteRequestView, RouteResponse};
 #[cfg(feature = "telemetry")]
@@ -11,11 +11,9 @@ use crate::sdk::r#match::coordinate;
 use crate::services::RPCAdapter;
 
 #[allow(refining_impl_trait)]
-impl<T, E, M> OptimiseService for RPCAdapter<T, E, M>
+impl<T> OptimiseService for RPCAdapter<T>
 where
-    T: Network<E, M> + Send + Sync + 'static,
-    M: Metadata + Send + Sync + 'static,
-    E: Entry + Send + Sync + 'static,
+    T: Network + Send + Sync + 'static,
 {
     #[cfg_attr(feature="telemetry", tracing::instrument(skip_all, level = Level::INFO))]
     async fn route(

--- a/libs/routers_rpc/src/services/proximity.rs
+++ b/libs/routers_rpc/src/services/proximity.rs
@@ -6,7 +6,7 @@ use connectrpc::{ConnectError, RequestContext, ServiceResult};
 use core::cmp::Ordering;
 use geo::{Distance, Haversine, Point};
 use log::{debug, info};
-use routers_network::{Entry, Metadata, Network};
+use routers_network::Network;
 use schema::connect::routers::api::scan::v1::ScanService;
 use schema::proto::routers::api::scan::v1::{
     __buffa::view::{EdgeRequestView, PointRequestView, PointSnappedRequestView},
@@ -16,11 +16,9 @@ use schema::proto::routers::api::scan::v1::{
 use tracing::Level;
 
 #[allow(refining_impl_trait)]
-impl<T, E, M> ScanService for RPCAdapter<T, E, M>
+impl<T> ScanService for RPCAdapter<T>
 where
-    T: Network<E, M> + Send + Sync + 'static,
-    M: Metadata + Send + Sync + 'static,
-    E: Entry + Send + Sync + 'static,
+    T: Network + Send + Sync + 'static,
 {
     #[cfg_attr(feature="telemetry", tracing::instrument(skip_all, level = Level::INFO))]
     async fn point(

--- a/libs/routers_shard/src/composite/network.rs
+++ b/libs/routers_shard/src/composite/network.rs
@@ -36,6 +36,7 @@ where
     S: ShardId,
 {
     type Entry = E;
+    type Runtime = M::Runtime;
     type Meta = M;
 
     fn metadata(&self, id: &E) -> Option<&M> {
@@ -76,7 +77,7 @@ where
     }
 }
 
-impl<E, M, S> Discovery<E> for MultiShardNetwork<E, M, S>
+impl<E, M, S> Discovery for MultiShardNetwork<E, M, S>
 where
     E: Entry,
     M: Metadata,
@@ -85,10 +86,7 @@ where
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a>
-    where
-        E: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a> {
         let mut seen: FxHashSet<(E, E)> = FxHashSet::default();
 
         Box::new(
@@ -121,10 +119,7 @@ where
     fn nodes_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Node<E>> + Send + 'a>
-    where
-        E: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = &'a Node<E>> + Send + 'a> {
         let mut seen: FxHashSet<E> = FxHashSet::default();
 
         Box::new(
@@ -151,16 +146,13 @@ where
     }
 }
 
-impl<E, M, S> Scan<E> for MultiShardNetwork<E, M, S>
+impl<E, M, S> Scan for MultiShardNetwork<E, M, S>
 where
     E: Entry,
     M: Metadata,
     S: ShardId,
 {
-    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<E>>
-    where
-        E: 'a,
-    {
+    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<E>> {
         self.shards
             .iter()
             .filter_map(|s| s.index.nearest_neighbor(point))
@@ -173,7 +165,7 @@ where
     }
 }
 
-impl<E, M, S> Route<E> for MultiShardNetwork<E, M, S>
+impl<E, M, S> Route for MultiShardNetwork<E, M, S>
 where
     E: Entry,
     M: Metadata,

--- a/libs/routers_shard/src/network.rs
+++ b/libs/routers_shard/src/network.rs
@@ -339,7 +339,7 @@ where
     }
 }
 
-impl<E, M, S> Discovery<E> for ShardedNetwork<E, M, S>
+impl<E, M, S> Discovery for ShardedNetwork<E, M, S>
 where
     E: Entry,
     M: Metadata,
@@ -348,10 +348,7 @@ where
     fn edges_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a>
-    where
-        E: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = Edge<Node<E>>> + Send + 'a> {
         Box::new(
             self.index_edge
                 .locate_in_envelope_intersecting(&aabb)
@@ -377,10 +374,7 @@ where
     fn nodes_in_box<'a>(
         &'a self,
         aabb: AABB<Point>,
-    ) -> Box<dyn Iterator<Item = &'a Node<E>> + Send + 'a>
-    where
-        E: 'a,
-    {
+    ) -> Box<dyn Iterator<Item = &'a Node<E>> + Send + 'a> {
         Box::new(self.index.locate_in_envelope(&aabb))
     }
 
@@ -400,21 +394,18 @@ where
     }
 }
 
-impl<E, M, S> Scan<E> for ShardedNetwork<E, M, S>
+impl<E, M, S> Scan for ShardedNetwork<E, M, S>
 where
     E: Entry,
     M: Metadata,
     S: ShardId,
 {
-    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<E>>
-    where
-        E: 'a,
-    {
+    fn nearest_node<'a>(&'a self, point: &Point) -> Option<&'a Node<E>> {
         self.index.nearest_neighbor(point)
     }
 }
 
-impl<E, M, S> Route<E> for ShardedNetwork<E, M, S>
+impl<E, M, S> Route for ShardedNetwork<E, M, S>
 where
     E: Entry,
     M: Metadata,
@@ -443,6 +434,7 @@ where
     S: ShardId,
 {
     type Entry = E;
+    type Runtime = M::Runtime;
     type Meta = M;
 
     fn metadata(&self, id: &E) -> Option<&M> {

--- a/libs/routers_transition/src/candidate/collapse.rs
+++ b/libs/routers_transition/src/candidate/collapse.rs
@@ -3,8 +3,8 @@ use alloc::borrow::Cow;
 use crate::candidate::*;
 use crate::primitives::Reachable;
 use geo::LineString;
-use routers_network::Network;
 use routers_network::Entry;
+use routers_network::Network;
 
 /// A solved map-match: the chosen candidate per input point, plus the routed
 /// path between them.

--- a/libs/routers_transition/src/candidate/collapse.rs
+++ b/libs/routers_transition/src/candidate/collapse.rs
@@ -4,7 +4,7 @@ use crate::candidate::*;
 use crate::primitives::Reachable;
 use geo::LineString;
 use routers_network::Network;
-use routers_network::{Entry, Metadata};
+use routers_network::Entry;
 
 /// A solved map-match: the chosen candidate per input point, plus the routed
 /// path between them.
@@ -63,7 +63,7 @@ where
 
     /// The full driven path as a [`LineString`] — the matched positions with the
     /// routed road geometry between them filled in, showing the turns taken.
-    pub fn interpolated<M: Metadata>(&self, map: &impl Network<E, M>) -> LineString {
+    pub fn interpolated(&self, map: &impl Network<Entry = E>) -> LineString {
         self.interpolated
             .iter()
             .enumerate()

--- a/libs/routers_transition/src/candidate/entry.rs
+++ b/libs/routers_transition/src/candidate/entry.rs
@@ -122,11 +122,7 @@ where
     }
 
     /// Calculates the offset, in meters, of the candidate to it's edge by the [`VirtualTail`].
-    pub fn offset<N>(
-        &self,
-        ctx: &RoutingContext<N>,
-        variant: VirtualTail,
-    ) -> Option<f64>
+    pub fn offset<N>(&self, ctx: &RoutingContext<N>, variant: VirtualTail) -> Option<f64>
     where
         N: Network<Entry = E> + ?Sized,
     {

--- a/libs/routers_transition/src/candidate/entry.rs
+++ b/libs/routers_transition/src/candidate/entry.rs
@@ -2,7 +2,7 @@ use crate::{candidate::CandidateRef, primitives::RoutingContext};
 
 use core::fmt::Debug;
 use geo::{Bearing, Distance, Haversine, LineLocatePoint, LineString, Point};
-use routers_network::{Edge, Entry, Metadata, Network};
+use routers_network::{Edge, Entry, Network};
 use serde::{Deserialize, Serialize};
 
 /// One possible anchoring of a trajectory point: an edge of the network, the
@@ -75,7 +75,7 @@ where
     ///               (40%)            (90%)
     /// ```
     ///
-    pub fn percentage<M: Metadata>(&self, graph: &dyn Network<E, M>) -> Option<f64> {
+    pub fn percentage<N: Network<Entry = E> + ?Sized>(&self, graph: &N) -> Option<f64> {
         let edge = graph
             .line(&[self.edge.source, self.edge.target])
             .into_iter()
@@ -89,10 +89,10 @@ where
     /// ahead of `self`. `None` when the shared edge is too degenerate to locate a
     /// position on. A `Some(false)` covers candidates on different edges (which
     /// must be routed between) and same-edge back-tracking.
-    pub fn directly_reachable<M: Metadata>(
+    pub fn directly_reachable<N: Network<Entry = E> + ?Sized>(
         &self,
         other: &Candidate<E>,
-        graph: &dyn Network<E, M>,
+        graph: &N,
     ) -> Option<bool> {
         if self.edge.id.index() != other.edge.id.index() {
             return Some(false);
@@ -106,10 +106,9 @@ where
     }
 
     /// Get the bearing of the candidate's edge (source endpoint -> target endpoint).
-    pub fn edge_heading<M, N>(&self, ctx: &RoutingContext<E, M, N>) -> Option<f64>
+    pub fn edge_heading<N>(&self, ctx: &RoutingContext<N>) -> Option<f64>
     where
-        M: Metadata,
-        N: Network<E, M>,
+        N: Network<Entry = E> + ?Sized,
     {
         let s = ctx.map.point(&self.edge.source)?;
         let t = ctx.map.point(&self.edge.target)?;
@@ -123,13 +122,13 @@ where
     }
 
     /// Calculates the offset, in meters, of the candidate to it's edge by the [`VirtualTail`].
-    pub fn offset<N, M: Metadata>(
+    pub fn offset<N>(
         &self,
-        ctx: &RoutingContext<E, M, N>,
+        ctx: &RoutingContext<N>,
         variant: VirtualTail,
     ) -> Option<f64>
     where
-        N: Network<E, M>,
+        N: Network<Entry = E> + ?Sized,
     {
         match variant {
             VirtualTail::ToSource => {

--- a/libs/routers_transition/src/candidate/route.rs
+++ b/libs/routers_transition/src/candidate/route.rs
@@ -43,7 +43,7 @@ where
     E: Entry,
     M: Metadata,
 {
-    pub fn new(collapsed_path: CollapsedPath<'_, E>, network: &impl Network<E, M>) -> Self {
+    pub fn new(collapsed_path: CollapsedPath<'_, E>, network: &impl Network<Entry = E, Meta = M>) -> Self {
         // Collect matched candidates in order.  Virtual start/end nodes have no
         // lookup entry so flat_map quietly skips them.
         let matched: Vec<Candidate<E>> = collapsed_path
@@ -191,7 +191,7 @@ where
     E: Entry,
     M: Metadata,
 {
-    pub fn new(candidate: Candidate<E>, network: &impl Network<E, M>) -> Option<Self> {
+    pub fn new(candidate: Candidate<E>, network: &impl Network<Entry = E, Meta = M>) -> Option<Self> {
         Some(PathElement {
             point: candidate.position.0,
             edge: network.fatten(&candidate.edge)?,
@@ -199,7 +199,7 @@ where
         })
     }
 
-    pub fn from_edge_source(edge: Edge<Node<E>>, network: &impl Network<E, M>) -> Option<Self> {
+    pub fn from_edge_source(edge: Edge<Node<E>>, network: &impl Network<Entry = E, Meta = M>) -> Option<Self> {
         Some(PathElement {
             point: edge.source.position.0,
             metadata: network.metadata(edge.id())?.clone(),
@@ -207,7 +207,7 @@ where
         })
     }
 
-    pub fn from_edge_target(edge: Edge<Node<E>>, network: &impl Network<E, M>) -> Option<Self> {
+    pub fn from_edge_target(edge: Edge<Node<E>>, network: &impl Network<Entry = E, Meta = M>) -> Option<Self> {
         Some(PathElement {
             point: edge.target.position.0,
             metadata: network.metadata(edge.id())?.clone(),

--- a/libs/routers_transition/src/candidate/route.rs
+++ b/libs/routers_transition/src/candidate/route.rs
@@ -43,7 +43,10 @@ where
     E: Entry,
     M: Metadata,
 {
-    pub fn new(collapsed_path: CollapsedPath<'_, E>, network: &impl Network<Entry = E, Meta = M>) -> Self {
+    pub fn new(
+        collapsed_path: CollapsedPath<'_, E>,
+        network: &impl Network<Entry = E, Meta = M>,
+    ) -> Self {
         // Collect matched candidates in order.  Virtual start/end nodes have no
         // lookup entry so flat_map quietly skips them.
         let matched: Vec<Candidate<E>> = collapsed_path
@@ -191,7 +194,10 @@ where
     E: Entry,
     M: Metadata,
 {
-    pub fn new(candidate: Candidate<E>, network: &impl Network<Entry = E, Meta = M>) -> Option<Self> {
+    pub fn new(
+        candidate: Candidate<E>,
+        network: &impl Network<Entry = E, Meta = M>,
+    ) -> Option<Self> {
         Some(PathElement {
             point: candidate.position.0,
             edge: network.fatten(&candidate.edge)?,
@@ -199,7 +205,10 @@ where
         })
     }
 
-    pub fn from_edge_source(edge: Edge<Node<E>>, network: &impl Network<Entry = E, Meta = M>) -> Option<Self> {
+    pub fn from_edge_source(
+        edge: Edge<Node<E>>,
+        network: &impl Network<Entry = E, Meta = M>,
+    ) -> Option<Self> {
         Some(PathElement {
             point: edge.source.position.0,
             metadata: network.metadata(edge.id())?.clone(),
@@ -207,7 +216,10 @@ where
         })
     }
 
-    pub fn from_edge_target(edge: Edge<Node<E>>, network: &impl Network<Entry = E, Meta = M>) -> Option<Self> {
+    pub fn from_edge_target(
+        edge: Edge<Node<E>>,
+        network: &impl Network<Entry = E, Meta = M>,
+    ) -> Option<Self> {
         Some(PathElement {
             point: edge.target.position.0,
             metadata: network.metadata(edge.id())?.clone(),

--- a/libs/routers_transition/src/costing/transition.rs
+++ b/libs/routers_transition/src/costing/transition.rs
@@ -4,7 +4,7 @@ use crate::costing::Strategy;
 use crate::map_path::MapPath;
 use crate::primitives::{ResolutionMethod, RoutingContext};
 use geo::{Distance, Haversine, Point};
-use routers_network::{Entry, Metadata, Network};
+use routers_network::{Entry, Network};
 
 pub trait TransitionStrategy<E>: for<'a> Strategy<TransitionContext<'a, E>> {}
 impl<T, E> TransitionStrategy<E> for T where T: for<'a> Strategy<TransitionContext<'a, E>> {}
@@ -135,14 +135,13 @@ where
     /// Candidate positions and the [`MapPath`] representation of the optimal
     /// path are derived internally — the caller supplies the candidate IDs
     /// and the map-node sequence between them.
-    pub fn new<M, N>(
-        ctx: &'a RoutingContext<'a, E, M, N>,
+    pub fn new<N>(
+        ctx: &'a RoutingContext<'a, N>,
         (src, trg): (CandidateRef, CandidateRef),
         map_path: &'a [E],
     ) -> Option<Self>
     where
-        M: Metadata,
-        N: Network<E, M>,
+        N: Network<Entry = E> + ?Sized,
     {
         let source = ctx.candidate(&src)?;
         let target = ctx.candidate(&trg)?;

--- a/libs/routers_transition/src/layer/generation/impls/standard.rs
+++ b/libs/routers_transition/src/layer/generation/impls/standard.rs
@@ -3,7 +3,7 @@ use crate::costing::{EmissionContext, EmissionStrategy};
 use crate::r#match::DEFAULT_SEARCH_DISTANCE;
 use crate::{candidate::Candidate, layer::generation::LayerGeneration};
 use geo::{Distance, Haversine, Point};
-use routers_network::{Entry, Metadata, Network};
+use routers_network::Network;
 use routers_trellis::{LayerId, NodeId};
 
 /// The default candidate generator: a radius search projected onto nearby
@@ -13,10 +13,9 @@ use routers_trellis::{LayerId, NodeId};
 /// trajectory point contributes one candidate — the point's projection onto
 /// that edge — priced by the supplied emission strategy.
 #[derive(Copy, Clone)]
-pub struct StandardGenerator<'a, E, M, Emmis>
+pub struct StandardGenerator<'a, N, Emmis>
 where
-    E: Entry,
-    M: Metadata,
+    N: Network + ?Sized,
     Emmis: EmissionStrategy + Send + Sync,
 {
     /// The maximum distance by which the generator will search for nodes,
@@ -34,17 +33,16 @@ where
     pub emission: &'a Emmis,
 
     /// The routing map used to pull candidates from, and provide layout context.
-    map: &'a dyn Network<E, M>,
+    map: &'a N,
 }
 
-impl<'a, E, M, Emmis> StandardGenerator<'a, E, M, Emmis>
+impl<'a, N, Emmis> StandardGenerator<'a, N, Emmis>
 where
-    E: Entry,
-    M: Metadata,
+    N: Network + ?Sized,
     Emmis: EmissionStrategy + Send + Sync,
 {
     /// Creates a [`StandardGenerator`] from a map and emission heuristic.
-    pub fn new(map: &'a dyn Network<E, M>, emission: &'a Emmis) -> Self {
+    pub fn new(map: &'a N, emission: &'a Emmis) -> Self {
         StandardGenerator {
             map,
             emission,
@@ -58,13 +56,12 @@ where
     }
 }
 
-impl<Emmis, E, M> LayerGeneration<E> for StandardGenerator<'_, E, M, Emmis>
+impl<Emmis, N> LayerGeneration<N::Entry> for StandardGenerator<'_, N, Emmis>
 where
-    E: Entry,
-    M: Metadata,
+    N: Network + ?Sized,
     Emmis: EmissionStrategy + Send + Sync,
 {
-    fn candidates(&self, origin: &Point, layer: LayerId) -> Vec<Candidate<E>> {
+    fn candidates(&self, origin: &Point, layer: LayerId) -> Vec<Candidate<N::Entry>> {
         self.map
             .nearest_nodes_projected(origin, self.search_distance)
             .enumerate()

--- a/libs/routers_transition/src/map_path/entity.rs
+++ b/libs/routers_transition/src/map_path/entity.rs
@@ -4,7 +4,7 @@ use core::{
 };
 
 use geo::{Bearing, Distance, Haversine, LineString, Point};
-use routers_network::{Entry, Metadata, Network, Node};
+use routers_network::{Entry, Network, Node};
 
 /// For asking geometric questions of a path over the network, use a
 /// [`MapPath`].
@@ -45,7 +45,7 @@ where
 
     // TODO: This should be done lazily, since we may not need the points but possibly OK as is.
     /// Creates a new path from a slice of node ids, and a map to look up their locations.
-    pub fn new_with_map<M: Metadata>(map: &dyn Network<E, M>, nodes: &[E]) -> Self {
+    pub fn new_with_map<N: Network<Entry = E> + ?Sized>(map: &N, nodes: &[E]) -> Self {
         let resolved = map.line(nodes);
 
         let nodes = resolved

--- a/libs/routers_transition/src/match/definition.rs
+++ b/libs/routers_transition/src/match/definition.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 
 use geo::LineString;
-use routers_network::{Entry, Metadata, Network};
+use routers_network::{Metadata, Network};
 
 use crate::{
     candidate::RoutedPath,
@@ -25,7 +25,7 @@ pub const DEFAULT_SEARCH_DISTANCE: f64 = 50.0; // 50m
 /// let routed = network.r#match(linestring, opts)?;
 /// ```
 #[derive(Clone, Debug)]
-pub struct MatchOptions<E: Entry, M: Metadata, N: Network<E, M>> {
+pub struct MatchOptions<N: Network> {
     /// The distance the solver will use to search for candidates
     /// around every given input position.
     ///
@@ -55,36 +55,36 @@ pub struct MatchOptions<E: Entry, M: Metadata, N: Network<E, M>> {
     /// Alternatively, it may be created directly if the value and
     /// type are known. This may be particularly useful in a custom
     /// implementation of graph metadata.
-    pub runtime: M::Runtime,
+    pub runtime: N::Runtime,
 
     /// The variant of solver to be used by the matcher.
     /// Any given value of the enumeration is accepted,
     pub solver: SolverVariant,
 
-    pub cache: Option<Arc<PredicateCache<E, M, N>>>,
+    pub cache: Option<Arc<PredicateCache<N>>>,
 }
 
-impl<E: Entry, M: Metadata, N: Network<E, M>> Default for MatchOptions<E, M, N> {
+impl<N: Network> Default for MatchOptions<N> {
     fn default() -> Self {
         Self {
             search_distance: DEFAULT_SEARCH_DISTANCE,
-            runtime: M::default_runtime(),
+            runtime: <N::Meta>::default_runtime(),
             solver: SolverVariant::default(),
             cache: None,
         }
     }
 }
 
-impl<E: Entry, M: Metadata, N: Network<E, M>> MatchOptions<E, M, N> {
+impl<N: Network> MatchOptions<N> {
     pub fn new() -> Self {
         Self::default()
     }
 
-    pub fn with_runtime(self, runtime: M::Runtime) -> Self {
+    pub fn with_runtime(self, runtime: N::Runtime) -> Self {
         Self { runtime, ..self }
     }
 
-    pub fn with_cache(self, cache: Arc<PredicateCache<E, M, N>>) -> Self {
+    pub fn with_cache(self, cache: Arc<PredicateCache<N>>) -> Self {
         Self {
             cache: Some(cache),
             ..self
@@ -114,11 +114,9 @@ impl<E: Entry, M: Metadata, N: Network<E, M>> MatchOptions<E, M, N> {
 /// pipeline, and resolves the result against the network into a
 /// [`RoutedPath`]. When the default options suffice, [`MatchSimpleExt`] drops
 /// the options argument too.
-pub trait Match<E, M, N>
+pub trait Match<N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
     /// Matches a given [linestring](LineString) against the map, collapsing
     /// the input onto the network to find the most plausible match for every
@@ -126,8 +124,8 @@ where
     fn r#match(
         &self,
         linestring: LineString,
-        opts: MatchOptions<E, M, N>,
-    ) -> Result<RoutedPath<E, M>, MatchError>;
+        opts: MatchOptions<N>,
+    ) -> Result<RoutedPath<N::Entry, N::Meta>, MatchError>;
 
     /// Snaps a given linestring against the map: each position moved to its
     /// most plausible road position, without routing between them.
@@ -136,27 +134,28 @@ where
     fn snap(
         &self,
         linestring: LineString,
-        opts: MatchOptions<E, M, N>,
-    ) -> Result<RoutedPath<E, M>, MatchError>;
+        opts: MatchOptions<N>,
+    ) -> Result<RoutedPath<N::Entry, N::Meta>, MatchError>;
 }
 
 /// Simplifies the interface to the `Match` trait, providing methods that uses appropriate options.
-pub trait MatchSimpleExt<E, M, N>: Match<E, M, N>
+pub trait MatchSimpleExt<N>: Match<N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
-    fn r#match_simple(&self, linestring: LineString) -> Result<RoutedPath<E, M>, MatchError> {
+    fn r#match_simple(
+        &self,
+        linestring: LineString,
+    ) -> Result<RoutedPath<N::Entry, N::Meta>, MatchError> {
         self.r#match(linestring, MatchOptions::default())
     }
 
-    fn snap_simple(&self, linestring: LineString) -> Result<RoutedPath<E, M>, MatchError> {
+    fn snap_simple(
+        &self,
+        linestring: LineString,
+    ) -> Result<RoutedPath<N::Entry, N::Meta>, MatchError> {
         self.snap(linestring, MatchOptions::default())
     }
 }
 
-impl<T, E: Entry, M: Metadata, N: Network<E, M>> MatchSimpleExt<E, M, N> for T where
-    T: Match<E, M, N>
-{
-}
+impl<T, N: Network> MatchSimpleExt<N> for T where T: Match<N> {}

--- a/libs/routers_transition/src/match/implementation.rs
+++ b/libs/routers_transition/src/match/implementation.rs
@@ -8,21 +8,20 @@ use crate::primitives::MatchError;
 use geo::LineString;
 use log::info;
 use routers_network::Network;
-use routers_network::{Entry, Metadata};
 
 #[cfg(feature = "tracing")]
 use tracing::Level;
 
-impl<T, E: Entry, M: Metadata> Match<E, M, T> for T
+impl<T> Match<T> for T
 where
-    T: Network<E, M>,
+    T: Network,
 {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all, level = Level::INFO))]
     fn r#match(
         &self,
         linestring: LineString,
-        opts: MatchOptions<E, M, T>,
-    ) -> Result<RoutedPath<E, M>, MatchError> {
+        opts: MatchOptions<T>,
+    ) -> Result<RoutedPath<T::Entry, T::Meta>, MatchError> {
         info!("Finding matched route for {} positions", linestring.0.len());
 
         let costing = CostingStrategies::default();
@@ -43,8 +42,8 @@ where
     fn snap(
         &self,
         _linestring: LineString,
-        _opts: MatchOptions<E, M, T>,
-    ) -> Result<RoutedPath<E, M>, MatchError> {
+        _opts: MatchOptions<T>,
+    ) -> Result<RoutedPath<T::Entry, T::Meta>, MatchError> {
         unimplemented!()
     }
 }

--- a/libs/routers_transition/src/matcher/entity.rs
+++ b/libs/routers_transition/src/matcher/entity.rs
@@ -1,8 +1,7 @@
 use alloc::borrow::Cow;
-use core::marker::PhantomData;
 
 use geo::{LineString, Point};
-use routers_network::{Entry, Metadata, Network};
+use routers_network::{Entry, Network};
 use routers_trellis::{LayerId, Path, SolveError, TrellisError, ViterbiSolver};
 
 use crate::candidate::{CandidateRef, CollapsedPath};
@@ -70,23 +69,19 @@ use crate::weigh::{Weigher, frontier_collapse};
 /// // given any solved point, you can obtain this information by using `snapshot(..)`.
 /// let collapsed = matcher.snapshot(&mut trip)?;
 /// ```
-pub struct Matcher<'a, Emmis, Trans, G, W, E, M, N>
+pub struct Matcher<'a, Emmis, Trans, G, W, N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
     Emmis: EmissionStrategy + Send + Sync,
-    Trans: TransitionStrategy<E> + Send + Sync,
-    G: LayerGeneration<E>,
-    W: Weigher<E, M, N> + Sync,
+    Trans: TransitionStrategy<N::Entry> + Send + Sync,
+    G: LayerGeneration<N::Entry>,
+    W: Weigher<N> + Sync,
 {
     map: &'a N,
-    heuristics: &'a CostingStrategies<Emmis, Trans, E>,
+    heuristics: &'a CostingStrategies<Emmis, Trans, N::Entry>,
     generator: G,
     weigher: W,
-    runtime: &'a M::Runtime,
-
-    _phantom: PhantomData<(E, M)>,
+    runtime: &'a N::Runtime,
 }
 
 /// The store-independent parts of a [`CollapsedPath`], as derived by
@@ -100,22 +95,20 @@ where
     interpolated: Vec<Reachable<E>>,
 }
 
-impl<'a, Emmis, Trans, G, W, E, M, N> Matcher<'a, Emmis, Trans, G, W, E, M, N>
+impl<'a, Emmis, Trans, G, W, N> Matcher<'a, Emmis, Trans, G, W, N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
     Emmis: EmissionStrategy + Send + Sync,
-    Trans: TransitionStrategy<E> + Send + Sync,
-    G: LayerGeneration<E>,
-    W: Weigher<E, M, N> + Sync,
+    Trans: TransitionStrategy<N::Entry> + Send + Sync,
+    G: LayerGeneration<N::Entry>,
+    W: Weigher<N> + Sync,
 {
     pub fn new(
         map: &'a N,
-        heuristics: &'a CostingStrategies<Emmis, Trans, E>,
+        heuristics: &'a CostingStrategies<Emmis, Trans, N::Entry>,
         generator: G,
         weigher: W,
-        runtime: &'a M::Runtime,
+        runtime: &'a N::Runtime,
     ) -> Self {
         Self {
             map,
@@ -123,17 +116,16 @@ where
             generator,
             weigher,
             runtime,
-            _phantom: PhantomData,
         }
     }
 
     /// A fresh, empty [`Trip`].
-    pub fn begin(&self) -> Trip<E> {
+    pub fn begin(&self) -> Trip<N::Entry> {
         Trip::new()
     }
 
     /// The [`RoutingContext`] over a trip's candidates.
-    fn context<'b>(&'b self, trip: &'b Trip<E>) -> RoutingContext<'b, E, M, N> {
+    fn context<'b>(&'b self, trip: &'b Trip<N::Entry>) -> RoutingContext<'b, N> {
         RoutingContext {
             candidates: trip.candidates(),
             map: self.map,
@@ -148,7 +140,7 @@ where
     /// A point with no road candidate within the generator's search radius is
     /// rejected ([`UnanchoredError`]) and leaves the trip unchanged, so the
     /// caller may drop or retry the point.
-    pub fn push(&self, trip: &mut Trip<E>, origin: Point) -> Result<LayerId, MatchError> {
+    pub fn push(&self, trip: &mut Trip<N::Entry>, origin: Point) -> Result<LayerId, MatchError> {
         let layer = trip.next_id();
         let candidates = self.generator.candidates(&origin, layer);
 
@@ -169,7 +161,7 @@ where
     ///
     /// Any point with no candidate rejects the whole batch ([`UnanchoredError`]
     /// reporting *every* such point) and leaves the trip unchanged.
-    pub fn extend(&self, trip: &mut Trip<E>, points: &[Point]) -> Result<(), MatchError> {
+    pub fn extend(&self, trip: &mut Trip<N::Entry>, points: &[Point]) -> Result<(), MatchError> {
         let first_layer = trip.next_id();
         let per_layer = self.generator.generate(points, first_layer);
 
@@ -198,7 +190,7 @@ where
     ///
     /// Already-resolved boundaries are never recomputed, so re-solving after an
     /// append weighs only the new boundaries (plus a µs-scale full DP pass).
-    pub fn solve<'b>(&self, trip: &'b mut Trip<E>) -> Result<&'b Path, MatchError> {
+    pub fn solve<'b>(&self, trip: &'b mut Trip<N::Entry>) -> Result<&'b Path, MatchError> {
         let mut trellis = match trip.take_state() {
             TripState::Empty => return Err(TrellisError::Empty.into()),
             TripState::Solved(solved) => {
@@ -253,7 +245,7 @@ where
     /// The trip is not consumed: the snapshot borrows its candidates, so the
     /// caller may keep streaming once the snapshot is dropped (or detached
     /// with [`CollapsedPath::into_owned`]).
-    pub fn snapshot<'t>(&self, trip: &'t mut Trip<E>) -> Result<CollapsedPath<'t, E>, MatchError> {
+    pub fn snapshot<'t>(&self, trip: &'t mut Trip<N::Entry>) -> Result<CollapsedPath<'t, N::Entry>, MatchError> {
         let Collapse {
             cost,
             route,
@@ -271,7 +263,7 @@ where
     /// Match a whole trajectory in one call: batch candidate generation,
     /// parallel weighing, solve, and collapse. The trip is internal here, so
     /// the result owns its candidates.
-    pub fn r#match(&self, linestring: LineString) -> Result<CollapsedPath<'a, E>, MatchError> {
+    pub fn r#match(&self, linestring: LineString) -> Result<CollapsedPath<'a, N::Entry>, MatchError> {
         let mut trip = self.begin();
         self.extend(&mut trip, &linestring.into_points())?;
 
@@ -292,7 +284,7 @@ where
 
     /// Solve (if pending) and derive the collapse: total cost, the chosen
     /// candidate per layer, and each hop's routed geometry.
-    fn collapse(&self, trip: &mut Trip<E>) -> Result<Collapse<E>, MatchError> {
+    fn collapse(&self, trip: &mut Trip<N::Entry>) -> Result<Collapse<N::Entry>, MatchError> {
         let path = self.solve(trip)?;
         let cost = path.cost;
 
@@ -320,10 +312,10 @@ where
     /// the caller owns any per-tick memoisation.
     pub fn hop(
         &self,
-        trip: &Trip<E>,
+        trip: &Trip<N::Entry>,
         from: CandidateRef,
         to: CandidateRef,
-    ) -> Option<Reachable<E>> {
+    ) -> Option<Reachable<N::Entry>> {
         let ctx = self.context(trip);
         self.weigher.reach(&ctx, from, to)
     }
@@ -339,7 +331,7 @@ where
 
     /// Boundary breaks as a [`DisconnectedError`], carrying the origins of the
     /// layers on each side.
-    fn disconnected(&self, trip: &Trip<E>, breaks: Vec<LayerId>) -> MatchError {
+    fn disconnected(&self, trip: &Trip<N::Entry>, breaks: Vec<LayerId>) -> MatchError {
         let breaks = breaks
             .into_iter()
             .map(|boundary| {

--- a/libs/routers_transition/src/matcher/entity.rs
+++ b/libs/routers_transition/src/matcher/entity.rs
@@ -245,7 +245,10 @@ where
     /// The trip is not consumed: the snapshot borrows its candidates, so the
     /// caller may keep streaming once the snapshot is dropped (or detached
     /// with [`CollapsedPath::into_owned`]).
-    pub fn snapshot<'t>(&self, trip: &'t mut Trip<N::Entry>) -> Result<CollapsedPath<'t, N::Entry>, MatchError> {
+    pub fn snapshot<'t>(
+        &self,
+        trip: &'t mut Trip<N::Entry>,
+    ) -> Result<CollapsedPath<'t, N::Entry>, MatchError> {
         let Collapse {
             cost,
             route,
@@ -263,7 +266,10 @@ where
     /// Match a whole trajectory in one call: batch candidate generation,
     /// parallel weighing, solve, and collapse. The trip is internal here, so
     /// the result owns its candidates.
-    pub fn r#match(&self, linestring: LineString) -> Result<CollapsedPath<'a, N::Entry>, MatchError> {
+    pub fn r#match(
+        &self,
+        linestring: LineString,
+    ) -> Result<CollapsedPath<'a, N::Entry>, MatchError> {
         let mut trip = self.begin();
         self.extend(&mut trip, &linestring.into_points())?;
 

--- a/libs/routers_transition/src/primitives/cache.rs
+++ b/libs/routers_transition/src/primitives/cache.rs
@@ -1,48 +1,51 @@
 use alloc::sync::Arc;
 use core::fmt::Debug;
 use geo::Distance;
-use routers_network::{Entry, Metadata, Network};
+use routers_network::{DataPlane, Metadata, Network};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use scc::HashMap;
 
-pub trait CacheKey: Entry {}
-impl<T> CacheKey for T where T: Entry {}
-
 /// A generic read-through cache for a hashmap-backed data structure
-#[derive(Debug)]
-pub struct CacheMap<K, V, M, N, Meta>
+pub struct CacheMap<V, N, Meta>
 where
-    K: CacheKey,
     V: Debug,
-    M: Metadata,
     Meta: Debug,
-    N: Network<K, M>,
+    N: Network,
 {
-    pub(crate) map: HashMap<K, Arc<V>, FxBuildHasher>,
+    pub(crate) map: HashMap<N::Entry, Arc<V>, FxBuildHasher>,
     pub(crate) metadata: Meta,
+}
 
-    _marker: core::marker::PhantomData<M>,
-    _marker2: core::marker::PhantomData<N>,
+// Hand-rolled so the `Debug` bound stays off the moka cache (whose own `Debug`,
+// and its stats accessors, would drag `V: Send + Sync + 'static` onto every use
+// of `CacheMap`). The entries themselves are elided.
+impl<V, N, Meta> Debug for CacheMap<V, N, Meta>
+where
+    V: Debug,
+    Meta: Debug,
+    N: Network,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CacheMap")
+            .field("metadata", &self.metadata)
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug)]
-pub struct LockedMap<K, V, M, N, Meta>(Arc<CacheMap<K, V, M, N, Meta>>)
+pub struct LockedMap<V, N, Meta>(Arc<CacheMap<V, N, Meta>>)
 where
-    LockedMap<K, V, M, N, Meta>: Calculable<K, M, N, V>,
-    M: Metadata,
-    K: CacheKey,
-    N: Network<K, M>,
+    LockedMap<V, N, Meta>: Calculable<N, V>,
+    N: Network,
     V: Debug,
     Meta: Debug;
 
-impl<K, V, M, N, Meta> Default for LockedMap<K, V, M, N, Meta>
+impl<V, N, Meta> Default for LockedMap<V, N, Meta>
 where
-    LockedMap<K, V, M, N, Meta>: Calculable<K, M, N, V>,
-    CacheMap<K, V, M, N, Meta>: Default,
-    M: Metadata,
-    K: CacheKey,
+    LockedMap<V, N, Meta>: Calculable<N, V>,
+    CacheMap<V, N, Meta>: Default,
     V: Debug,
-    N: Network<K, M>,
+    N: Network,
     Meta: Debug,
 {
     fn default() -> Self {
@@ -50,13 +53,11 @@ where
     }
 }
 
-impl<K, V, M, N, Meta> Clone for LockedMap<K, V, M, N, Meta>
+impl<V, N, Meta> Clone for LockedMap<V, N, Meta>
 where
-    LockedMap<K, V, M, N, Meta>: Calculable<K, M, N, V>,
-    CacheMap<K, V, M, N, Meta>: Default,
-    N: Network<K, M>,
-    M: Metadata,
-    K: CacheKey,
+    LockedMap<V, N, Meta>: Calculable<N, V>,
+    CacheMap<V, N, Meta>: Default,
+    N: Network,
     V: Debug,
     Meta: Debug,
 {
@@ -65,13 +66,11 @@ where
     }
 }
 
-impl<K, V, N, M, Meta> LockedMap<K, V, M, N, Meta>
+impl<V, N, Meta> LockedMap<V, N, Meta>
 where
-    LockedMap<K, V, M, N, Meta>: Calculable<K, M, N, V>,
-    M: Metadata,
-    K: CacheKey,
-    N: Network<K, M>,
-    V: Debug,
+    LockedMap<V, N, Meta>: Calculable<N, V>,
+    N: Network,
+    V: Debug + Send + Sync + 'static,
     Meta: Debug,
 {
     /// Exposes a query call for the cache map, allowing the caller
@@ -84,9 +83,9 @@ where
     ///
     /// The function returns the value, [`V`] wrapped in a reference counter.
     /// This, therefore does not require [`V`] to be `Clone`. However, it
-    /// consumes an owned value of the key, [`K`], which is required for the
-    /// call to the [`Calculable::calculate`] function.
-    pub fn query(&self, ctx: &RoutingContext<K, M, N>, key: K) -> Arc<V> {
+    /// consumes an owned value of the key, [`N::Entry`], which is required
+    /// for the call to the [`Calculable::calculate`] function.
+    pub fn query(&self, ctx: &RoutingContext<N>, key: N::Entry) -> Arc<V> {
         if let Some(value) = self.0.map.get(&key) {
             return Arc::clone(value.get());
         }
@@ -98,29 +97,24 @@ where
     }
 }
 
-impl<K, V, M, N, Meta> Default for CacheMap<K, V, M, N, Meta>
+impl<V, N, Meta> Default for CacheMap<V, N, Meta>
 where
-    K: CacheKey,
-    V: Debug,
-    M: Metadata,
-    N: Network<K, M>,
+    V: Debug + Send + Sync + 'static,
+    N: Network,
     Meta: Default + Debug,
 {
     fn default() -> Self {
         Self {
             map: HashMap::default(),
             metadata: Meta::default(),
-
-            _marker: core::marker::PhantomData,
-            _marker2: core::marker::PhantomData,
         }
     }
 }
 
 /// Implementation of a routing-domain calculable KV pair.
 ///
-/// Asserts that the value, [`V`] can be generated from the key, [`K`],
-/// given routing context, and the base structure.
+/// Asserts that the value, [`V`] can be generated from the key
+/// (the network's [`Entry`]), given routing context, and the base structure.
 ///
 /// ### Examples
 ///
@@ -130,13 +124,13 @@ where
 /// The [`SuccessorsCache`], given an underlying map key,
 /// can derive the successors using the routing map and an
 /// upper-bounded dijkstra algorithm.
-pub trait Calculable<E: CacheKey, M: Metadata, N: Network<E, M>, V> {
+pub trait Calculable<N: Network, V> {
     /// The concrete implementation of the function which derives the
-    /// value, [`V`], from the key, [`K`].
+    /// value, [`V`], from the key.
     ///
     /// The function parameters include relevant [`RoutingContext`] which
     /// may be required for the calculation.
-    fn calculate(&self, ctx: &RoutingContext<E, M, N>, key: E) -> V;
+    fn calculate(&self, ctx: &RoutingContext<N>, key: N::Entry) -> V;
 }
 
 mod successor {
@@ -153,13 +147,11 @@ mod successor {
     ///
     /// It accepts a node id as input, from which it will obtain all outgoing
     /// edges and obtain the distances to each one as a [`WeightAndDistance`].
-    pub type SuccessorsCache<E, M, N> = LockedMap<E, SuccessorWeights<E>, M, N, ()>;
+    pub type SuccessorsCache<N> = LockedMap<SuccessorWeights<<N as DataPlane>::Entry>, N, ()>;
 
-    impl<E: CacheKey, M: Metadata, N: Network<E, M>> Calculable<E, M, N, SuccessorWeights<E>>
-        for SuccessorsCache<E, M, N>
-    {
+    impl<N: Network> Calculable<N, SuccessorWeights<N::Entry>> for SuccessorsCache<N> {
         #[inline]
-        fn calculate(&self, ctx: &RoutingContext<E, M, N>, key: E) -> SuccessorWeights<E> {
+        fn calculate(&self, ctx: &RoutingContext<N>, key: N::Entry) -> SuccessorWeights<N::Entry> {
             // Calc. once
             #[allow(unsafe_code)]
             let source = unsafe { ctx.map.point(&key).unwrap_unchecked() };
@@ -189,32 +181,28 @@ mod successor {
 
 mod predicate {
     use crate::primitives::{Dijkstra, algorithms::DijkstraReachableItem};
-    use routers_network::{Entry, Network};
+    use routers_network::Network;
 
     use super::*;
 
     const DEFAULT_THRESHOLD: f64 = 200_000f64; // 2km in cm
 
     #[derive(Debug)]
-    pub struct PredicateMetadata<E, M, N>
+    pub struct PredicateMetadata<N>
     where
-        E: Entry,
-        M: Metadata,
-        N: Network<E, M>,
+        N: Network,
     {
         /// The successors cache used to back the successors and
         /// prevent repeated calculations.
-        successors: SuccessorsCache<E, M, N>,
+        successors: SuccessorsCache<N>,
 
         /// The threshold by which the solver is bounded, in centimeters.
         threshold_distance: f64,
     }
 
-    impl<E, M, N> Default for PredicateMetadata<E, M, N>
+    impl<N> Default for PredicateMetadata<N>
     where
-        E: Entry,
-        M: Metadata,
-        N: Network<E, M>,
+        N: Network,
     {
         fn default() -> Self {
             Self {
@@ -244,10 +232,10 @@ mod predicate {
     /// matches (see
     /// [`MatchOptions::with_cache`](crate::MatchOptions::with_cache)) so
     /// later matches run warm.
-    pub type PredicateCache<E, M, N> =
-        LockedMap<E, Predicates<E>, M, N, PredicateMetadata<E, M, N>>;
+    pub type PredicateCache<N> =
+        LockedMap<Predicates<<N as DataPlane>::Entry>, N, PredicateMetadata<N>>;
 
-    impl<E: CacheKey, M: Metadata, N: Network<E, M>> PredicateCache<E, M, N> {
+    impl<N: Network> PredicateCache<N> {
         pub fn with_threshold(threshold_cm: f64) -> Self {
             LockedMap(Arc::new(CacheMap {
                 map: HashMap::default(),
@@ -255,17 +243,13 @@ mod predicate {
                     successors: SuccessorsCache::default(),
                     threshold_distance: threshold_cm,
                 },
-                _marker: core::marker::PhantomData,
-                _marker2: core::marker::PhantomData,
             }))
         }
     }
 
-    impl<E: CacheKey, M: Metadata, N: Network<E, M>> Calculable<E, M, N, Predicates<E>>
-        for PredicateCache<E, M, N>
-    {
+    impl<N: Network> Calculable<N, Predicates<N::Entry>> for PredicateCache<N> {
         #[inline]
-        fn calculate(&self, ctx: &RoutingContext<E, M, N>, key: E) -> Predicates<E> {
+        fn calculate(&self, ctx: &RoutingContext<N>, key: N::Entry) -> Predicates<N::Entry> {
             let threshold = self.0.metadata.threshold_distance;
 
             Dijkstra
@@ -299,7 +283,7 @@ mod predicate {
                 .map(|DijkstraReachableItem { node, parent, .. }| {
                     (node, parent.unwrap_or_default())
                 })
-                .collect::<Predicates<E>>()
+                .collect::<Predicates<N::Entry>>()
         }
     }
 }

--- a/libs/routers_transition/src/primitives/routing.rs
+++ b/libs/routers_transition/src/primitives/routing.rs
@@ -1,4 +1,4 @@
-use routers_network::{Edge, Entry, Metadata, Network};
+use routers_network::{Edge, Network};
 
 use crate::candidate::{Candidate, CandidateRef, CandidateStore};
 
@@ -9,30 +9,26 @@ use crate::candidate::{Candidate, CandidateRef, CandidateStore};
 /// references, so an extension point sees exactly what the built-in pipeline
 /// sees.
 #[derive(Clone, Copy, Debug)]
-pub struct RoutingContext<'a, E, M, N>
+pub struct RoutingContext<'a, N>
 where
-    E: Entry + 'a,
-    M: Metadata + 'a,
-    N: Network<E, M>,
+    N: Network + ?Sized,
 {
-    pub candidates: &'a CandidateStore<E>,
+    pub candidates: &'a CandidateStore<N::Entry>,
     pub map: &'a N,
-    pub runtime: &'a M::Runtime,
+    pub runtime: &'a N::Runtime,
 }
 
-impl<N, E, M> RoutingContext<'_, E, M, N>
+impl<N> RoutingContext<'_, N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network + ?Sized,
 {
     /// Obtain a [candidate](Candidate), should it exist, by its [ref](CandidateRef).
-    pub fn candidate(&self, candidate: &CandidateRef) -> Option<Candidate<E>> {
+    pub fn candidate(&self, candidate: &CandidateRef) -> Option<Candidate<N::Entry>> {
         self.candidates.candidate(candidate)
     }
 
     /// Obtain the [edge](Edge), should it exist, between two nodes (specified as ids).
-    pub fn edge(&self, a: &E, b: &E) -> Option<Edge<E>> {
+    pub fn edge(&self, a: &N::Entry, b: &N::Entry) -> Option<Edge<N::Entry>> {
         self.map.edge(a, b)
     }
 }

--- a/libs/routers_transition/src/weigh/all_compute.rs
+++ b/libs/routers_transition/src/weigh/all_compute.rs
@@ -3,9 +3,8 @@
 //! See [`Selective`](crate::Selective) for the pruned counterpart.
 
 use alloc::sync::Arc;
-use core::marker::PhantomData;
 
-use routers_network::{Entry, Metadata, Network};
+use routers_network::Network;
 use routers_trellis::NodeId;
 
 use crate::{
@@ -15,37 +14,29 @@ use crate::{
 };
 
 /// Weighs every reachable transition. Inherits the full [`Weigher`] pipeline.
-pub struct AllCompute<E, M, N>
+pub struct AllCompute<N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
-    predicate: Arc<PredicateCache<E, M, N>>,
-    _phantom: PhantomData<N>,
+    predicate: Arc<PredicateCache<N>>,
 }
 
-impl<E, M, N> Default for AllCompute<E, M, N>
+impl<N> Default for AllCompute<N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
     fn default() -> Self {
         Self {
             predicate: Arc::new(PredicateCache::default()),
-            _phantom: PhantomData,
         }
     }
 }
 
-impl<E, M, N> AllCompute<E, M, N>
+impl<N> AllCompute<N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
-    pub fn use_cache(self, cache: Arc<PredicateCache<E, M, N>>) -> Self {
+    pub fn use_cache(self, cache: Arc<PredicateCache<N>>) -> Self {
         Self {
             predicate: cache,
             ..self
@@ -53,21 +44,19 @@ where
     }
 }
 
-impl<E, M, N> Weigher<E, M, N> for AllCompute<E, M, N>
+impl<N> Weigher<N> for AllCompute<N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
-    fn cache(&self) -> &PredicateCache<E, M, N> {
+    fn cache(&self) -> &PredicateCache<N> {
         &self.predicate
     }
 
     fn select(
         &self,
-        _ctx: &RoutingContext<E, M, N>,
-        _source: &Candidate<E>,
-        to_layer: &[Candidate<E>],
+        _ctx: &RoutingContext<N>,
+        _source: &Candidate<N::Entry>,
+        to_layer: &[Candidate<N::Entry>],
     ) -> Vec<NodeId> {
         (0..to_layer.len() as u32).map(NodeId).collect()
     }

--- a/libs/routers_transition/src/weigh/expansion.rs
+++ b/libs/routers_transition/src/weigh/expansion.rs
@@ -3,7 +3,7 @@
 
 use core::hash::Hash;
 
-use routers_network::{Edge, Entry, Metadata, Network};
+use routers_network::{Edge, Network};
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -38,25 +38,21 @@ where
     }
 }
 
-pub(crate) struct Expansion<'a, E, M, N>
+pub(crate) struct Expansion<'a, N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
-    ctx: &'a RoutingContext<'a, E, M, N>,
-    predicate: &'a PredicateCache<E, M, N>,
+    ctx: &'a RoutingContext<'a, N>,
+    predicate: &'a PredicateCache<N>,
 }
 
-impl<'a, E, M, N> Expansion<'a, E, M, N>
+impl<'a, N> Expansion<'a, N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
     pub(crate) fn new(
-        ctx: &'a RoutingContext<'a, E, M, N>,
-        predicate: &'a PredicateCache<E, M, N>,
+        ctx: &'a RoutingContext<'a, N>,
+        predicate: &'a PredicateCache<N>,
     ) -> Self {
         Self { ctx, predicate }
     }
@@ -67,7 +63,7 @@ where
     /// Candidates already sharing a directed edge resolve directly (by distance);
     /// otherwise the routed path between their edges is walked from the predicate
     /// map.
-    pub(crate) fn reach(&self, from: CandidateRef, to: CandidateRef) -> Option<Reachable<E>> {
+    pub(crate) fn reach(&self, from: CandidateRef, to: CandidateRef) -> Option<Reachable<N::Entry>> {
         let source = self.ctx.candidate(&from)?;
         let target = self.ctx.candidate(&to)?;
 
@@ -80,7 +76,7 @@ where
 
     /// The road edges linking `source`'s edge to `target`'s edge, walked from the
     /// bounded-Dijkstra predicate map rooted at `source`'s edge target.
-    fn route(&self, source: &Candidate<E>, target: &Candidate<E>) -> Option<Vec<Edge<E>>> {
+    fn route(&self, source: &Candidate<N::Entry>, target: &Candidate<N::Entry>) -> Option<Vec<Edge<N::Entry>>> {
         let parents = self.predicate.query(self.ctx, source.edge.target);
         let nodes = parents.path(&source.edge.target, &target.edge.source)?;
 

--- a/libs/routers_transition/src/weigh/expansion.rs
+++ b/libs/routers_transition/src/weigh/expansion.rs
@@ -50,10 +50,7 @@ impl<'a, N> Expansion<'a, N>
 where
     N: Network,
 {
-    pub(crate) fn new(
-        ctx: &'a RoutingContext<'a, N>,
-        predicate: &'a PredicateCache<N>,
-    ) -> Self {
+    pub(crate) fn new(ctx: &'a RoutingContext<'a, N>, predicate: &'a PredicateCache<N>) -> Self {
         Self { ctx, predicate }
     }
 
@@ -63,7 +60,11 @@ where
     /// Candidates already sharing a directed edge resolve directly (by distance);
     /// otherwise the routed path between their edges is walked from the predicate
     /// map.
-    pub(crate) fn reach(&self, from: CandidateRef, to: CandidateRef) -> Option<Reachable<N::Entry>> {
+    pub(crate) fn reach(
+        &self,
+        from: CandidateRef,
+        to: CandidateRef,
+    ) -> Option<Reachable<N::Entry>> {
         let source = self.ctx.candidate(&from)?;
         let target = self.ctx.candidate(&to)?;
 
@@ -76,7 +77,11 @@ where
 
     /// The road edges linking `source`'s edge to `target`'s edge, walked from the
     /// bounded-Dijkstra predicate map rooted at `source`'s edge target.
-    fn route(&self, source: &Candidate<N::Entry>, target: &Candidate<N::Entry>) -> Option<Vec<Edge<N::Entry>>> {
+    fn route(
+        &self,
+        source: &Candidate<N::Entry>,
+        target: &Candidate<N::Entry>,
+    ) -> Option<Vec<Edge<N::Entry>>> {
         let parents = self.predicate.query(self.ctx, source.edge.target);
         let nodes = parents.path(&source.edge.target, &target.edge.source)?;
 

--- a/libs/routers_transition/src/weigh/mod.rs
+++ b/libs/routers_transition/src/weigh/mod.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use itertools::Itertools;
 use rayon::prelude::*;
-use routers_network::{Entry, Metadata, Network};
+use routers_network::Network;
 use routers_trellis::{LayerId, MAX_WEIGHT, NO_EDGE, NodeId, Trellis};
 
 /// A strategy for weighing the pending boundaries of a [`Trellis`].
@@ -32,23 +32,21 @@ use routers_trellis::{LayerId, MAX_WEIGHT, NO_EDGE, NodeId, Trellis};
 /// Weighing touches only **pending** boundaries: resolved weights are
 /// append-stable and never recomputed, so weighing a grown trellis costs only
 /// the new boundaries.
-pub trait Weigher<E, M, N>
+pub trait Weigher<N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
     /// The predicate cache backing this weigher's reachability queries.
-    fn cache(&self) -> &PredicateCache<E, M, N>;
+    fn cache(&self) -> &PredicateCache<N>;
 
     /// Which next-layer candidates to weigh for `source`, as positions within
     /// `to_layer`. All-compute returns all of them; a selective strategy returns a
     /// promising subset.
     fn select(
         &self,
-        ctx: &RoutingContext<E, M, N>,
-        source: &Candidate<E>,
-        to_layer: &[Candidate<E>],
+        ctx: &RoutingContext<N>,
+        source: &Candidate<N::Entry>,
+        to_layer: &[Candidate<N::Entry>],
     ) -> Vec<NodeId>;
 
     /// How candidate `to` is reached from `from` on the road network, or `None`
@@ -56,10 +54,10 @@ where
     /// deterministic, so it reproduces exactly what weighing costed.
     fn reach(
         &self,
-        ctx: &RoutingContext<E, M, N>,
+        ctx: &RoutingContext<N>,
         from: CandidateRef,
         to: CandidateRef,
-    ) -> Option<Reachable<E>> {
+    ) -> Option<Reachable<N::Entry>> {
         Expansion::new(ctx, self.cache()).reach(from, to)
     }
 
@@ -68,14 +66,14 @@ where
     /// here — they are node weights.
     fn hop<Emmis, Trans>(
         &self,
-        ctx: &RoutingContext<E, M, N>,
-        costing: &CostingStrategies<Emmis, Trans, E>,
+        ctx: &RoutingContext<N>,
+        costing: &CostingStrategies<Emmis, Trans, N::Entry>,
         from: CandidateRef,
         to: CandidateRef,
     ) -> Option<u32>
     where
         Emmis: EmissionStrategy + Send + Sync,
-        Trans: TransitionStrategy<E> + Send + Sync,
+        Trans: TransitionStrategy<N::Entry> + Send + Sync,
     {
         let reachable = self.reach(ctx, from, to)?;
 
@@ -90,14 +88,14 @@ where
     /// where absent.
     fn weigh_source<Emmis, Trans>(
         &self,
-        ctx: &RoutingContext<E, M, N>,
-        costing: &CostingStrategies<Emmis, Trans, E>,
-        source: &Candidate<E>,
-        to_layer: &[Candidate<E>],
+        ctx: &RoutingContext<N>,
+        costing: &CostingStrategies<Emmis, Trans, N::Entry>,
+        source: &Candidate<N::Entry>,
+        to_layer: &[Candidate<N::Entry>],
     ) -> Vec<u32>
     where
         Emmis: EmissionStrategy + Send + Sync,
-        Trans: TransitionStrategy<E> + Send + Sync,
+        Trans: TransitionStrategy<N::Entry> + Send + Sync,
     {
         let mut row = vec![NO_EDGE; to_layer.len()];
 
@@ -118,13 +116,13 @@ where
     /// narrow boundaries don't drown the row's work in task overhead.
     fn weigh_boundary<Emmis, Trans>(
         &self,
-        ctx: &RoutingContext<E, M, N>,
-        costing: &CostingStrategies<Emmis, Trans, E>,
+        ctx: &RoutingContext<N>,
+        costing: &CostingStrategies<Emmis, Trans, N::Entry>,
         boundary: LayerId,
     ) -> Vec<u32>
     where
         Emmis: EmissionStrategy + Send + Sync,
-        Trans: TransitionStrategy<E> + Send + Sync,
+        Trans: TransitionStrategy<N::Entry> + Send + Sync,
         Self: Sync,
     {
         let (Some(from_layer), Some(to_layer)) = (
@@ -150,13 +148,13 @@ where
     /// records a gap (see [`Trellis::disconnections`]).
     fn weigh<Emmis, Trans>(
         &self,
-        ctx: &RoutingContext<E, M, N>,
-        costing: &CostingStrategies<Emmis, Trans, E>,
+        ctx: &RoutingContext<N>,
+        costing: &CostingStrategies<Emmis, Trans, N::Entry>,
         trellis: &mut Trellis,
     ) -> Result<(), MatchError>
     where
         Emmis: EmissionStrategy + Send + Sync,
-        Trans: TransitionStrategy<E> + Send + Sync,
+        Trans: TransitionStrategy<N::Entry> + Send + Sync,
         Self: Sync,
     {
         let pending = trellis

--- a/libs/routers_transition/src/weigh/selective.rs
+++ b/libs/routers_transition/src/weigh/selective.rs
@@ -5,10 +5,9 @@
 //! guaranteed-exact matching use [`AllCompute`](crate::AllCompute).
 
 use alloc::sync::Arc;
-use core::marker::PhantomData;
 
 use geo::{Distance, Haversine};
-use routers_network::{Entry, Metadata, Network};
+use routers_network::Network;
 use routers_trellis::NodeId;
 
 use crate::{
@@ -22,39 +21,31 @@ pub const DEFAULT_FANOUT: usize = 16;
 
 /// Weighs the `fanout` nearest next-layer candidates per source. Inherits the
 /// full [`Weigher`] pipeline.
-pub struct Selective<E, M, N>
+pub struct Selective<N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
-    predicate: Arc<PredicateCache<E, M, N>>,
+    predicate: Arc<PredicateCache<N>>,
     fanout: usize,
-    _phantom: PhantomData<N>,
 }
 
-impl<E, M, N> Default for Selective<E, M, N>
+impl<N> Default for Selective<N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
     fn default() -> Self {
         Self {
             predicate: Arc::new(PredicateCache::default()),
             fanout: DEFAULT_FANOUT,
-            _phantom: PhantomData,
         }
     }
 }
 
-impl<E, M, N> Selective<E, M, N>
+impl<N> Selective<N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
-    pub fn use_cache(self, cache: Arc<PredicateCache<E, M, N>>) -> Self {
+    pub fn use_cache(self, cache: Arc<PredicateCache<N>>) -> Self {
         Self {
             predicate: cache,
             ..self
@@ -67,21 +58,19 @@ where
     }
 }
 
-impl<E, M, N> Weigher<E, M, N> for Selective<E, M, N>
+impl<N> Weigher<N> for Selective<N>
 where
-    E: Entry,
-    M: Metadata,
-    N: Network<E, M>,
+    N: Network,
 {
-    fn cache(&self) -> &PredicateCache<E, M, N> {
+    fn cache(&self) -> &PredicateCache<N> {
         &self.predicate
     }
 
     fn select(
         &self,
-        _ctx: &RoutingContext<E, M, N>,
-        source: &Candidate<E>,
-        to_layer: &[Candidate<E>],
+        _ctx: &RoutingContext<N>,
+        source: &Candidate<N::Entry>,
+        to_layer: &[Candidate<N::Entry>],
     ) -> Vec<NodeId> {
         let mut nearest = (0..to_layer.len()).collect::<Vec<_>>();
         if nearest.len() > self.fanout {

--- a/libs/routers_transition/src/weigh/variant.rs
+++ b/libs/routers_transition/src/weigh/variant.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 
-use routers_network::{Entry, Metadata, Network};
+use routers_network::Network;
 use routers_trellis::NodeId;
 
 use crate::{
@@ -11,9 +11,9 @@ use crate::{
 
 /// A [`Weigher`] chosen at runtime by [`SolverVariant`]. Used purely through the
 /// [`Weigher`] trait, so callers stay decoupled from any concrete strategy struct.
-pub enum WeigherImpl<E: Entry, M: Metadata, N: Network<E, M>> {
-    AllCompute(AllCompute<E, M, N>),
-    Selective(Selective<E, M, N>),
+pub enum WeigherImpl<N: Network> {
+    AllCompute(AllCompute<N>),
+    Selective(Selective<N>),
 }
 
 /// Selects which [`Weigher`] strategy a match should use.
@@ -30,19 +30,19 @@ pub enum SolverVariant {
 }
 
 impl SolverVariant {
-    pub(crate) fn without_cache<E: Entry, M: Metadata, N: Network<E, M>>(
+    pub(crate) fn without_cache<N: Network>(
         self,
-    ) -> WeigherImpl<E, M, N> {
+    ) -> WeigherImpl<N> {
         match self {
             SolverVariant::Selective => WeigherImpl::Selective(Selective::default()),
             _ => WeigherImpl::AllCompute(AllCompute::default()),
         }
     }
 
-    pub(crate) fn instance<E: Entry, M: Metadata, N: Network<E, M>>(
+    pub(crate) fn instance<N: Network>(
         self,
-        cache: Arc<PredicateCache<E, M, N>>,
-    ) -> WeigherImpl<E, M, N> {
+        cache: Arc<PredicateCache<N>>,
+    ) -> WeigherImpl<N> {
         match self {
             SolverVariant::Selective => {
                 WeigherImpl::Selective(Selective::default().use_cache(cache))
@@ -54,8 +54,8 @@ impl SolverVariant {
 
 /// Dispatches the two strategy hooks to the chosen weigher; the rest of the
 /// pipeline is inherited from [`Weigher`]'s provided methods.
-impl<E: Entry, M: Metadata, N: Network<E, M>> Weigher<E, M, N> for WeigherImpl<E, M, N> {
-    fn cache(&self) -> &PredicateCache<E, M, N> {
+impl<N: Network> Weigher<N> for WeigherImpl<N> {
+    fn cache(&self) -> &PredicateCache<N> {
         match self {
             WeigherImpl::AllCompute(weigher) => weigher.cache(),
             WeigherImpl::Selective(weigher) => weigher.cache(),
@@ -64,9 +64,9 @@ impl<E: Entry, M: Metadata, N: Network<E, M>> Weigher<E, M, N> for WeigherImpl<E
 
     fn select(
         &self,
-        ctx: &RoutingContext<E, M, N>,
-        source: &Candidate<E>,
-        to_layer: &[Candidate<E>],
+        ctx: &RoutingContext<N>,
+        source: &Candidate<N::Entry>,
+        to_layer: &[Candidate<N::Entry>],
     ) -> Vec<NodeId> {
         match self {
             WeigherImpl::AllCompute(weigher) => weigher.select(ctx, source, to_layer),

--- a/libs/routers_transition/src/weigh/variant.rs
+++ b/libs/routers_transition/src/weigh/variant.rs
@@ -30,19 +30,14 @@ pub enum SolverVariant {
 }
 
 impl SolverVariant {
-    pub(crate) fn without_cache<N: Network>(
-        self,
-    ) -> WeigherImpl<N> {
+    pub(crate) fn without_cache<N: Network>(self) -> WeigherImpl<N> {
         match self {
             SolverVariant::Selective => WeigherImpl::Selective(Selective::default()),
             _ => WeigherImpl::AllCompute(AllCompute::default()),
         }
     }
 
-    pub(crate) fn instance<N: Network>(
-        self,
-        cache: Arc<PredicateCache<N>>,
-    ) -> WeigherImpl<N> {
+    pub(crate) fn instance<N: Network>(self, cache: Arc<PredicateCache<N>>) -> WeigherImpl<N> {
         match self {
             SolverVariant::Selective => {
                 WeigherImpl::Selective(Selective::default().use_cache(cache))

--- a/libs/routers_viewer/src/components/matcher.rs
+++ b/libs/routers_viewer/src/components/matcher.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use egui::Response;
 use geo::{Coord, LineString};
-use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId, OsmNetwork, OsmTripConfiguration};
+use routers_codec::osm::{OsmNetwork, OsmTripConfiguration};
 use routers_transition::LayerId;
 use routers_transition::layer::generation::StandardGenerator;
 use routers_transition::primitives::PredicateCache;
@@ -11,7 +11,7 @@ use routers_transition::{Matcher as TransitionMatcher, costing::CostingStrategie
 
 use crate::utils::{Component, MatchCandidate, MatchData, MatchLayer};
 
-pub type MatchCache = Arc<PredicateCache<OsmEntryId, OsmEdgeMetadata, OsmNetwork>>;
+pub type MatchCache = Arc<PredicateCache<OsmNetwork>>;
 
 pub struct MatchOutput {
     pub confirmed: Option<Result<MatchData, String>>,


### PR DESCRIPTION
Currently the E and M traits (Entry and Metadata), are passed around too many times in order to satisfy Network<E, M> 's requirements. Leading to excessive typing, as well as PhantomData types that aren't really necessary.