### PR TITLE
feat: Expose Viterbi Convergence Point

### DIFF
--- a/libs/routers_trellis/src/solver/viterbi.rs
+++ b/libs/routers_trellis/src/solver/viterbi.rs
@@ -94,6 +94,31 @@ impl ViterbiSolver {
         }
     }
 
+    /// The predecessor of `chosen` across `boundary`: the node reaching it
+    /// cheapest, ties to the lowest node. The chosen node's own weight is a
+    /// shared constant per candidate set, so ignoring it preserves the argmin.
+    ///
+    /// This tie-break is what makes "the optimal path ending at a node"
+    /// well-defined, and [`backtrack`](Self::backtrack) and
+    /// [`convergence`](Self::convergence) must agree on it exactly — the
+    /// convergence guarantee is stated over the paths backtracking chooses.
+    fn predecessor(boundary: &Boundary, dist: &[u32], chosen: NodeId) -> Option<NodeId> {
+        let into_chosen = boundary
+            .weights
+            .iter()
+            .skip(chosen.index())
+            .step_by(boundary.next.len());
+
+        dist[boundary.cur.clone()]
+            .iter()
+            .zip(into_chosen)
+            .map(|(&cost, &edge)| cost.saturating_add(edge))
+            .enumerate()
+            .map(|(node, cost)| (cost, NodeId::from_index(node)))
+            .min()
+            .map(|(_, predecessor)| predecessor)
+    }
+
     /// Trace the optimal path backwards through `dist`.
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip_all))]
     fn backtrack(
@@ -118,28 +143,11 @@ impl ViterbiSolver {
             return Err(SolveError::Unreachable);
         }
 
-        // Walk the boundaries in reverse, at each picking the predecessor that
-        // reaches the chosen node cheapest; ties go to the lowest node. The
-        // chosen node's own weight is a shared constant per candidate set, so
-        // ignoring it preserves the argmin.
         let tail_to_head: Vec<NodeId> = boundaries
             .iter()
             .rev()
             .scan(final_node, |chosen, boundary| {
-                let into_chosen = boundary
-                    .weights
-                    .iter()
-                    .skip(chosen.index())
-                    .step_by(boundary.next.len());
-
-                let (_, predecessor) = dist[boundary.cur.clone()]
-                    .iter()
-                    .zip(into_chosen)
-                    .map(|(&cost, &edge)| cost.saturating_add(edge))
-                    .enumerate()
-                    .map(|(node, cost)| (cost, NodeId::from_index(node)))
-                    .min()?;
-
+                let predecessor = Self::predecessor(boundary, dist, *chosen)?;
                 *chosen = predecessor;
                 Some(predecessor)
             })
@@ -152,6 +160,91 @@ impl ViterbiSolver {
             .collect();
         Ok(Path::new(nodes, best_cost))
     }
+
+    /// The sweep behind [`convergence`](Self::convergence), positioned by a
+    /// prepared DP table.
+    ///
+    /// Distinct nodes map to single predecessors, so the frontier only
+    /// narrows walking backwards, and the first collapse is the latest one.
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip_all))]
+    fn converged_layer(
+        last: Range<usize>,
+        boundaries: &[Boundary],
+        dist: &[u32],
+    ) -> Option<LayerId> {
+        let mut frontier: Vec<NodeId> = dist[last]
+            .iter()
+            .enumerate()
+            .filter(|&(_, &cost)| cost < INF_W)
+            .map(|(node, _)| NodeId::from_index(node))
+            .collect();
+
+        if frontier.len() == 1 {
+            return Some(LayerId(boundaries.len() as u32));
+        }
+
+        for boundary in boundaries.iter().rev() {
+            frontier = frontier
+                .iter()
+                .filter_map(|&node| Self::predecessor(boundary, dist, node))
+                .collect();
+            frontier.sort_unstable();
+            frontier.dedup();
+
+            // Predecessors live in the boundary's lower layer, which is what
+            // its id names.
+            if frontier.len() == 1 {
+                return Some(boundary.id);
+            }
+        }
+
+        None
+    }
+
+    /// Resolve every boundary and run the forward pass: the positioned DP
+    /// table that backtracking and convergence detection both read.
+    fn tables<'a>(
+        &self,
+        t: &'a Trellis,
+    ) -> Result<(Vec<Boundary<'a>>, Range<usize>, Vec<u32>), SolveError> {
+        let boundaries = Self::boundaries(t).inspect_err(|e| warn!("{e}"))?;
+        let last = t.layer_ranges().last().unwrap_or(0..0);
+
+        // The first layer's starting cost is its node weights; every later
+        // layer is overwritten by the forward pass before use.
+        let mut dist = t.node_table().to_vec();
+        self.forward_pass(&boundaries, &mut dist);
+
+        Ok((boundaries, last, dist))
+    }
+
+    /// The convergence point of `t`'s solution: the latest layer at which the
+    /// optimal paths ending in every *live* final node (cost below infinity —
+    /// every node a future layer could extend) all pass through one shared
+    /// node. The forward pass is prefix-stable, so appending layers can never
+    /// change the chosen path at or before this layer — which is what lets a
+    /// streaming caller emit that prefix and cut the trellis behind it.
+    ///
+    /// Errors exactly where [`solve`] errors, so `None` means one thing only:
+    /// live paths exist but never fuse. Across solvable appends the point
+    /// never moves backwards.
+    ///
+    /// A pure query, priced accordingly: it rebuilds the DP table [`solve`]
+    /// builds, so asking is one extra forward pass. Callers on a hot path
+    /// should ask once per solve, not once per read.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(level = "debug", name = "convergence", skip(self, t), fields(layers = t.layers()))
+    )]
+    pub fn convergence(&self, t: &Trellis) -> Result<Option<LayerId>, SolveError> {
+        let (boundaries, last, dist) = self.tables(t)?;
+
+        if dist[last.clone()].iter().all(|&cost| cost >= INF_W) {
+            return Err(SolveError::Unreachable);
+        }
+
+        Ok(Self::converged_layer(last, &boundaries, &dist))
+    }
 }
 
 impl Solve for ViterbiSolver {
@@ -163,14 +256,7 @@ impl Solve for ViterbiSolver {
     fn solve(&self, t: &Trellis) -> Result<Path, SolveError> {
         debug!("{} layers, widths={:?}", t.layers(), t.widths());
 
-        let boundaries = Self::boundaries(t).inspect_err(|e| warn!("{e}"))?;
-        let last = t.layer_ranges().last().unwrap_or(0..0);
-
-        // The first layer's starting cost is its node weights; every later
-        // layer is overwritten by the forward pass before use.
-        let mut dist = t.node_table().to_vec();
-
-        self.forward_pass(&boundaries, &mut dist);
+        let (boundaries, last, dist) = self.tables(t)?;
         let path = self.backtrack(last, &boundaries, &dist)?;
 
         debug!("cost={}", path.cost);

--- a/libs/routers_trellis/tests/trellis.rs
+++ b/libs/routers_trellis/tests/trellis.rs
@@ -472,3 +472,162 @@ fn one_solver_interleaved_across_two_trellises() {
         assert_eq!(solver.solve(&b), ViterbiSolver::new().solve(&b));
     }
 }
+
+// ---- convergence ----
+
+#[test]
+fn single_live_final_node_converges_at_the_last_layer() {
+    let t = line(&[2, 3, 5]);
+    let solver = ViterbiSolver::new();
+    assert_eq!(solver.solve(&t).unwrap().nodes, vec![NodeId(0); 4]);
+    assert_eq!(solver.convergence(&t).unwrap(), Some(LayerId(3)));
+}
+
+#[test]
+fn bottleneck_layer_is_the_convergence_point() {
+    // Both final nodes are live, but every path threads the width-1 middle
+    // layer — the prefix up to it is final, the tail is still ambiguous.
+    let mut t = Trellis::new(vec![2u32, 1, 2]).unwrap();
+    t.fill_transition(LayerId(0), &[1, 2]).unwrap();
+    t.fill_transition(LayerId(1), &[5, 5]).unwrap();
+
+    let solver = ViterbiSolver::new();
+    let path = solver.solve(&t).unwrap();
+    assert_eq!(path.nodes, vec![NodeId(0), NodeId(0), NodeId(0)]);
+    assert_eq!(solver.convergence(&t).unwrap(), Some(LayerId(1)));
+}
+
+#[test]
+fn parallel_lanes_never_converge() {
+    // Two disjoint equal-cost lanes: neither prefix is final, ever.
+    let lanes = [1, NO_EDGE, NO_EDGE, 1];
+    let mut t = Trellis::new(vec![2u32, 2, 2]).unwrap();
+    t.fill_transition(LayerId(0), &lanes).unwrap();
+    t.fill_transition(LayerId(1), &lanes).unwrap();
+
+    assert_eq!(ViterbiSolver::new().convergence(&t).unwrap(), None);
+}
+
+#[test]
+fn dead_final_nodes_do_not_block_convergence() {
+    // The final layer is width 2, but only node 0 is reachable — a future
+    // layer can only extend through it, so the whole path is converged.
+    let mut t = Trellis::new(vec![2u32, 2]).unwrap();
+    t.fill_transition(LayerId(0), &[1, NO_EDGE, 2, NO_EDGE])
+        .unwrap();
+
+    let solver = ViterbiSolver::new();
+    assert_eq!(solver.solve(&t).unwrap().nodes, vec![NodeId(0); 2]);
+    assert_eq!(solver.convergence(&t).unwrap(), Some(LayerId(1)));
+}
+
+#[test]
+fn convergence_of_a_certified_solve_reads_from_its_trellis() {
+    // The intended callsite shape: solve certifies, then the caller asks the
+    // solver about the trellis the certificate holds.
+    let mut t = Trellis::new(vec![2u32, 1, 2]).unwrap();
+    t.fill_transition(LayerId(0), &[1, 2]).unwrap();
+    t.fill_transition(LayerId(1), &[5, 5]).unwrap();
+
+    let solved = t.solve(&ViterbiSolver::new()).unwrap();
+    let convergence = ViterbiSolver::new().convergence(solved.trellis()).unwrap();
+    assert_eq!(convergence, Some(LayerId(1)));
+}
+
+#[test]
+fn convergence_errors_on_pending_like_solve() {
+    let t = Trellis::new(vec![2u32, 2]).unwrap();
+    assert_eq!(
+        ViterbiSolver::new().convergence(&t),
+        Err(SolveError::NotResolved(LayerId(0)))
+    );
+}
+
+#[test]
+fn convergence_errors_on_unreachable_like_solve() {
+    // Symmetry with solve keeps None meaning one thing: live but unfused.
+    let mut t = Trellis::new(vec![2u32, 2]).unwrap();
+    t.fill_transition(LayerId(0), &[NO_EDGE; 4]).unwrap();
+    assert_eq!(
+        ViterbiSolver::new().convergence(&t),
+        Err(SolveError::Unreachable)
+    );
+}
+
+#[test]
+fn a_dead_append_errors_rather_than_regressing_the_point() {
+    // A fused frontier cannot unfuse, but it can die: an append no live path
+    // crosses errors on both APIs instead of demoting Some to None.
+    let mut t = line(&[2, 3]);
+    let solver = ViterbiSolver::new();
+    assert_eq!(solver.convergence(&t).unwrap(), Some(LayerId(2)));
+
+    let boundary = t.last_id();
+    t.add_layer(1).unwrap();
+    t.fill_transition(boundary, &[NO_EDGE]).unwrap();
+
+    assert_eq!(solver.solve(&t), Err(SolveError::Unreachable));
+    assert_eq!(solver.convergence(&t), Err(SolveError::Unreachable));
+}
+
+/// The guarantee itself, tested as stated: everything at or before the
+/// reported convergence point survives any append. Also its corollary — the
+/// point never moves backwards — since a new frontier's paths all thread the
+/// old one's fusion node.
+#[test]
+fn converged_prefix_is_stable_under_appends() {
+    let width = 4u32;
+    let solver = ViterbiSolver::new();
+    let mut converged_mid_trellis = false;
+
+    for seed in 0u64..20 {
+        let mut t = random_noded_trellis(6, width, seed);
+        let mut path = solver.solve(&t).unwrap();
+        let mut convergence = solver.convergence(&t).unwrap();
+
+        let mut s = seed.wrapping_mul(0x9e37_79b9_7f4a_7c15) | 1;
+        let mut rng = || {
+            s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+            ((s >> 40) as u32) % 100
+        };
+
+        for _ in 0..4 {
+            let boundary = t.last_id();
+            t.add_layer(width).unwrap();
+            let row: Vec<u32> = (0..(width * width) as usize).map(|_| rng()).collect();
+            t.fill_transition(boundary, &row).unwrap();
+            let weights: Vec<u32> = (0..width as usize).map(|_| rng()).collect();
+            t.fill_nodes(t.last_id(), &weights).unwrap();
+
+            let next_path = solver.solve(&t).unwrap();
+            let next_convergence = solver.convergence(&t).unwrap();
+
+            if let Some(layer) = convergence {
+                if layer < t.last_id() {
+                    converged_mid_trellis = true;
+                }
+
+                let frozen = ..=layer.index();
+                assert_eq!(
+                    next_path.nodes[frozen], path.nodes[frozen],
+                    "seed {seed}: converged prefix changed after an append"
+                );
+
+                let moved = next_convergence.expect(
+                    "a fused frontier cannot unfuse: its paths all thread the old fusion node",
+                );
+                assert!(
+                    moved >= layer,
+                    "seed {seed}: convergence moved backwards ({moved} < {layer})"
+                );
+            }
+
+            (path, convergence) = (next_path, next_convergence);
+        }
+    }
+
+    assert!(
+        converged_mid_trellis,
+        "no seed converged mid-trellis; the stability assertions never ran against a live tail"
+    );
+}


### PR DESCRIPTION
Matcher nodes had no way to indicate to downstream consumers when a notify will never be modified further.

Therefore, the nodes must emit the entire history it know of, including the trellis, on each inbound message.

The convergence point is a layer within the transition trellis which all end-layer candidates which remain reachable point back to.

A way to compartmentalise this is best explained using intuition. Imagine a vehicle moving along a highway, then taking an offramp to join a highway perpendicular to the one it was in before. We might assume the candidates now all lie within this new highway (after some time) and so candidates on the original highway further down, etc. can no longer reach these new candidates as they all share a *common* route through the off-ramp. This is our convergence point.