### PR TITLE
feat: Use `moka::Cache` instead of `scc::HashMap` for Mem Bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4005,6 +4005,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6707,6 +6724,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "measure_time",
+ "moka",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -6719,7 +6737,6 @@ dependencies = [
  "routers_trellis",
  "rstar 0.12.2",
  "rustc-hash 2.1.3",
- "scc",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -7041,15 +7058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7106,12 +7114,6 @@ dependencies = [
  "smithay-client-toolkit 0.19.2",
  "tiny-skia",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -7861,6 +7863,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ routers = { path = ".", version = "0.3.3" }
 
 # Optimisation Crates
 rayon = "1.10.0"
-scc = "2.3.4"
+moka = { version = "0.12", features = ["sync"] }
 itertools = "0.14.0"
 indexmap = "2.9.0"
 petgraph = { version = "0.8.2", features = ["serde-1", "graphmap", "rayon"] }

--- a/libs/routers_transition/Cargo.toml
+++ b/libs/routers_transition/Cargo.toml
@@ -39,7 +39,7 @@ opentelemetry-otlp = { workspace = true, optional = true }
 
 # Optimisations and Compression
 rayon = { workspace = true }
-scc = { workspace = true }
+moka = { workspace = true }
 itertools = { workspace = true }
 indexmap = { workspace = true }
 thiserror = { workspace = true }

--- a/libs/routers_transition/src/primitives/cache.rs
+++ b/libs/routers_transition/src/primitives/cache.rs
@@ -1,9 +1,10 @@
 use alloc::sync::Arc;
 use core::fmt::Debug;
 use geo::Distance;
-use routers_network::{DataPlane, Metadata, Network};
+use moka::sync::Cache;
+use routers_network::{DataPlane, DirectionAwareEdgeId, Entry, Metadata, Network};
 use rustc_hash::{FxBuildHasher, FxHashMap};
-use scc::HashMap;
+use std::{hash::Hash, ops::Deref};
 
 /// A generic read-through cache for a hashmap-backed data structure
 pub struct CacheMap<V, N, Meta>
@@ -12,7 +13,7 @@ where
     Meta: Debug,
     N: Network,
 {
-    pub(crate) map: HashMap<N::Entry, Arc<V>, FxBuildHasher>,
+    pub(crate) map: Cache<N::Entry, Arc<V>, FxBuildHasher>,
     pub(crate) metadata: Meta,
 }
 
@@ -39,6 +40,20 @@ where
     N: Network,
     V: Debug,
     Meta: Debug;
+
+impl<V, N, Meta> Deref for LockedMap<V, N, Meta>
+where
+    LockedMap<V, N, Meta>: Calculable<N, V>,
+    V: Debug,
+    N: Network,
+    Meta: Debug,
+{
+    type Target = CacheMap<V, N, Meta>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl<V, N, Meta> Default for LockedMap<V, N, Meta>
 where
@@ -86,26 +101,69 @@ where
     /// consumes an owned value of the key, [`N::Entry`], which is required
     /// for the call to the [`Calculable::calculate`] function.
     pub fn query(&self, ctx: &RoutingContext<N>, key: N::Entry) -> Arc<V> {
-        if let Some(value) = self.0.map.get(&key) {
-            return Arc::clone(value.get());
-        }
-
-        let calculated = Arc::new(self.calculate(ctx, key));
-        let _ = self.0.map.insert(key, calculated.clone());
-
-        Arc::clone(&calculated)
+        self.map
+            .get_with(key, || Arc::new(self.calculate(ctx, key)))
     }
+}
+
+pub trait CacheWeight: Send + Sync + 'static {
+    /// Estimated heap bytes this value occupies.
+    fn weight_bytes(&self) -> u32;
+
+    fn cache_of<K>() -> Cache<K, Arc<Self>, FxBuildHasher>
+    where
+        K: Hash + Eq + Send + Sync + Clone + 'static,
+    {
+        Cache::builder()
+            .max_capacity(Self::BUDGET_MB.saturating_mul(1024 * 1024))
+            .weigher(|_key, value: &Arc<Self>| value.weight_bytes())
+            .build_with_hasher(FxBuildHasher)
+    }
+
+    /// Size budget in MiB
+    const BUDGET_MB: u64;
+}
+
+impl<E: Entry> CacheWeight for Vec<(E, DirectionAwareEdgeId<E>, WeightAndDistance)> {
+    #[inline]
+    fn weight_bytes(&self) -> u32 {
+        // Vec header (ptr/len/cap) atop `capacity` inline elements.
+        const HEADER: usize = 24;
+        let per_elem = core::mem::size_of::<(E, DirectionAwareEdgeId<E>, WeightAndDistance)>();
+        self.capacity()
+            .saturating_mul(per_elem)
+            .saturating_add(HEADER)
+            .min(u32::MAX as usize) as u32
+    }
+
+    const BUDGET_MB: u64 = 128;
+}
+
+impl<E: Entry> CacheWeight for FxHashMap<E, E> {
+    #[inline]
+    fn weight_bytes(&self) -> u32 {
+        // hashbrown holds `capacity` (K, V) slots plus ~1 control byte each,
+        // atop a small fixed table header.
+        const HEADER: usize = 48;
+        let per_slot = core::mem::size_of::<(E, E)>() + 1;
+        self.capacity()
+            .saturating_mul(per_slot)
+            .saturating_add(HEADER)
+            .min(u32::MAX as usize) as u32
+    }
+
+    const BUDGET_MB: u64 = 512;
 }
 
 impl<V, N, Meta> Default for CacheMap<V, N, Meta>
 where
-    V: Debug + Send + Sync + 'static,
+    V: CacheWeight + Debug + Send + Sync + 'static,
     N: Network,
     Meta: Default + Debug,
 {
     fn default() -> Self {
         Self {
-            map: HashMap::default(),
+            map: V::cache_of(),
             metadata: Meta::default(),
         }
     }
@@ -238,7 +296,7 @@ mod predicate {
     impl<N: Network> PredicateCache<N> {
         pub fn with_threshold(threshold_cm: f64) -> Self {
             LockedMap(Arc::new(CacheMap {
-                map: HashMap::default(),
+                map: FxHashMap::<N::Entry, N::Entry>::cache_of(),
                 metadata: PredicateMetadata {
                     successors: SuccessorsCache::default(),
                     threshold_distance: threshold_cm,
@@ -318,4 +376,4 @@ where
 pub use predicate::PredicateCache;
 pub use successor::SuccessorsCache;
 
-use crate::primitives::RoutingContext;
+use crate::primitives::{RoutingContext, WeightAndDistance};


### PR DESCRIPTION
Bound memory using `moka::Cache` with an LRU policy (via. TinyLFU)