### PR TITLE
fix: Optimize Caching in Workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,8 +8,14 @@ on:
     types: [opened, synchronize]
   workflow_dispatch:
 
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   PROTOC_VERSION: 3.20.3
+  # Keep in step with the `buffa` workspace dependency and flake.nix.
+  BUFFA_VERSION: 0.6.0
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -40,22 +46,38 @@ jobs:
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Caches are branch-scoped, so only `main` writes one for PRs to restore.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Cache packaging plugin
+        id: packager-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo-tools
+          key: buffa-packaging-${{ runner.os }}-${{ runner.arch }}-${{ env.BUFFA_VERSION }}
 
       - name: Install Packager
+        if: steps.packager-cache.outputs.cache-hit != 'true'
         run: |
-          cargo install --locked protoc-gen-buffa-packaging
+          cargo install --locked --root ~/.cargo-tools \
+            protoc-gen-buffa-packaging@${{ env.BUFFA_VERSION }}
+
+      - name: Put packaging plugin on PATH
+        run: echo "$HOME/.cargo-tools/bin" >> "$GITHUB_PATH"
 
       - name: Generate Schema
         run: |
           buf generate
 
+      # `routers_viewer` has no benches; excluding it drops the whole GUI stack.
       - name: 🔨Build (workspace)
-        run: cargo codspeed build --workspace --jobs 4
+        run: cargo codspeed build --workspace --exclude routers_viewer
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v3
         with:
-          run: INSTA_UPDATE=always cargo codspeed run --workspace
+          run: INSTA_UPDATE=always cargo codspeed run --workspace --exclude routers_viewer
           token: ${{ secrets.CODSPEED_TOKEN }}
 
       - name: Check for snapshot drift

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           lfs: true
 
+      - name: install protoc
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc@${{ env.PROTOC_VERSION }}
+
       - name: Install Buf
         uses: bufbuild/buf-action@v1
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,12 +3,18 @@ name: Format & Check
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: format-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   PROTOC_VERSION: 3.20.3
+  # Keep in step with the `buffa` workspace dependency and flake.nix.
+  BUFFA_VERSION: 0.6.0
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -27,6 +33,9 @@ jobs:
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Caches are branch-scoped, so only `main` writes one for PRs to restore.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install `toolchain`
         run: rustup toolchain install stable
@@ -37,9 +46,21 @@ jobs:
       - name: Install `clippy`
         run: rustup component add clippy
 
+      - name: Cache packaging plugin
+        id: packager-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo-tools
+          key: buffa-packaging-${{ runner.os }}-${{ runner.arch }}-${{ env.BUFFA_VERSION }}
+
       - name: Install Packager
+        if: steps.packager-cache.outputs.cache-hit != 'true'
         run: |
-          cargo install --locked protoc-gen-buffa-packaging
+          cargo install --locked --root ~/.cargo-tools \
+            protoc-gen-buffa-packaging@${{ env.BUFFA_VERSION }}
+
+      - name: Put packaging plugin on PATH
+        run: echo "$HOME/.cargo-tools/bin" >> "$GITHUB_PATH"
 
       - name: Generate Schema
         run: |
@@ -49,4 +70,4 @@ jobs:
         run: cargo fmt --check
 
       - name: 🔍 Clippy
-        run: cargo clippy
+        run: cargo clippy --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,18 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   PROTOC_VERSION: 3.20.3
+  # Keep in step with the `buffa` workspace dependency and flake.nix.
+  BUFFA_VERSION: 0.6.0
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -40,10 +46,25 @@ jobs:
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Caches are branch-scoped, so only `main` writes one for PRs to restore.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Cache packaging plugin
+        id: packager-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo-tools
+          key: buffa-packaging-${{ runner.os }}-${{ runner.arch }}-${{ env.BUFFA_VERSION }}
 
       - name: Install Packager
+        if: steps.packager-cache.outputs.cache-hit != 'true'
         run: |
-          cargo install --locked protoc-gen-buffa-packaging
+          cargo install --locked --root ~/.cargo-tools \
+            protoc-gen-buffa-packaging@${{ env.BUFFA_VERSION }}
+
+      - name: Put packaging plugin on PATH
+        run: echo "$HOME/.cargo-tools/bin" >> "$GITHUB_PATH"
 
       - name: Generate Schema
         run: |


### PR DESCRIPTION
## Changes
- Use `BUFFA_VERSION` environment variable for consistent versioning across workflows
- Add concurrency groups with selective cancellation for PR branches- Configure Rust cache with `save-if` condition to write only on 
- Add packaging plugin cache using `actions/cache@v4`
- Exclude `routers_viewer` workspace member from build and codspeed runs