### PR TITLE
feat: Widen VehicleID to `u64` and retire TripID

### DIFF
--- a/libs/routers_realtime/bin/replay.rs
+++ b/libs/routers_realtime/bin/replay.rs
@@ -3,7 +3,7 @@
 use anyhow::Context;
 use async_nats::{ConnectOptions, ServerAddr};
 use clap::Parser;
-use fnv_rs::{Fnv32, FnvHasher};
+use fnv_rs::{Fnv64, FnvHasher};
 use futures::SinkExt;
 use geo::Point;
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
@@ -13,7 +13,7 @@ use log::{debug, info};
 use polars::prelude::*;
 use routers_realtime::{
     bus::NATSSink,
-    event::{Payload, TripId, VehicleId},
+    event::{Payload, VehicleId},
 };
 use routers_shard::{GeohashStrategy, ShardingStrategy};
 use std::{fmt::Write, path::PathBuf, time::Duration};
@@ -65,7 +65,6 @@ const BUFFERED_PUBLISH_SIZE: usize = 8;
 
 // Column names
 const VEHICLE_ID_COL: &str = "VehicleID";
-const TRIP_ID_COL: &str = "TripID";
 
 const PROVIDER_COL: &str = "Provider";
 const EVENT_TIME_COL: &str = "EventTime";
@@ -124,7 +123,6 @@ async fn main() -> anyhow::Result<()> {
         .finish()?
         .sort([EVENT_TIME_COL], SortMultipleOptions::default())
         .select([
-            col(TRIP_ID_COL),
             col(VEHICLE_ID_COL),
             col(PROVIDER_COL),
             parse_datetime(TIME_FORMAT).fill_null(parse_datetime(TIME_FORMAT_FRACTIONAL)),
@@ -200,7 +198,6 @@ async fn main() -> anyhow::Result<()> {
 }
 
 fn rows_of(df: &DataFrame) -> PolarsResult<impl Iterator<Item = (u64, Payload)> + '_> {
-    let trip = df.column(TRIP_ID_COL)?.str()?;
     let vehicle = df.column(VEHICLE_ID_COL)?.str()?;
     let provider = df.column(PROVIDER_COL)?.str()?;
     let etime = df.column(EVENT_TIME_COL)?.datetime()?;
@@ -208,20 +205,20 @@ fn rows_of(df: &DataFrame) -> PolarsResult<impl Iterator<Item = (u64, Payload)> 
     let lon = df.column(LONGITUDE_COL)?.f64()?;
 
     Ok(izip!(
-        trip.into_iter(),
         vehicle.into_iter(),
         provider.into_iter(),
         etime.into_iter(),
         lat.into_iter(),
         lon.into_iter()
     )
-    .filter_map(|(trip, vehicle, _, etime, lat, lon)| {
-        let trip_id: [u8; 4] = Fnv32::hash(trip?).as_bytes().try_into().ok()?;
-        let vehicle_id: [u8; 4] = Fnv32::hash(vehicle?).as_bytes().try_into().ok()?;
+    .filter_map(|(vehicle, _, etime, lat, lon)| {
+        // The id contract (schema: realtime/v1/event.proto): the FNV-1a
+        // 64-bit hash of the upstream string, as an integer. `as_bytes`
+        // yields it big-endian.
+        let vehicle_id: [u8; 8] = Fnv64::hash(vehicle?).as_bytes().try_into().ok()?;
 
         let payload = Payload {
-            trip_id: TripId(u32::from_le_bytes(trip_id)),
-            vehicle_id: VehicleId(u32::from_le_bytes(vehicle_id)),
+            vehicle_id: VehicleId(u64::from_be_bytes(vehicle_id)),
             // The column is parsed as microseconds since the Unix epoch.
             timestamp: chrono::DateTime::from_timestamp_micros(etime.unwrap_or_default())
                 .unwrap_or_default(),

--- a/libs/routers_realtime/src/event.rs
+++ b/libs/routers_realtime/src/event.rs
@@ -19,10 +19,10 @@ macro_rules! wire_id {
     ($(#[$doc:meta])* $name:ident) => {
         $(#[$doc])*
         #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-        pub struct $name(pub u32);
+        pub struct $name(pub u64);
 
-        impl From<u32> for $name {
-            fn from(value: u32) -> Self {
+        impl From<u64> for $name {
+            fn from(value: u64) -> Self {
                 Self(value)
             }
         }
@@ -36,12 +36,9 @@ macro_rules! wire_id {
 }
 
 wire_id! {
-    /// Identifies one vehicle across its events, history, and matches.
+    /// Identifies one vehicle across its events, history, and matches:
+    /// the FNV-1a 64-bit hash of the upstream string id.
     VehicleId
-}
-wire_id! {
-    /// Identifies the trip an event was observed under.
-    TripId
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -60,7 +57,6 @@ pub struct MatchResult<E: Entry, M: Metadata> {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Payload {
-    pub trip_id: TripId,
     pub vehicle_id: VehicleId,
 
     /// When the observation was made. Serialized as microseconds since the
@@ -91,7 +87,6 @@ impl Wire for Payload {
 impl From<&Payload> for proto::Payload {
     fn from(payload: &Payload) -> Self {
         proto::Payload {
-            trip_id: payload.trip_id.0,
             vehicle_id: payload.vehicle_id.0,
             timestamp: buffa::MessageField::some(
                 buffa_types::google::protobuf::Timestamp::from_unix(
@@ -115,7 +110,6 @@ impl From<proto::Payload> for Payload {
         let timestamp = payload.timestamp.into_option().unwrap_or_default();
 
         Payload {
-            trip_id: TripId(payload.trip_id),
             vehicle_id: VehicleId(payload.vehicle_id),
             timestamp: DateTime::from_timestamp(timestamp.seconds, timestamp.nanos as u32)
                 .unwrap_or_default(),
@@ -168,8 +162,8 @@ mod tests {
     #[test]
     fn payload_round_trips_over_the_wire() {
         let payload = Payload {
-            trip_id: TripId(0xdead),
-            vehicle_id: VehicleId(0xbeef),
+            // Above u32::MAX, so a truncation anywhere in the round trip fails.
+            vehicle_id: VehicleId(0xdead_beef_cafe_f00d),
             timestamp: DateTime::from_timestamp_micros(1_775_000_000_123_456).unwrap(),
             point: Point::new(150.871294, -33.938879),
         };
@@ -177,7 +171,6 @@ mod tests {
         let bytes = payload.encode().expect("payload must encode");
         let decoded = Payload::decode(&bytes).expect("payload must decode");
 
-        assert_eq!(decoded.trip_id, payload.trip_id);
         assert_eq!(decoded.vehicle_id, payload.vehicle_id);
         assert_eq!(decoded.timestamp, payload.timestamp);
         assert_eq!(decoded.point, payload.point);

--- a/schema/proto/routers/realtime/v1/event.proto
+++ b/schema/proto/routers/realtime/v1/event.proto
@@ -9,17 +9,18 @@ import "routers/model/v1/geo.proto";
 // Producers (in any language) publish this, protobuf-encoded, to the raw
 // events subject (`events.raw.{shard}`).
 //
-// Identifiers are compact 32-bit values, stepped down from the upstream
-// string ids at the ingest boundary (FNV-1a over the string); the strings
-// themselves never cross the wire. The step-down must be stable across
-// processes and runs — every producer must derive the same id for the same
-// vehicle.
+// The vehicle identifier is a compact 64-bit value, stepped down from the
+// upstream string id at the ingest boundary: the FNV-1a 64-bit hash of the
+// string's UTF-8 bytes, taken as an integer. The strings themselves never
+// cross the wire. The step-down must be stable across processes and runs —
+// every producer must derive the same id for the same vehicle.
 message Payload {
-  // The trip this observation was made under.
-  uint32 trip_id = 1;
+  // Field 1 carried a 32-bit trip id; retired, never reuse.
+  reserved 1;
+  reserved "trip_id";
 
   // The observed vehicle.
-  uint32 vehicle_id = 2;
+  uint64 vehicle_id = 2;
 
   // When the observation was made.
   google.protobuf.Timestamp timestamp = 3;


### PR DESCRIPTION
Switching to u64 for vehicle identifier to match an upstream retirement. Also removes the trip id, as it's now an external responsibility.