### PR TITLE
feat: Optimisations in Realtime Pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6568,6 +6568,8 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-nats",
+ "buffa",
+ "buffa-types",
  "chrono",
  "clap",
  "env_logger",
@@ -6586,6 +6588,7 @@ dependencies = [
  "redis",
  "routers_codec",
  "routers_network",
+ "routers_schema",
  "routers_shard",
  "routers_transition",
  "serde",

--- a/libs/routers_realtime/Cargo.toml
+++ b/libs/routers_realtime/Cargo.toml
@@ -11,6 +11,7 @@ routers_codec = { workspace = true }
 routers_network = { workspace = true }
 routers_shard = { workspace = true }
 routers_transition = { workspace = true }
+schema = { workspace = true }
 
 # Logging & Telemetry
 env_logger = { workspace = true }
@@ -44,6 +45,8 @@ indicatif-log-bridge = "0.2.3"
 # Serialization
 serde = { workspace = true, features = ["derive"] }
 postcard = { workspace = true }
+buffa = { workspace = true }
+buffa-types = { workspace = true }
 
 # Systems
 async-nats = "0.38.0"

--- a/libs/routers_realtime/bin/historian.rs
+++ b/libs/routers_realtime/bin/historian.rs
@@ -30,6 +30,12 @@ struct Args {
     #[arg(short, long, env)]
     subject: String,
 
+    /// The NATS queue group to subscribe under. Replicas sharing a group
+    /// split the subject between them, so each event is archived once —
+    /// a plain fan-out subscription would write one copy per replica.
+    #[arg(long, env, default_value = "historian")]
+    queue_group: String,
+
     /// The number of events to keep in the Redis history
     #[arg(long, env, default_value_t = 25)]
     history: usize,
@@ -58,7 +64,7 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("could not connect to NATS")?;
     let subscriber = client
-        .subscribe(args.subject)
+        .queue_subscribe(args.subject, args.queue_group)
         .await
         .context("could not subscribe to NATS subject")?;
 

--- a/libs/routers_realtime/bin/orchestrator.rs
+++ b/libs/routers_realtime/bin/orchestrator.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId};
 use routers_realtime::{
     bus::{NATSSink, NATSStream},
-    event::{MatchContext, MatchResult, Payload, RawEvent},
+    event::{MatchContext, MatchResult, Payload, RawEvent, VehicleId},
     store::RedisStore,
 };
 use routers_transition::Continuation;
@@ -94,7 +94,7 @@ struct App<'a> {
     gap: chrono::TimeDelta,
     jump_distance: f64,
     context_window: usize,
-    trips: &'a HashMap<String, Trip<E>>,
+    trips: &'a HashMap<VehicleId, Trip<E>>,
     kv: &'a mut RedisStore<RawEvent>,
 }
 
@@ -156,8 +156,8 @@ async fn main() -> anyhow::Result<()> {
             // resumed from on its next event; `origins` is when each vehicle's
             // newest event was published, for the end-to-end `event_to_match`
             // span. Both are derived — losing them just forces a restart.
-            let mut trips: HashMap<String, Trip<E>> = HashMap::new();
-            let mut origins: HashMap<String, web_time::SystemTime> = HashMap::new();
+            let mut trips: HashMap<VehicleId, Trip<E>> = HashMap::new();
+            let mut origins: HashMap<VehicleId, web_time::SystemTime> = HashMap::new();
 
             while let Some(Dispatch {
                 queued_at,
@@ -174,7 +174,7 @@ async fn main() -> anyhow::Result<()> {
                 match inbound {
                     Inbound::Event(payload) => {
                         if let Some(sent_at) = sent_at {
-                            origins.insert(payload.vehicle_id.clone(), sent_at);
+                            origins.insert(payload.vehicle_id, sent_at);
                         }
 
                         let span = info_span!(
@@ -236,8 +236,8 @@ async fn main() -> anyhow::Result<()> {
         let sent_at = routers_realtime::bus::last_sent_at();
 
         let vehicle_id = match &inbound {
-            Inbound::Event(payload) => &payload.vehicle_id,
-            Inbound::Result(result) => &result.vehicle_id,
+            Inbound::Event(payload) => payload.vehicle_id,
+            Inbound::Result(result) => result.vehicle_id,
         };
 
         let mut hasher = DefaultHasher::new();
@@ -308,7 +308,7 @@ impl App<'_> {
         }
 
         let mut history: Vec<RawEvent> = std::iter::once(RawEvent {
-            vehicle_id: vehicle_id.clone(),
+            vehicle_id,
             point,
             timestamp,
         })

--- a/libs/routers_realtime/bin/orchestrator.rs
+++ b/libs/routers_realtime/bin/orchestrator.rs
@@ -72,7 +72,7 @@ struct Args {
 
     /// Points older than this will be discarded from history, regardless
     /// of if it's within the KV store, or not.
-    #[arg(long, env, value_parser = humantime::parse_duration, default_value = "120s")]
+    #[arg(long, env, value_parser = humantime::parse_duration, default_value = "300s")]
     gap: Duration,
 
     /// Consecutive points further away than this will be treated as a "teleport",

--- a/libs/routers_realtime/bin/replay.rs
+++ b/libs/routers_realtime/bin/replay.rs
@@ -56,11 +56,26 @@ const BUFFERED_PUBLISH_SIZE: usize = 8;
 const VEHICLE_ID_COL: &str = "VehicleID";
 const TRIP_ID_COL: &str = "TripID";
 
-const PROVIDER_COL: &str = "Provider";
 const EVENT_TIME_COL: &str = "EventTime";
 
 const LATITUDE_COL: &str = "Latitude";
 const LONGITUDE_COL: &str = "Longitude";
+
+/// Step an upstream string id down to its compact wire id (FNV-1a, 32-bit).
+///
+/// The hash must be stable across processes and runs — the redis history,
+/// a resumed trip, and a restarted orchestrator all have to agree on the
+/// same id for the same vehicle — which rules out `DefaultHasher`
+/// (per-process random keys). Collisions merge two vehicles' streams; at
+/// fleet cardinality `n` the odds are ~`n²/2³³` (a 100k fleet: ~0.1%).
+fn stepdown<I: From<u32>>(value: &str) -> I {
+    let mut hash: u32 = 0x811c9dc5;
+    for byte in value.as_bytes() {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(0x01000193);
+    }
+    I::from(hash)
+}
 
 fn parse_datetime(fmt: &str) -> Expr {
     col(EVENT_TIME_COL).str().to_datetime(
@@ -104,7 +119,6 @@ async fn main() -> anyhow::Result<()> {
         .select([
             col(TRIP_ID_COL),
             col(VEHICLE_ID_COL),
-            col(PROVIDER_COL),
             parse_datetime(TIME_FORMAT).fill_null(parse_datetime(TIME_FORMAT_FRACTIONAL)),
             col(LATITUDE_COL),
             col(LONGITUDE_COL),
@@ -180,7 +194,6 @@ async fn main() -> anyhow::Result<()> {
 fn rows_of(df: &DataFrame) -> PolarsResult<impl Iterator<Item = (u64, Payload)> + '_> {
     let trip = df.column(TRIP_ID_COL)?.str()?;
     let vehicle = df.column(VEHICLE_ID_COL)?.str()?;
-    let provider = df.column(PROVIDER_COL)?.str()?;
     let etime = df.column(EVENT_TIME_COL)?.datetime()?;
     let lat = df.column(LATITUDE_COL)?.f64()?;
     let lon = df.column(LONGITUDE_COL)?.f64()?;
@@ -188,16 +201,16 @@ fn rows_of(df: &DataFrame) -> PolarsResult<impl Iterator<Item = (u64, Payload)> 
     Ok(izip!(
         trip.into_iter(),
         vehicle.into_iter(),
-        provider.into_iter(),
         etime.into_iter(),
         lat.into_iter(),
         lon.into_iter()
     )
-    .map(|(trip, vehicle, provider, etime, lat, lon)| {
+    .map(|(trip, vehicle, etime, lat, lon)| {
+        // Step the upstream string ids down to u32s here, at the ingest
+        // boundary, so the strings never cross the wire.
         let payload = Payload {
-            trip_id: trip.unwrap_or_default().to_owned(),
-            vehicle_id: vehicle.unwrap_or_default().to_owned(),
-            provider: provider.unwrap_or_default().to_owned(),
+            trip_id: stepdown(trip.unwrap_or_default()),
+            vehicle_id: stepdown(vehicle.unwrap_or_default()),
             // The column is parsed as microseconds since the Unix epoch.
             timestamp: chrono::DateTime::from_timestamp_micros(etime.unwrap_or_default())
                 .unwrap_or_default(),

--- a/libs/routers_realtime/src/bus/mod.rs
+++ b/libs/routers_realtime/src/bus/mod.rs
@@ -4,3 +4,32 @@ mod trace;
 pub use nats::NATSSink;
 pub use nats::NATSStream;
 pub use trace::{last_sent_at, span_between, wallclock};
+
+/// How a message crosses the bus.
+///
+/// Rust-internal messages (the match control plane) use postcard via
+/// [`postcard_wire!`]; boundary messages the wider world produces or
+/// consumes (the raw ingest surface) encode as protobuf against the
+/// `routers.realtime.v1` schema, so any language can speak them.
+pub trait Wire: Sized {
+    fn encode(&self) -> anyhow::Result<Vec<u8>>;
+    fn decode(bytes: &[u8]) -> anyhow::Result<Self>;
+}
+
+/// Carry a serde message over the bus as postcard.
+macro_rules! postcard_wire {
+    ($name:ident $(< $($p:ident : $bound:path),+ >)?) => {
+        impl $(< $($p: $bound + serde::Serialize + serde::de::DeserializeOwned),+ >)?
+            $crate::bus::Wire for $name $(< $($p),+ >)?
+        {
+            fn encode(&self) -> anyhow::Result<Vec<u8>> {
+                Ok(postcard::to_allocvec(self)?)
+            }
+
+            fn decode(bytes: &[u8]) -> anyhow::Result<Self> {
+                Ok(postcard::from_bytes(bytes)?)
+            }
+        }
+    };
+}
+pub(crate) use postcard_wire;

--- a/libs/routers_realtime/src/bus/nats.rs
+++ b/libs/routers_realtime/src/bus/nats.rs
@@ -4,10 +4,10 @@ use std::task::{Context as Ctx, Poll, ready};
 use anyhow::Context;
 use futures::future::BoxFuture;
 use futures::{FutureExt, Sink, Stream, StreamExt};
-use serde::Serialize;
-use serde::de::DeserializeOwned;
 
-pub struct NATSSink<T: Serialize> {
+use super::Wire;
+
+pub struct NATSSink<T: Wire> {
     client: async_nats::Client,
     subject_of: Box<dyn Fn(&T) -> String + Send + Sync>,
     in_flight: Option<BoxFuture<'static, anyhow::Result<()>>>,
@@ -15,12 +15,12 @@ pub struct NATSSink<T: Serialize> {
     _phantom: std::marker::PhantomData<T>,
 }
 
-pub struct NATSStream<T: DeserializeOwned> {
+pub struct NATSStream<T: Wire> {
     subscriber: Option<async_nats::Subscriber>,
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T: Serialize> NATSSink<T> {
+impl<T: Wire> NATSSink<T> {
     pub fn new(
         client: async_nats::Client,
         subject_of: impl Fn(&T) -> String + Send + Sync + 'static,
@@ -51,7 +51,7 @@ impl<T: Serialize> NATSSink<T> {
     }
 }
 
-impl<T: Serialize + Unpin> Sink<T> for NATSSink<T> {
+impl<T: Wire + Unpin> Sink<T> for NATSSink<T> {
     type Error = anyhow::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Ctx<'_>) -> Poll<Result<(), Self::Error>> {
@@ -60,7 +60,7 @@ impl<T: Serialize + Unpin> Sink<T> for NATSSink<T> {
 
     fn start_send(self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
         let this = self.get_mut();
-        let payload: Vec<u8> = postcard::to_allocvec(&item).context("failed to serialize")?;
+        let payload: Vec<u8> = item.encode().context("failed to serialize")?;
 
         let subject = this.subject_for(&item);
         let client = this.client.clone();
@@ -91,7 +91,7 @@ impl<T: Serialize + Unpin> Sink<T> for NATSSink<T> {
     }
 }
 
-impl<T: DeserializeOwned> NATSStream<T> {
+impl<T: Wire> NATSStream<T> {
     pub fn new(subscriber: async_nats::Subscriber) -> Self {
         Self {
             subscriber: Some(subscriber),
@@ -102,7 +102,7 @@ impl<T: DeserializeOwned> NATSStream<T> {
 
 impl<T> Stream for NATSStream<T>
 where
-    T: Serialize + DeserializeOwned + Unpin,
+    T: Wire + Unpin,
 {
     type Item = T;
 
@@ -115,7 +115,7 @@ where
 
         loop {
             match ready!(subscriber.poll_next_unpin(cx)) {
-                Some(message) => match postcard::from_bytes(&message.payload) {
+                Some(message) => match T::decode(&message.payload) {
                     Ok(item) => {
                         // Close the publisher's timing loop: the gap between
                         // its send stamp and now is the queue-wait span.

--- a/libs/routers_realtime/src/event.rs
+++ b/libs/routers_realtime/src/event.rs
@@ -6,28 +6,62 @@ use routers_transition::candidate::RoutedPath;
 use routers_transition::matcher::{Continuation, Trip};
 use serde::{Deserialize, Serialize};
 
+use buffa::Message;
+use schema::proto::routers::realtime::v1 as proto;
+
+use crate::bus::{Wire, postcard_wire};
 use crate::store::Storable;
+
+/// Declare a compact wire identifier. The upstream string ids are stepped
+/// down to these at the ingest boundary (see the replay binary), so the
+/// strings never cross the wire again.
+macro_rules! wire_id {
+    ($(#[$doc:meta])* $name:ident) => {
+        $(#[$doc])*
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        pub struct $name(pub u32);
+
+        impl From<u32> for $name {
+            fn from(value: u32) -> Self {
+                Self(value)
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+    };
+}
+
+wire_id! {
+    /// Identifies one vehicle across its events, history, and matches.
+    VehicleId
+}
+wire_id! {
+    /// Identifies the trip an event was observed under.
+    TripId
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound(serialize = "E: Serialize", deserialize = "E: Deserialize<'de>"))]
 pub struct MatchContext<E: Entry> {
     pub continuation: Continuation<E>,
-    pub vehicle_id: String,
+    pub vehicle_id: VehicleId,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MatchResult<E: Entry, M: Metadata> {
     pub path: RoutedPath<E, M>,
-    pub vehicle_id: String,
+    pub vehicle_id: VehicleId,
     pub trip: Trip<E>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Payload {
-    pub trip_id: String,
-    pub vehicle_id: String,
-
-    pub provider: String,
+    pub trip_id: TripId,
+    pub vehicle_id: VehicleId,
 
     /// When the observation was made. Serialized as microseconds since the
     /// Unix epoch on the wire.
@@ -37,10 +71,61 @@ pub struct Payload {
     pub point: Point,
 }
 
+// The match control plane is Rust-internal: postcard on the wire.
+postcard_wire!(MatchContext<E: Entry>);
+postcard_wire!(MatchResult<E: Entry, M: Metadata>);
+
+/// The ingest surface crosses the bus as protobuf
+/// (`routers.realtime.v1.Payload`), so producers in any language can
+/// publish raw events against the schema.
+impl Wire for Payload {
+    fn encode(&self) -> anyhow::Result<Vec<u8>> {
+        Ok(proto::Payload::from(self).encode_to_vec())
+    }
+
+    fn decode(bytes: &[u8]) -> anyhow::Result<Self> {
+        Ok(Self::from(proto::Payload::decode_from_slice(bytes)?))
+    }
+}
+
+impl From<&Payload> for proto::Payload {
+    fn from(payload: &Payload) -> Self {
+        proto::Payload {
+            trip_id: payload.trip_id.0,
+            vehicle_id: payload.vehicle_id.0,
+            timestamp: buffa::MessageField::some(buffa_types::google::protobuf::Timestamp::from_unix(
+                payload.timestamp.timestamp(),
+                payload.timestamp.timestamp_subsec_nanos() as i32,
+            )),
+            point: buffa::MessageField::some(schema::proto::routers::model::v1::Coordinate {
+                longitude: payload.point.x(),
+                latitude: payload.point.y(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<proto::Payload> for Payload {
+    fn from(payload: proto::Payload) -> Self {
+        let point = payload.point.into_option().unwrap_or_default();
+        let timestamp = payload.timestamp.into_option().unwrap_or_default();
+
+        Payload {
+            trip_id: TripId(payload.trip_id),
+            vehicle_id: VehicleId(payload.vehicle_id),
+            timestamp: DateTime::from_timestamp(timestamp.seconds, timestamp.nanos as u32)
+                .unwrap_or_default(),
+            point: Point::new(point.longitude, point.latitude),
+        }
+    }
+}
+
 impl Payload {
     pub fn as_event(&self) -> RawEvent {
         RawEvent {
-            vehicle_id: self.vehicle_id.clone(),
+            vehicle_id: self.vehicle_id,
             point: self.point,
             timestamp: self.timestamp,
         }
@@ -49,7 +134,7 @@ impl Payload {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RawEvent {
-    pub vehicle_id: String,
+    pub vehicle_id: VehicleId,
     pub point: Point,
 
     /// When the observation was made. Serialized as microseconds since the
@@ -60,13 +145,39 @@ pub struct RawEvent {
 
 impl Storable for RawEvent {
     type ShardId = Geohash;
-    type Key = String;
+    type Key = VehicleId;
 
     fn shard_id(&self) -> Self::ShardId {
         GeohashStrategy::with_precision(4).locate(self.point)
     }
 
     fn key(&self) -> Self::Key {
-        self.vehicle_id.clone()
+        self.vehicle_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The ingest surface must survive its protobuf round trip exactly:
+    /// a foreign producer encoding `routers.realtime.v1.Payload` and this
+    /// crate must agree on every field.
+    #[test]
+    fn payload_round_trips_over_the_wire() {
+        let payload = Payload {
+            trip_id: TripId(0xdead),
+            vehicle_id: VehicleId(0xbeef),
+            timestamp: DateTime::from_timestamp_micros(1_775_000_000_123_456).unwrap(),
+            point: Point::new(150.871294, -33.938879),
+        };
+
+        let bytes = payload.encode().expect("payload must encode");
+        let decoded = Payload::decode(&bytes).expect("payload must decode");
+
+        assert_eq!(decoded.trip_id, payload.trip_id);
+        assert_eq!(decoded.vehicle_id, payload.vehicle_id);
+        assert_eq!(decoded.timestamp, payload.timestamp);
+        assert_eq!(decoded.point, payload.point);
     }
 }

--- a/libs/routers_realtime/src/event.rs
+++ b/libs/routers_realtime/src/event.rs
@@ -93,10 +93,12 @@ impl From<&Payload> for proto::Payload {
         proto::Payload {
             trip_id: payload.trip_id.0,
             vehicle_id: payload.vehicle_id.0,
-            timestamp: buffa::MessageField::some(buffa_types::google::protobuf::Timestamp::from_unix(
-                payload.timestamp.timestamp(),
-                payload.timestamp.timestamp_subsec_nanos() as i32,
-            )),
+            timestamp: buffa::MessageField::some(
+                buffa_types::google::protobuf::Timestamp::from_unix(
+                    payload.timestamp.timestamp(),
+                    payload.timestamp.timestamp_subsec_nanos() as i32,
+                ),
+            ),
             point: buffa::MessageField::some(schema::proto::routers::model::v1::Coordinate {
                 longitude: payload.point.x(),
                 latitude: payload.point.y(),

--- a/libs/routers_realtime/src/store/redis.rs
+++ b/libs/routers_realtime/src/store/redis.rs
@@ -34,7 +34,7 @@ impl<T: Storable> RedisStore<T> {
 }
 
 impl<T: Storable> RedisStore<T> {
-    pub async fn get_many(&mut self, vehicle_id: &str, len: usize) -> Result<Vec<T>> {
+    pub async fn get_many(&mut self, vehicle_id: &T::Key, len: usize) -> Result<Vec<T>> {
         let key = format!("vehicle:{}:positions", vehicle_id);
 
         let reply: StreamRangeReply = redis::cmd("XREVRANGE")
@@ -103,8 +103,8 @@ impl<T: Storable> CachedRedisStore<T> {
         }
     }
 
-    pub async fn get_many(&mut self, vehicle_id: &str, len: usize) -> Result<Vec<T>> {
-        if let Some(cached) = self.cache.get(vehicle_id).cloned() {
+    pub async fn get_many(&mut self, vehicle_id: &T::Key, len: usize) -> Result<Vec<T>> {
+        if let Some(cached) = self.cache.get(&vehicle_id.to_string()).cloned() {
             return Ok(cached);
         }
 
@@ -118,7 +118,7 @@ impl<T: Storable> CachedRedisStore<T> {
     /// this the cache is a frozen snapshot of the first read — which, for a
     /// consumer racing the writer on a vehicle's first event, is empty
     /// forever.
-    pub fn push(&mut self, key: &str, item: T, len: usize) {
+    pub fn push(&mut self, key: &T::Key, item: T, len: usize) {
         let entries = self.cache.entry(key.to_string()).or_default();
         entries.insert(0, item);
         entries.truncate(len);

--- a/libs/routers_transition/tests/streaming.rs
+++ b/libs/routers_transition/tests/streaming.rs
@@ -246,6 +246,130 @@ fn reconcile_resumes_and_trims_to_overlap() {
     assert_same_match(&streamed, &batch);
 }
 
+/// The realtime dissemination loop, as the orchestrator + matcher run it:
+/// each tick reconciles the previously-committed trip against the committed
+/// history, pushes only the fresh points, solves, snapshots, and commits the
+/// (serde round-tripped) trip for the next tick.
+///
+/// When the history window covers the whole trip, every tick's snapshot must
+/// span the *entire* trajectory so far — a consumer that replaces its trace
+/// with each result (the realtime viewer) sees the full tail.
+#[test]
+fn ticked_resume_snapshots_full_history() {
+    let net = bent_road();
+    let costing = Costing::default();
+    let generator = || StandardGenerator::new(&net, &costing.emission);
+
+    let points = trajectory().into_points();
+    let mut committed: Option<Trip<MockEntryId>> = None;
+
+    for tick in 1..=points.len() {
+        let history = &points[..tick];
+        let m = Matcher::new(&net, &costing, generator(), AllCompute::default(), &());
+
+        let (mut trip, fresh) = match Continuation::reconcile(committed.take(), history) {
+            Continuation::Resume { trip, fresh } => (trip, fresh),
+            Continuation::Restart { fresh } => (m.begin(), fresh),
+        };
+
+        assert!(
+            trip.layers() + fresh.len() >= history.len(),
+            "tick {tick}: reconcile lost context: {} retained + {} fresh < {} history",
+            trip.layers(),
+            fresh.len(),
+            history.len()
+        );
+
+        for point in fresh {
+            m.push(&mut trip, point).expect("push must anchor");
+        }
+
+        let streamed = m.snapshot(&mut trip).expect("tick must solve");
+        let batch = m
+            .r#match(LineString::from(history.to_vec()))
+            .expect("batch match must succeed");
+        assert_same_match(&streamed, &batch);
+
+        // Tick boundary: the trip travels matcher → orchestrator over the bus.
+        let wire = serde_json::to_string(&trip).expect("trip must serialize");
+        committed = Some(serde_json::from_str(&wire).expect("trip must deserialize"));
+    }
+}
+
+/// The same loop, but the committed history is a sliding window (the
+/// orchestrator's `--context-window`). Reconcile trims the resumed trip to
+/// the window overlap, so the emitted snapshot can never span more points
+/// than the window holds — a supersede-style consumer's trace is bounded by
+/// the orchestrator window, *not* by the trip's true length.
+#[test]
+fn windowed_history_bounds_the_emitted_trace() {
+    const WINDOW: usize = 3;
+
+    let net = bent_road();
+    let costing = Costing::default();
+    let generator = || StandardGenerator::new(&net, &costing.emission);
+
+    let points = trajectory().into_points();
+    let mut committed: Option<Trip<MockEntryId>> = None;
+
+    for tick in 1..=points.len() {
+        let history = &points[tick.saturating_sub(WINDOW)..tick];
+        let m = Matcher::new(&net, &costing, generator(), AllCompute::default(), &());
+
+        let (mut trip, fresh) = match Continuation::reconcile(committed.take(), history) {
+            Continuation::Resume { trip, fresh } => (trip, fresh),
+            Continuation::Restart { fresh } => (m.begin(), fresh),
+        };
+        for point in fresh {
+            m.push(&mut trip, point).expect("push must anchor");
+        }
+        m.solve(&mut trip).expect("tick must solve");
+        committed = Some(trip);
+    }
+
+    let finished = committed.expect("loop ran");
+    assert_eq!(
+        finished.layers(),
+        WINDOW,
+        "the trip is windowed to the history overlap, so per-tick results \
+         cannot carry the full trace"
+    );
+    assert_eq!(finished.points(), &points[points.len() - WINDOW..]);
+}
+
+/// The rendering signature of a gap-cut restart: a trip holding a single
+/// point still emits a non-empty interpolated path — its matched edge's
+/// source node plus the matched position. A supersede-style consumer
+/// replaces the vehicle's whole trace with this short stub.
+#[test]
+fn single_point_restart_emits_a_stub_segment() {
+    let net = bent_road();
+    let costing = Costing::default();
+    let generator = StandardGenerator::new(&net, &costing.emission);
+    let m = Matcher::new(&net, &costing, generator, AllCompute::default(), &());
+
+    let mut trip = m.begin();
+    m.push(&mut trip, point!(x: -118.155, y: 34.1503))
+        .expect("push must anchor");
+
+    let snapshot = m.snapshot(&mut trip).expect("single point must solve");
+    assert_eq!(snapshot.route.len(), 1, "one layer, one chosen candidate");
+    assert!(
+        snapshot.interpolated.is_empty(),
+        "no hop exists, so nothing to interpolate"
+    );
+
+    let routed = routers_transition::candidate::RoutedPath::new(snapshot, &net);
+    assert!(
+        !routed.interpolated.is_empty(),
+        "the routed view still emits a stub (edge source + matched point)"
+    );
+    assert!(
+        routed.interpolated.len() <= 2,
+        "the stub is at most two elements, not a trace"
+    );
+}
+
 /// A history the trip's origins never overlap (a teleport cut everything the
 /// trellis knew) — and the absence of any trip at all — both restart.
 #[test]

--- a/libs/routers_viewer/src/bin/realtime/app.rs
+++ b/libs/routers_viewer/src/bin/realtime/app.rs
@@ -88,7 +88,7 @@ impl eframe::App for RealtimeApp {
             .traces
             .iter()
             .map(|(vehicle_id, trace)| TraceLine {
-                colour: vehicle_colour(vehicle_id),
+                colour: vehicle_colour(*vehicle_id),
                 points: trace.flattened(),
             })
             .collect();

--- a/libs/routers_viewer/src/bin/realtime/plugin.rs
+++ b/libs/routers_viewer/src/bin/realtime/plugin.rs
@@ -25,7 +25,7 @@ impl TracesPlugin {
 
 /// Stable, well-spread colour for a vehicle id: hash to a hue, keep
 /// saturation and value fixed so every trace is legible on light tiles.
-pub fn vehicle_colour(vehicle_id: &str) -> Color32 {
+pub fn vehicle_colour(vehicle_id: routers_realtime::event::VehicleId) -> Color32 {
     let mut hasher = DefaultHasher::new();
     vehicle_id.hash(&mut hasher);
     let hue = (hasher.finish() % 360) as f32 / 360.0;

--- a/libs/routers_viewer/src/bin/realtime/store.rs
+++ b/libs/routers_viewer/src/bin/realtime/store.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use web_time::Instant;
 
 use geo::Point;
-use routers_realtime::event::MatchResult;
+use routers_realtime::event::{MatchResult, VehicleId};
 
 use crate::{E, M};
 
@@ -52,7 +52,7 @@ pub struct StoreStats {
 pub struct TraceStore {
     capacity: usize,
     idle_ttl: Duration,
-    pub traces: HashMap<String, VehicleTrace>,
+    pub traces: HashMap<VehicleId, VehicleTrace>,
     event_bucket: VecDeque<Instant>,
     total_events: u64,
 }

--- a/schema/proto/routers/realtime/v1/event.proto
+++ b/schema/proto/routers/realtime/v1/event.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package routers.realtime.v1;
+
+import "google/protobuf/timestamp.proto";
+import "routers/model/v1/geo.proto";
+
+// A raw vehicle observation: the ingest surface of the realtime pipeline.
+// Producers (in any language) publish this, protobuf-encoded, to the raw
+// events subject (`events.raw.{shard}`).
+//
+// Identifiers are compact 32-bit values, stepped down from the upstream
+// string ids at the ingest boundary (FNV-1a over the string); the strings
+// themselves never cross the wire. The step-down must be stable across
+// processes and runs — every producer must derive the same id for the same
+// vehicle.
+message Payload {
+  // The trip this observation was made under.
+  uint32 trip_id = 1;
+
+  // The observed vehicle.
+  uint32 vehicle_id = 2;
+
+  // When the observation was made.
+  google.protobuf.Timestamp timestamp = 3;
+
+  // Where the vehicle was observed.
+  routers.model.v1.Coordinate point = 4;
+}


### PR DESCRIPTION
### Changes

- Use `proto` item in event stream (not postcard Rust struct), for inter-language compatability.
- Cast (stepdown) vehicle and trip identifiers into integer values (more compressible, easier to anonymize)
- Use 5min gap instead of 2min (cover higher % of vehicles)
- Add some tests, etc.