### PR TITLE
feat: Include Observation Timestamp(s)

### DIFF
--- a/libs/routers_realtime/bin/matcher.rs
+++ b/libs/routers_realtime/bin/matcher.rs
@@ -125,8 +125,8 @@ impl Matching {
         };
 
         info_span!("push", points = fresh.len()).in_scope(|| {
-            for point in fresh {
-                match matcher.push(&mut trip, point) {
+            for origin in fresh {
+                match matcher.push(&mut trip, origin) {
                     Ok(_) => {}
                     Err(MatchError::Unanchored(err)) => {
                         info_span!("point_drop", reason = "unanchored")

--- a/libs/routers_realtime/bin/orchestrator.rs
+++ b/libs/routers_realtime/bin/orchestrator.rs
@@ -10,14 +10,14 @@ use routers_realtime::{
     event::{MatchContext, MatchResult, Payload, RawEvent},
     store::RedisStore,
 };
-use routers_transition::Continuation;
 use routers_transition::matcher::Trip;
+use routers_transition::{Continuation, Origin};
 
 use anyhow::{Context, Result};
 use async_nats::{ConnectOptions, ServerAddr};
 use clap::Parser;
 use futures::{SinkExt, StreamExt};
-use geo::{Distance, Haversine, Point};
+use geo::{Distance, Haversine};
 use log::{debug, error, info};
 use tokio::sync::mpsc;
 use tracing::{Instrument, field, info_span, warn};
@@ -354,14 +354,14 @@ impl App<'_> {
         history.sort_by_key(|event| event.timestamp);
         history.dedup_by_key(|event| event.timestamp);
 
-        let points = history
+        let origins = history
             .into_iter()
-            .map(|event| event.point)
-            .collect::<Vec<Point>>();
+            .map(|event| Origin::new(event.point, event.timestamp.timestamp_micros()))
+            .collect::<Vec<_>>();
 
         let previous = self.trips.get(&vehicle_id).map(|trip| trip.get().clone());
         let continuation =
-            info_span!("reconcile").in_scope(|| Continuation::reconcile(previous, &points));
+            info_span!("reconcile").in_scope(|| Continuation::reconcile(previous, &origins));
 
         let span = tracing::Span::current();
         span.record("cut", cut);

--- a/libs/routers_transition/benches/matching.rs
+++ b/libs/routers_transition/benches/matching.rs
@@ -13,7 +13,7 @@ use geo::{Coord, LineString, point};
 
 use routers_network::mock::{MockEntryId, MockNetwork, MockNetworkBuilder};
 use routers_transition::{
-    MatchSimpleExt, Matcher,
+    MatchSimpleExt, Matcher, Origin,
     costing::CostingStrategies,
     layer::generation::{LayerGeneration, StandardGenerator},
     weigh::AllCompute,
@@ -95,8 +95,10 @@ fn bench_streaming_match(c: &mut Criterion) {
                 let matcher = Matcher::new(&net, &costing, generator, AllCompute::default(), &());
 
                 let mut trip = matcher.begin();
-                for &point in &points {
-                    matcher.push(&mut trip, point).expect("push must anchor");
+                for (index, &point) in points.iter().enumerate() {
+                    matcher
+                        .push(&mut trip, Origin::new(point, index as i64))
+                        .expect("push must anchor");
                     matcher.solve(&mut trip).expect("solve must succeed");
                 }
 

--- a/libs/routers_transition/examples/streaming.rs
+++ b/libs/routers_transition/examples/streaming.rs
@@ -7,7 +7,7 @@ use routers_transition::costing::CostingStrategies;
 use routers_transition::layer::generation::StandardGenerator;
 use routers_transition::matcher::Trip;
 use routers_transition::weigh::AllCompute;
-use routers_transition::{MatchError, Matcher};
+use routers_transition::{MatchError, Matcher, Origin};
 use routers_trellis::LayerId;
 
 /// A staircase road: west along lat 34.15, south, then west again.
@@ -47,8 +47,8 @@ fn main() -> Result<(), MatchError> {
     let mut trip = matcher.begin();
 
     for (tick, position) in stream().into_iter().enumerate() {
-        // `push` is atomic, it either adds the position, or fails.
-        let layer = match matcher.push(&mut trip, position) {
+        // `push` is atomic, it either adds the observation, or fails.
+        let layer = match matcher.push(&mut trip, Origin::new(position, tick as i64)) {
             Ok(layer) => layer,
             Err(MatchError::Unanchored(e)) => {
                 println!("tick {tick}: dropped off-network point ({e})");

--- a/libs/routers_transition/src/lib.rs
+++ b/libs/routers_transition/src/lib.rs
@@ -37,7 +37,7 @@ extern crate alloc;
 #[doc(inline)]
 pub use r#match::{MatchOptions, MatchSimpleExt};
 #[doc(inline)]
-pub use matcher::{Continuation, Matcher};
+pub use matcher::{Continuation, Matcher, Origin};
 #[doc(inline)]
 pub use primitives::MatchError;
 

--- a/libs/routers_transition/src/matcher/continuation.rs
+++ b/libs/routers_transition/src/matcher/continuation.rs
@@ -1,8 +1,7 @@
-use geo::Point;
 use routers_network::Entry;
 use serde::{Deserialize, Serialize};
 
-use crate::matcher::Trip;
+use crate::matcher::{Origin, Trip};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(serialize = "E: Serialize", deserialize = "E: Deserialize<'de>"))]
@@ -11,14 +10,14 @@ where
     E: Entry,
 {
     /// The trip agrees with the history, and is resumable. The
-    /// fresh points are those beyond the trip which are not yet
-    /// matched against the history.
-    Resume { trip: Trip<E>, fresh: Vec<Point> },
+    /// fresh observations are those beyond the trip which are not
+    /// yet matched against the history.
+    Resume { trip: Trip<E>, fresh: Vec<Origin> },
 
     /// The trip contradicts the history (or there was none), and
     /// must be restarted from scratch, the raw event history
     /// is given.
-    Restart { fresh: Vec<Point> },
+    Restart { fresh: Vec<Origin> },
 }
 
 impl<E> Continuation<E>
@@ -26,14 +25,18 @@ where
     E: Entry,
 {
     /// Reconcile a persisted trip with the committed `history` (chronological, oldest first).
-    pub fn reconcile(trip: Option<Trip<E>>, history: &[Point]) -> Self {
+    ///
+    /// Overlap is exact [`Origin`] equality — timestamp and position both.
+    /// A layer sharing a timestamp with the history but not a position was
+    /// solved against data the history contradicts, so it must not resume.
+    pub fn reconcile(trip: Option<Trip<E>>, history: &[Origin]) -> Self {
         let Some(mut trip) = trip else {
             return Self::Restart {
                 fresh: history.to_vec(),
             };
         };
 
-        let origins = trip.points();
+        let origins = trip.origins();
         let bound = origins.len().min(history.len());
         let overlap = (0..=bound)
             .rev()

--- a/libs/routers_transition/src/matcher/entity.rs
+++ b/libs/routers_transition/src/matcher/entity.rs
@@ -1,14 +1,14 @@
 use alloc::borrow::Cow;
 
-use geo::{LineString, Point};
+use geo::LineString;
 use routers_network::{Entry, Network};
 use routers_trellis::{LayerId, Path, SolveError, TrellisError, ViterbiSolver};
 
 use crate::candidate::{CandidateRef, CollapsedPath};
 use crate::costing::{CostingStrategies, EmissionStrategy, TransitionStrategy};
 use crate::layer::generation::LayerGeneration;
-use crate::matcher::Trip;
 use crate::matcher::trip::TripState;
+use crate::matcher::{Origin, Trip};
 use crate::primitives::{
     Disconnected, DisconnectedError, MatchError, Reachable, RoutingContext, Unanchored,
     UnanchoredError,
@@ -133,22 +133,22 @@ where
         }
     }
 
-    /// Append one trajectory position as a new layer: generate its candidates,
+    /// Append one observation as a new layer: generate its candidates,
     /// extend the trellis, and record the emission costs as node weights — one
     /// atomic operation, so the trip cannot desynchronise.
     ///
-    /// A point with no road candidate within the generator's search radius is
-    /// rejected ([`UnanchoredError`]) and leaves the trip unchanged, so the
-    /// caller may drop or retry the point.
-    pub fn push(&self, trip: &mut Trip<N::Entry>, origin: Point) -> Result<LayerId, MatchError> {
+    /// An observation with no road candidate within the generator's search
+    /// radius is rejected ([`UnanchoredError`]) and leaves the trip unchanged,
+    /// so the caller may drop or retry it.
+    pub fn push(&self, trip: &mut Trip<N::Entry>, origin: Origin) -> Result<LayerId, MatchError> {
         let layer = trip.next_id();
-        let candidates = self.generator.candidates(&origin, layer);
+        let candidates = self.generator.candidates(&origin.point, layer);
 
         if candidates.is_empty() {
             return Err(UnanchoredError {
                 points: vec![Unanchored {
                     layer: layer.index(),
-                    origin,
+                    origin: origin.point,
                 }],
             }
             .into());
@@ -157,17 +157,24 @@ where
         Ok(trip.push_layer(origin, candidates)?)
     }
 
-    /// Append many positions at once, generating their candidates in parallel.
+    /// Append many observations at once, generating their candidates in
+    /// parallel.
     ///
-    /// Any point with no candidate rejects the whole batch ([`UnanchoredError`]
-    /// reporting *every* such point) and leaves the trip unchanged.
-    pub fn extend(&self, trip: &mut Trip<N::Entry>, points: &[Point]) -> Result<(), MatchError> {
+    /// Any observation with no candidate rejects the whole batch
+    /// ([`UnanchoredError`] reporting *every* such point) and leaves the trip
+    /// unchanged.
+    pub fn extend(&self, trip: &mut Trip<N::Entry>, origins: &[Origin]) -> Result<(), MatchError> {
         let first_layer = trip.next_id();
-        let per_layer = self.generator.generate(points, first_layer);
+
+        let points = origins
+            .iter()
+            .map(|origin| origin.point)
+            .collect::<Vec<_>>();
+        let per_layer = self.generator.generate(&points, first_layer);
 
         let unanchored = per_layer
             .iter()
-            .zip(points)
+            .zip(&points)
             .enumerate()
             .filter(|(_, (candidates, _))| candidates.is_empty())
             .map(|(offset, (_, &origin))| Unanchored {
@@ -179,7 +186,7 @@ where
             return Err(UnanchoredError { points: unanchored }.into());
         }
 
-        for (&origin, candidates) in points.iter().zip(per_layer) {
+        for (&origin, candidates) in origins.iter().zip(per_layer) {
             trip.push_layer(origin, candidates)?;
         }
         Ok(())
@@ -271,7 +278,16 @@ where
         linestring: LineString,
     ) -> Result<CollapsedPath<'a, N::Entry>, MatchError> {
         let mut trip = self.begin();
-        self.extend(&mut trip, &linestring.into_points())?;
+
+        // A bare linestring carries no observation times; indices stand in.
+        // Order is the only property the batch lifecycle reads from them.
+        let origins = linestring
+            .into_points()
+            .into_iter()
+            .enumerate()
+            .map(|(index, point)| Origin::new(point, index as i64))
+            .collect::<Vec<_>>();
+        self.extend(&mut trip, &origins)?;
 
         let Collapse {
             cost,

--- a/libs/routers_transition/src/matcher/mod.rs
+++ b/libs/routers_transition/src/matcher/mod.rs
@@ -9,8 +9,10 @@
 
 mod continuation;
 mod entity;
+mod origin;
 mod trip;
 
 pub use continuation::Continuation;
 pub use entity::Matcher;
+pub use origin::Origin;
 pub use trip::{Trip, TripState};

--- a/libs/routers_transition/src/matcher/origin.rs
+++ b/libs/routers_transition/src/matcher/origin.rs
@@ -1,0 +1,26 @@
+use geo::Point;
+use serde::{Deserialize, Serialize};
+
+/// One observed position and when it was observed.
+///
+/// The timestamp is microseconds since the Unix epoch, minted by the supplier
+/// at the ingest boundary — the per-vehicle ordering and identity key for
+/// everything derived from the observation. This crate never interprets it
+/// beyond equality; it rides along so every trip layer stays addressable by
+/// the observation that created it.
+///
+/// Equality is exact on both fields: two observations sharing a timestamp but
+/// not a position contradict each other, and a resume must refuse the pair.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Origin {
+    pub point: Point,
+
+    /// Microseconds since the Unix epoch.
+    pub timestamp: i64,
+}
+
+impl Origin {
+    pub fn new(point: Point, timestamp: i64) -> Self {
+        Self { point, timestamp }
+    }
+}

--- a/libs/routers_transition/src/matcher/trip.rs
+++ b/libs/routers_transition/src/matcher/trip.rs
@@ -4,6 +4,7 @@ use routers_trellis::{LayerId, Path, Solved, Trellis, TrellisError};
 use serde::{Deserialize, Serialize};
 
 use crate::candidate::{Candidate, CandidateRef, CandidateStore};
+use crate::matcher::Origin;
 
 /// The state of a match, ownership and responsibility lies with the caller.
 ///
@@ -16,7 +17,7 @@ pub struct Trip<E>
 where
     E: Entry,
 {
-    origins: Vec<Point>,
+    origins: Vec<Origin>,
     candidates: CandidateStore<E>,
     pub state: TripState,
 }
@@ -63,11 +64,11 @@ where
 
     /// The input position that created `layer`.
     pub fn point(&self, layer: LayerId) -> Option<Point> {
-        self.origins.get(layer.index()).copied()
+        self.origins.get(layer.index()).map(|origin| origin.point)
     }
 
-    /// Every input position, in layer order.
-    pub fn points(&self) -> &[Point] {
+    /// Every input observation, in layer order.
+    pub fn origins(&self) -> &[Origin] {
         &self.origins
     }
 
@@ -151,7 +152,7 @@ where
     /// as node weights. A solved trip reopens through [`Solved::append`].
     pub(crate) fn push_layer(
         &mut self,
-        origin: Point,
+        origin: Origin,
         mut candidates: Vec<Candidate<E>>,
     ) -> Result<LayerId, TrellisError> {
         let width = candidates.len() as u32;

--- a/libs/routers_transition/tests/streaming.rs
+++ b/libs/routers_transition/tests/streaming.rs
@@ -9,7 +9,7 @@ use routers_transition::costing::{CostingStrategies, DefaultEmissionCost, Defaul
 use routers_transition::layer::generation::StandardGenerator;
 use routers_transition::matcher::Trip;
 use routers_transition::weigh::AllCompute;
-use routers_transition::{Continuation, MatchError, Matcher};
+use routers_transition::{Continuation, MatchError, Matcher, Origin};
 
 type Costing = CostingStrategies<DefaultEmissionCost, DefaultTransitionCost, MockEntryId>;
 
@@ -35,6 +35,17 @@ fn trajectory() -> LineString {
             -118.170 34.1490, -118.172 34.1403, -118.179 34.1403
         )
     }
+}
+
+/// Index-stamped observations over a shared timeline. Reconcile compares
+/// timestamps, so every slice of one trajectory must agree on them — stamp
+/// once, then slice.
+fn origins_of(points: &[Point]) -> Vec<Origin> {
+    points
+        .iter()
+        .enumerate()
+        .map(|(index, &point)| Origin::new(point, index as i64))
+        .collect()
 }
 
 fn assert_same_match(a: &CollapsedPath<MockEntryId>, b: &CollapsedPath<MockEntryId>) {
@@ -63,8 +74,8 @@ fn streaming_equals_batch() {
     let batch = m.r#match(trajectory()).expect("batch match must succeed");
 
     let mut trip = m.begin();
-    for point in trajectory().into_points() {
-        m.push(&mut trip, point).expect("push must anchor");
+    for origin in origins_of(&trajectory().into_points()) {
+        m.push(&mut trip, origin).expect("push must anchor");
         m.solve(&mut trip).expect("every prefix must solve");
     }
     let streamed = m.snapshot(&mut trip).expect("snapshot must succeed");
@@ -81,12 +92,12 @@ fn trip_serde_round_trip_resumes() {
     let generator = || StandardGenerator::new(&net, &costing.emission);
     let m = Matcher::new(&net, &costing, generator(), AllCompute::default(), &());
 
-    let points = trajectory().into_points();
-    let (head, tail) = points.split_at(3);
+    let origins = origins_of(&trajectory().into_points());
+    let (head, tail) = origins.split_at(3);
 
     let mut trip = m.begin();
-    for &point in head {
-        m.push(&mut trip, point).expect("push must anchor");
+    for &origin in head {
+        m.push(&mut trip, origin).expect("push must anchor");
     }
     m.solve(&mut trip).expect("prefix must solve");
 
@@ -99,8 +110,8 @@ fn trip_serde_round_trip_resumes() {
     assert!(resumed.is_solved(), "solved state must survive the trip");
 
     let m2 = Matcher::new(&net, &costing, generator(), AllCompute::default(), &());
-    for &point in tail {
-        m2.push(&mut resumed, point).expect("push must anchor");
+    for &origin in tail {
+        m2.push(&mut resumed, origin).expect("push must anchor");
         m2.solve(&mut resumed).expect("every prefix must solve");
     }
     let streamed = m2.snapshot(&mut resumed).expect("snapshot must succeed");
@@ -119,15 +130,15 @@ fn unanchored_push_leaves_trip_unchanged() {
     let m = Matcher::new(&net, &costing, generator, AllCompute::default(), &());
 
     let mut trip = m.begin();
-    m.push(&mut trip, point!(x: -118.151, y: 34.1503))
+    m.push(&mut trip, Origin::new(point!(x: -118.151, y: 34.1503), 0))
         .expect("on-road point must anchor");
 
-    let off_network = point!(x: 0.0, y: 0.0);
+    let off_network = Origin::new(point!(x: 0.0, y: 0.0), 1);
     let err = m.push(&mut trip, off_network).expect_err("must reject");
     assert!(matches!(err, MatchError::Unanchored(_)));
     assert_eq!(trip.layers(), 1, "rejected push must not grow the trip");
 
-    m.push(&mut trip, point!(x: -118.155, y: 34.1503))
+    m.push(&mut trip, Origin::new(point!(x: -118.155, y: 34.1503), 2))
         .expect("stream continues after a dropped point");
     let path = m.solve(&mut trip).expect("solve must succeed");
     assert_eq!(path.nodes.len(), 2);
@@ -162,16 +173,17 @@ fn tail_matches_batch_over_suffix() {
     let m = Matcher::new(&net, &costing, generator(), AllCompute::default(), &());
 
     let points = trajectory().into_points();
+    let origins = origins_of(&points);
 
     let mut trip = m.begin();
-    for &point in &points {
-        m.push(&mut trip, point).expect("push must anchor");
+    for &origin in &origins {
+        m.push(&mut trip, origin).expect("push must anchor");
     }
     m.solve(&mut trip).expect("full trip must solve");
 
     trip.tail(3);
     assert_eq!(trip.layers(), 3, "trip must hold exactly the suffix");
-    assert_eq!(trip.points(), &points[3..], "origins must be the suffix");
+    assert_eq!(trip.origins(), &origins[3..], "origins must be the suffix");
     assert!(!trip.is_solved(), "a cut certificate must reopen");
 
     let streamed = m.snapshot(&mut trip).expect("trimmed trip must re-solve");
@@ -191,8 +203,8 @@ fn tail_bounds_are_noop_and_empty() {
     let m = Matcher::new(&net, &costing, generator, AllCompute::default(), &());
 
     let mut trip = m.begin();
-    for point in trajectory().into_points() {
-        m.push(&mut trip, point).expect("push must anchor");
+    for origin in origins_of(&trajectory().into_points()) {
+        m.push(&mut trip, origin).expect("push must anchor");
     }
     m.solve(&mut trip).expect("trip must solve");
 
@@ -215,17 +227,18 @@ fn reconcile_resumes_and_trims_to_overlap() {
     let m = Matcher::new(&net, &costing, generator, AllCompute::default(), &());
 
     let points = trajectory().into_points();
+    let origins = origins_of(&points);
 
-    // "Yesterday's" persisted trip: the first four points.
+    // "Yesterday's" persisted trip: the first four observations.
     let mut persisted = m.begin();
-    for &point in &points[..4] {
-        m.push(&mut persisted, point).expect("push must anchor");
+    for &origin in &origins[..4] {
+        m.push(&mut persisted, origin).expect("push must anchor");
     }
     m.solve(&mut persisted).expect("prefix must solve");
 
     // Today's committed history: the window slid past the first point and
     // two new points arrived.
-    let history = &points[1..];
+    let history = &origins[1..];
 
     let Continuation::Resume { mut trip, fresh } =
         Continuation::reconcile(Some(persisted), history)
@@ -233,15 +246,15 @@ fn reconcile_resumes_and_trims_to_overlap() {
         panic!("overlapping history must resume");
     };
     assert_eq!(trip.layers(), 3, "trip must trim to the overlap");
-    assert_eq!(trip.points(), &points[1..4]);
-    assert_eq!(fresh, points[4..].to_vec(), "unseen points must be fresh");
+    assert_eq!(trip.origins(), &origins[1..4]);
+    assert_eq!(fresh, origins[4..].to_vec(), "unseen points must be fresh");
 
-    for point in fresh {
-        m.push(&mut trip, point).expect("push must anchor");
+    for origin in fresh {
+        m.push(&mut trip, origin).expect("push must anchor");
     }
     let streamed = m.snapshot(&mut trip).expect("resumed trip must solve");
     let batch = m
-        .r#match(LineString::from(history.to_vec()))
+        .r#match(LineString::from(points[1..].to_vec()))
         .expect("batch match must succeed");
     assert_same_match(&streamed, &batch);
 }
@@ -261,10 +274,11 @@ fn ticked_resume_snapshots_full_history() {
     let generator = || StandardGenerator::new(&net, &costing.emission);
 
     let points = trajectory().into_points();
+    let origins = origins_of(&points);
     let mut committed: Option<Trip<MockEntryId>> = None;
 
     for tick in 1..=points.len() {
-        let history = &points[..tick];
+        let history = &origins[..tick];
         let m = Matcher::new(&net, &costing, generator(), AllCompute::default(), &());
 
         let (mut trip, fresh) = match Continuation::reconcile(committed.take(), history) {
@@ -280,13 +294,13 @@ fn ticked_resume_snapshots_full_history() {
             history.len()
         );
 
-        for point in fresh {
-            m.push(&mut trip, point).expect("push must anchor");
+        for origin in fresh {
+            m.push(&mut trip, origin).expect("push must anchor");
         }
 
         let streamed = m.snapshot(&mut trip).expect("tick must solve");
         let batch = m
-            .r#match(LineString::from(history.to_vec()))
+            .r#match(LineString::from(points[..tick].to_vec()))
             .expect("batch match must succeed");
         assert_same_match(&streamed, &batch);
 
@@ -310,18 +324,19 @@ fn windowed_history_bounds_the_emitted_trace() {
     let generator = || StandardGenerator::new(&net, &costing.emission);
 
     let points = trajectory().into_points();
+    let origins = origins_of(&points);
     let mut committed: Option<Trip<MockEntryId>> = None;
 
-    for tick in 1..=points.len() {
-        let history = &points[tick.saturating_sub(WINDOW)..tick];
+    for tick in 1..=origins.len() {
+        let history = &origins[tick.saturating_sub(WINDOW)..tick];
         let m = Matcher::new(&net, &costing, generator(), AllCompute::default(), &());
 
         let (mut trip, fresh) = match Continuation::reconcile(committed.take(), history) {
             Continuation::Resume { trip, fresh } => (trip, fresh),
             Continuation::Restart { fresh } => (m.begin(), fresh),
         };
-        for point in fresh {
-            m.push(&mut trip, point).expect("push must anchor");
+        for origin in fresh {
+            m.push(&mut trip, origin).expect("push must anchor");
         }
         m.solve(&mut trip).expect("tick must solve");
         committed = Some(trip);
@@ -334,7 +349,7 @@ fn windowed_history_bounds_the_emitted_trace() {
         "the trip is windowed to the history overlap, so per-tick results \
          cannot carry the full trace"
     );
-    assert_eq!(finished.points(), &points[points.len() - WINDOW..]);
+    assert_eq!(finished.origins(), &origins[origins.len() - WINDOW..]);
 }
 
 /// The rendering signature of a gap-cut restart: a trip holding a single
@@ -349,7 +364,7 @@ fn single_point_restart_emits_a_stub_segment() {
     let m = Matcher::new(&net, &costing, generator, AllCompute::default(), &());
 
     let mut trip = m.begin();
-    m.push(&mut trip, point!(x: -118.155, y: 34.1503))
+    m.push(&mut trip, Origin::new(point!(x: -118.155, y: 34.1503), 0))
         .expect("push must anchor");
 
     let snapshot = m.snapshot(&mut trip).expect("single point must solve");
@@ -379,15 +394,15 @@ fn reconcile_restarts_on_divergence() {
     let generator = StandardGenerator::new(&net, &costing.emission);
     let m = Matcher::new(&net, &costing, generator, AllCompute::default(), &());
 
-    let points = trajectory().into_points();
+    let origins = origins_of(&trajectory().into_points());
 
     let mut persisted = m.begin();
-    for &point in &points[..3] {
-        m.push(&mut persisted, point).expect("push must anchor");
+    for &origin in &origins[..3] {
+        m.push(&mut persisted, origin).expect("push must anchor");
     }
 
     // Post-teleport: the orchestrator discarded everything the trip has seen.
-    let history = points[3..].to_vec();
+    let history = origins[3..].to_vec();
 
     match Continuation::reconcile(Some(persisted), &history) {
         Continuation::Restart { fresh } => assert_eq!(fresh, history),
@@ -398,6 +413,51 @@ fn reconcile_restarts_on_divergence() {
         Continuation::Restart { fresh } => assert_eq!(fresh, history),
         Continuation::Resume { .. } => panic!("no trip must restart"),
     }
+}
+
+/// Overlap is the whole observation, not just the position: a history that
+/// re-times the same points was not what the trip was solved against, and a
+/// history that re-places the same timestamps contradicts it. Both restart.
+#[test]
+fn reconcile_restarts_when_observations_disagree() {
+    let net = bent_road();
+    let costing = Costing::default();
+    let generator = || StandardGenerator::new(&net, &costing.emission);
+    let m = Matcher::new(&net, &costing, generator(), AllCompute::default(), &());
+
+    let origins = origins_of(&trajectory().into_points());
+
+    let persist = || {
+        let mut persisted = m.begin();
+        for &origin in &origins[..3] {
+            m.push(&mut persisted, origin).expect("push must anchor");
+        }
+        persisted
+    };
+
+    // Same positions, shifted timestamps.
+    let retimed: Vec<Origin> = origins[..3]
+        .iter()
+        .map(|o| Origin::new(o.point, o.timestamp + 100))
+        .collect();
+    assert!(
+        matches!(
+            Continuation::reconcile(Some(persist()), &retimed),
+            Continuation::Restart { .. }
+        ),
+        "re-timed history must restart"
+    );
+
+    // Same timestamps, one contradicted position.
+    let mut replaced = origins[..3].to_vec();
+    replaced[2].point = point!(x: -118.180, y: 34.1403);
+    assert!(
+        matches!(
+            Continuation::reconcile(Some(persist()), &replaced),
+            Continuation::Restart { .. }
+        ),
+        "a contradicted position must restart"
+    );
 }
 
 /// `LayerId` indexes everything on a trip: origins, candidate layers, trellis.
@@ -411,11 +471,13 @@ fn trip_accessors_are_layer_indexed() {
     let mut trip = m.begin();
     assert!(trip.is_empty() && trip.last_id().is_none());
 
-    let origin: Point = point!(x: -118.151, y: 34.1503);
-    let id = m.push(&mut trip, origin).expect("push must anchor");
+    let position: Point = point!(x: -118.151, y: 34.1503);
+    let id = m
+        .push(&mut trip, Origin::new(position, 7))
+        .expect("push must anchor");
 
     assert_eq!(trip.last_id(), Some(id));
-    assert_eq!(trip.point(id), Some(origin));
+    assert_eq!(trip.point(id), Some(position));
 
     let layer = trip.layer(id).expect("layer must exist");
     assert!(!layer.is_empty());


### PR DESCRIPTION
`Origin` pairs a position with its supplier-minted timestamp. The timestamp is the per-vehicle ordering and identity key from which everything downstream derives.

`Trip`/`Continuation` postcard layouts change (one `i64` per layer). These types live only on the NATS control plane between orchestrator and matcher, which deploy together; nothing durable stores them.