### PR TITLE
feat: Differential Event Output

### DIFF
--- a/libs/routers_realtime/Cargo.toml
+++ b/libs/routers_realtime/Cargo.toml
@@ -56,6 +56,9 @@ redis = { version = "0.29", features = ["tokio-comp", "streams"] }
 polars = { version = "0.46", default-features = false, features = ["lazy", "csv", "strings", "dtype-full"] }
 stream-partition = "0.1.0"
 
+[dev-dependencies]
+routers_network = { workspace = true, features = ["testing"] }
+
 [lints]
 workspace = true
 

--- a/libs/routers_realtime/bin/matcher.rs
+++ b/libs/routers_realtime/bin/matcher.rs
@@ -5,12 +5,11 @@ use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId};
 use routers_network::Metadata;
 use routers_realtime::{
     bus::{NATSSink, NATSStream},
-    event::{MatchContext, MatchResult},
+    event::{MatchContext, MatchResult, MatchedDiff},
 };
 use routers_shard::{FileFetcher, Geohash, ShardLoader, ShardedNetwork};
 use routers_transition::{
     Continuation, MatchError, Matcher,
-    candidate::RoutedPath,
     costing::{CostingStrategies, DefaultEmissionCost, DefaultTransitionCost},
     layer::generation::StandardGenerator,
     primitives::PredicateCache,
@@ -90,7 +89,7 @@ impl Matching {
             vehicle_id,
             continuation,
         }: MatchContext<E>,
-    ) -> Option<MatchResult<E, M>> {
+    ) -> Option<MatchResult<E>> {
         let mut generator = StandardGenerator::new(self.network.as_ref(), &self.costing.emission);
         if let Some(distance) = self.search_distance {
             generator = generator.with_search_distance(distance);
@@ -110,6 +109,8 @@ impl Matching {
             outcome = field::Empty,
             severity = field::Empty,
             continuation = field::Empty,
+            converged = field::Empty,
+            emitted = field::Empty,
         );
         let _entered = span.enter();
 
@@ -155,6 +156,9 @@ impl Matching {
             return None;
         }
 
+        // Copied out: the snapshot's borrow spans the whole trip mutably.
+        let origins = trip.origins().to_vec();
+
         let solution = match info_span!("snapshot").in_scope(|| matcher.snapshot(&mut trip)) {
             Ok(solution) => solution,
             Err(err) => {
@@ -165,13 +169,33 @@ impl Matching {
             }
         };
 
+        // Emit everything a future solve could still change — the whole trip
+        // since its last cut. Revision 0 until durable ingest supplies stream
+        // sequences.
+        let diff = info_span!("emit")
+            .in_scope(|| MatchedDiff::new(&solution, &origins, self.network.as_ref(), 0));
+        drop(solution);
+        span.record("emitted", diff.layers.len());
+
+        // Cut behind the convergence point: those layers are final, already
+        // emitted, and only cost wire from here on. The convergence layer
+        // itself stays as the resume anchor. An unfused trip stays whole —
+        // the orchestrator's context window bounds its growth.
+        match matcher.convergence(&trip) {
+            Ok(Some(layer)) => {
+                span.record("converged", layer.index() as u64);
+                trip.tail(trip.layers() - layer.index());
+            }
+            Ok(None) => {}
+            Err(err) => error!("{vehicle_id}: convergence query failed: {err}"),
+        }
+
         span.record("outcome", "success");
         span.record("severity", "ok");
 
-        let path = RoutedPath::new(solution, self.network.as_ref());
         Some(MatchResult {
-            path,
             vehicle_id,
+            diff,
             trip,
         })
     }
@@ -219,7 +243,7 @@ async fn main() -> anyhow::Result<()> {
         .context("could not subscribe to NATS subject")?;
     let source = NATSStream::<MatchContext<E>>::new(subscriber);
 
-    let sink = NATSSink::<MatchResult<E, M>>::new(client, move |_| args.outbound_subject.clone());
+    let sink = NATSSink::<MatchResult<E>>::new(client, move |_| args.outbound_subject.clone());
 
     let matching = Arc::new(Matching {
         network,

--- a/libs/routers_realtime/bin/orchestrator.rs
+++ b/libs/routers_realtime/bin/orchestrator.rs
@@ -4,7 +4,7 @@ use routers_realtime::event::VehicleId;
 use scc::HashCache;
 use scc::hash_cache::Entry;
 
-use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId};
+use routers_codec::osm::OsmEntryId;
 use routers_realtime::{
     bus::{NATSSink, NATSStream},
     event::{MatchContext, MatchResult, Payload, RawEvent},
@@ -24,13 +24,12 @@ use tracing::{Instrument, field, info_span, warn};
 use url::Url;
 
 type E = OsmEntryId;
-type M = OsmEdgeMetadata;
 
 /// Everything the orchestrator reacts to: raw positions to assemble context
 /// for, and match results whose trip markers it commits to the store.
 enum Inbound {
     Event(Payload),
-    Result(MatchResult<E, M>),
+    Result(MatchResult<E>),
 }
 
 /// An [`Inbound`] handed to a worker, tagged with the wall-clock stamps the
@@ -140,7 +139,7 @@ async fn main() -> anyhow::Result<()> {
     )
     .map(Inbound::Event);
 
-    let results = NATSStream::<MatchResult<E, M>>::new(
+    let results = NATSStream::<MatchResult<E>>::new(
         client
             .subscribe(args.results_subject)
             .await

--- a/libs/routers_realtime/src/event.rs
+++ b/libs/routers_realtime/src/event.rs
@@ -1,9 +1,9 @@
 use chrono::{DateTime, Utc};
 use geo::Point;
-use routers_network::{Entry, Metadata};
+use routers_network::{Edge, Entry, Network};
 use routers_shard::{Geohash, GeohashStrategy, ShardingStrategy};
-use routers_transition::candidate::RoutedPath;
-use routers_transition::matcher::{Continuation, Trip};
+use routers_transition::candidate::CollapsedPath;
+use routers_transition::matcher::{Continuation, Origin, Trip};
 use serde::{Deserialize, Serialize};
 
 use buffa::Message;
@@ -49,10 +49,94 @@ pub struct MatchContext<E: Entry> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct MatchResult<E: Entry, M: Metadata> {
-    pub path: RoutedPath<E, M>,
+pub struct MatchResult<E: Entry> {
     pub vehicle_id: VehicleId,
+    pub diff: MatchedDiff<E>,
+
+    /// The trip, cut at its convergence point — the resume state the
+    /// orchestrator commits for the vehicle's next event.
     pub trip: Trip<E>,
+}
+
+/// One layer of matched history: the observation's identity (its timestamp),
+/// where it matched, and the road geometry driven since the previous layer.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(serialize = "E: Serialize", deserialize = "E: Deserialize<'de>"))]
+pub struct MatchedLayer<E: Entry> {
+    /// When the observation was made (microseconds since the Unix epoch).
+    /// With the vehicle, this addresses the layer fleet-wide: overlapping
+    /// emissions merge on it.
+    pub timestamp: i64,
+
+    /// The directed network edge the observation matched onto.
+    pub edge: Edge<E>,
+
+    /// The observation, snapped onto the edge.
+    pub position: Point,
+
+    /// Interpolated road geometry between the previous layer's position and
+    /// this one. Empty on a diff's first layer: its inbound hop was emitted
+    /// while both endpoints were still in the trip.
+    pub path: Vec<Point>,
+}
+
+/// Everything a solve could still change, emitted whole: one layer per trip
+/// observation since the last convergence cut. Consumers merge layers by
+/// (vehicle, timestamp) and resolve competing solves by revision — highest
+/// wins, equal is a duplicate — so re-emission is convergence, not conflict.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(serialize = "E: Serialize", deserialize = "E: Deserialize<'de>"))]
+pub struct MatchedDiff<E: Entry> {
+    /// Orders competing solves for a vehicle. Becomes the stream sequence of
+    /// the triggering ingest message once durable ingest lands; 0 until then.
+    pub revision: u64,
+
+    /// Set when a resume was rejected and the solve restarted from raw
+    /// history — the emitted region may rewrite more than usual.
+    pub downgraded: bool,
+
+    pub layers: Vec<MatchedLayer<E>>,
+}
+
+impl<E: Entry> MatchedDiff<E> {
+    /// Lift a solved trip into its emission: one layer per observation, hops
+    /// resolved to geometry against the (matcher-local) network.
+    pub fn new<N: Network<Entry = E>>(
+        solution: &CollapsedPath<'_, E>,
+        origins: &[Origin],
+        map: &N,
+        revision: u64,
+    ) -> Self {
+        let layers = solution
+            .route
+            .iter()
+            .zip(origins)
+            .enumerate()
+            .filter_map(|(index, (chosen, origin))| {
+                let candidate = solution.candidates.candidate(chosen)?;
+
+                // Hop `i - 1` carries the roads driven into layer `i`; the
+                // endpoints' own positions live on their layers.
+                let path = match index.checked_sub(1) {
+                    Some(hop) => solution.hop_geometry(hop, map),
+                    None => Vec::new(),
+                };
+
+                Some(MatchedLayer {
+                    timestamp: origin.timestamp,
+                    edge: candidate.edge,
+                    position: candidate.position,
+                    path,
+                })
+            })
+            .collect();
+
+        Self {
+            revision,
+            downgraded: false,
+            layers,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -69,7 +153,7 @@ pub struct Payload {
 
 // The match control plane is Rust-internal: postcard on the wire.
 postcard_wire!(MatchContext<E: Entry>);
-postcard_wire!(MatchResult<E: Entry, M: Metadata>);
+postcard_wire!(MatchResult<E: Entry>);
 
 /// The ingest surface crosses the bus as protobuf
 /// (`routers.realtime.v1.Payload`), so producers in any language can

--- a/libs/routers_realtime/tests/matched_diff.rs
+++ b/libs/routers_realtime/tests/matched_diff.rs
@@ -1,0 +1,128 @@
+//! The diff emission a matcher publishes per solve: one layer per trip
+//! observation, addressable by timestamp, with hop geometry resolved against
+//! the matcher's network.
+
+use geo::point;
+use routers_network::mock::{MockEntryId, MockNetwork, MockNetworkBuilder};
+use routers_realtime::event::MatchedDiff;
+use routers_transition::costing::{CostingStrategies, DefaultEmissionCost, DefaultTransitionCost};
+use routers_transition::layer::generation::StandardGenerator;
+use routers_transition::weigh::AllCompute;
+use routers_transition::{Matcher, Origin};
+
+type Costing = CostingStrategies<DefaultEmissionCost, DefaultTransitionCost, MockEntryId>;
+
+/// A staircase road: west, then south, then west again.
+fn bent_road() -> MockNetwork {
+    MockNetworkBuilder::new()
+        .node(1, point!(x: -118.15, y: 34.15))
+        .node(2, point!(x: -118.16, y: 34.15))
+        .node(3, point!(x: -118.17, y: 34.15))
+        .node(4, point!(x: -118.17, y: 34.14))
+        .node(5, point!(x: -118.18, y: 34.14))
+        .edge(1, 2)
+        .edge(2, 3)
+        .edge(3, 4)
+        .edge(4, 5)
+        .build()
+}
+
+fn observations() -> Vec<Origin> {
+    [
+        point!(x: -118.151, y: 34.1503),
+        point!(x: -118.155, y: 34.1503),
+        point!(x: -118.165, y: 34.1503),
+        point!(x: -118.170, y: 34.1490),
+        point!(x: -118.172, y: 34.1403),
+        point!(x: -118.179, y: 34.1403),
+    ]
+    .into_iter()
+    .enumerate()
+    // Realistic supplier stamps: distinct, spaced, non-zero micros.
+    .map(|(index, point)| Origin::new(point, 1_775_000_000_000_000 + index as i64 * 5_000_000))
+    .collect()
+}
+
+#[test]
+fn diff_lifts_every_layer_with_its_timestamp() {
+    let net = bent_road();
+    let costing = Costing::default();
+    let generator = StandardGenerator::new(&net, &costing.emission);
+    let m = Matcher::new(&net, &costing, generator, AllCompute::default(), &());
+
+    let origins = observations();
+    let mut trip = m.begin();
+    for &origin in &origins {
+        m.push(&mut trip, origin).expect("push must anchor");
+    }
+
+    let solution = m.snapshot(&mut trip).expect("trip must solve");
+    let diff = MatchedDiff::new(&solution, &origins, &net, 42);
+
+    assert_eq!(diff.revision, 42);
+    assert!(!diff.downgraded);
+    assert_eq!(
+        diff.layers.len(),
+        origins.len(),
+        "one emitted layer per observation"
+    );
+
+    for (layer, origin) in diff.layers.iter().zip(&origins) {
+        assert_eq!(
+            layer.timestamp, origin.timestamp,
+            "layers are addressed by their observation's timestamp"
+        );
+    }
+
+    assert!(
+        diff.layers[0].path.is_empty(),
+        "the first layer has no inbound hop"
+    );
+
+    // The staircase forces the interpolation through the bend: at least one
+    // hop must resolve interior geometry, or the diff carries no more than
+    // the raw positions did.
+    assert!(
+        diff.layers.iter().any(|layer| !layer.path.is_empty()),
+        "hop geometry must resolve against the network"
+    );
+}
+
+#[test]
+fn diff_layers_flatten_into_a_connected_trace() {
+    let net = bent_road();
+    let costing = Costing::default();
+    let generator = StandardGenerator::new(&net, &costing.emission);
+    let m = Matcher::new(&net, &costing, generator, AllCompute::default(), &());
+
+    let origins = observations();
+    let mut trip = m.begin();
+    for &origin in &origins {
+        m.push(&mut trip, origin).expect("push must anchor");
+    }
+
+    let solution = m.snapshot(&mut trip).expect("trip must solve");
+    let interpolated = solution.interpolated(&net);
+
+    let diff = MatchedDiff::new(&solution, &origins, &net, 0);
+
+    // Rendering the diff — each layer's path then its position, in timestamp
+    // order — must reproduce the solution's own interpolated linestring.
+    let rendered: Vec<geo::Point> = diff
+        .layers
+        .iter()
+        .flat_map(|layer| {
+            layer
+                .path
+                .iter()
+                .copied()
+                .chain(core::iter::once(layer.position))
+        })
+        .collect();
+
+    let expected: Vec<geo::Point> = interpolated.into_points();
+    assert_eq!(
+        rendered, expected,
+        "the diff must carry exactly the interpolated geometry"
+    );
+}

--- a/libs/routers_transition/src/candidate/collapse.rs
+++ b/libs/routers_transition/src/candidate/collapse.rs
@@ -1,8 +1,8 @@
 use alloc::borrow::Cow;
 
 use crate::candidate::*;
-use crate::primitives::Reachable;
-use geo::LineString;
+use crate::primitives::{Reachable, ResolutionMethod};
+use geo::{LineString, Point};
 use routers_network::Entry;
 use routers_network::Network;
 
@@ -61,22 +61,57 @@ where
             .collect::<LineString>()
     }
 
-    /// The full driven path as a [`LineString`] — the matched positions with the
-    /// routed road geometry between them filled in, showing the turns taken.
+    /// The road geometry driven across hop `hop` (between matched layers
+    /// `hop` and `hop + 1`), exclusive of both endpoints' matched positions:
+    /// the current edge's exit node, any routed intermediate nodes, and the
+    /// next edge's entry node, with the shared seam nodes deduplicated.
+    ///
+    /// Empty for a same-edge hop — travel never leaves the edge, so the
+    /// endpoints alone describe it — and for a `hop` out of range.
+    pub fn hop_geometry(&self, hop: usize, map: &impl Network<Entry = E>) -> Vec<Point> {
+        let Some(reachable) = self.interpolated.get(hop) else {
+            return Vec::new();
+        };
+        if !matches!(reachable.resolution_method, ResolutionMethod::Standard) {
+            return Vec::new();
+        }
+
+        let exit = self
+            .candidates
+            .candidate(&reachable.source)
+            .map(|candidate| candidate.edge.target);
+        let entry = self
+            .candidates
+            .candidate(&reachable.target)
+            .map(|candidate| candidate.edge.source);
+
+        // Consecutive bridge edges share their endpoints with each other and
+        // with the exit/entry nodes, so the seams dedup away.
+        let mut points: Vec<Point> = exit
+            .into_iter()
+            .chain(reachable.path_nodes())
+            .chain(entry)
+            .filter_map(|node| map.point(&node))
+            .collect();
+        points.dedup();
+        points
+    }
+
+    /// The full driven path as a [`LineString`] — the matched positions with
+    /// each hop's [`geometry`](Self::hop_geometry) filled in, showing the
+    /// turns taken.
     pub fn interpolated(&self, map: &impl Network<Entry = E>) -> LineString {
-        self.interpolated
-            .iter()
-            .enumerate()
-            .flat_map(|(index, reachable)| {
-                let source = self.candidates.candidate(&reachable.source).unwrap();
-                let target = self.candidates.candidate(&reachable.target).unwrap();
+        let matched = self.matched();
 
-                let path = reachable.path_nodes().filter_map(|node| map.point(&node));
+        let mut points = Vec::new();
+        if let Some(first) = matched.first() {
+            points.push(first.position);
+        }
+        for (index, target) in matched.iter().enumerate().skip(1) {
+            points.extend(self.hop_geometry(index - 1, map));
+            points.push(target.position);
+        }
 
-                core::iter::repeat_n(source.position, if index == 0 { 1 } else { 0 })
-                    .chain(path)
-                    .chain(core::iter::once(target.position))
-            })
-            .collect::<LineString>()
+        points.into_iter().collect::<LineString>()
     }
 }

--- a/libs/routers_transition/src/matcher/entity.rs
+++ b/libs/routers_transition/src/matcher/entity.rs
@@ -245,6 +245,22 @@ where
         }
     }
 
+    /// The convergence point of the trip's current solution: the latest layer
+    /// no future push can change, asked of the same solver [`solve`] runs.
+    /// `None` when the live paths never fuse; errors where a solve would
+    /// (nothing to solve, pending boundaries, unreachable).
+    ///
+    /// See [`ViterbiSolver::convergence`] for the guarantee and its price —
+    /// one extra forward pass per ask.
+    ///
+    /// [`solve`]: Self::solve
+    pub fn convergence(&self, trip: &Trip<N::Entry>) -> Result<Option<LayerId>, MatchError> {
+        let Some(trellis) = trip.trellis() else {
+            return Err(TrellisError::Empty.into());
+        };
+        Ok(ViterbiSolver::new().convergence(trellis)?)
+    }
+
     /// Solve (if pending) and collapse the trip's current solution into a
     /// [`CollapsedPath`], re-deriving each chosen hop's routed geometry from
     /// the (warm) predicate cache — nothing is stored during weighing.

--- a/libs/routers_viewer/src/bin/realtime/app.rs
+++ b/libs/routers_viewer/src/bin/realtime/app.rs
@@ -10,9 +10,9 @@ use walkers::{MapMemory, lon_lat};
 
 use routers_viewer::{ColourFactory, Component, Context, Map, Regular};
 
+use crate::E;
 use crate::plugin::{TraceLine, TracesPlugin, vehicle_colour};
 use crate::store::{StoreStats, TraceStore};
-use crate::{E, M};
 
 /// Maximum events drained from the channel per frame, so a burst can't
 /// stall the UI thread.
@@ -21,14 +21,14 @@ const DRAIN_PER_FRAME: usize = 2_000;
 pub struct RealtimeApp {
     map: Map,
     store: TraceStore,
-    rx: Receiver<MatchResult<E, M>>,
+    rx: Receiver<MatchResult<E>>,
     centered: bool,
 }
 
 impl RealtimeApp {
     pub fn new(
         ctx: &CreationContext<'_>,
-        mut source: NATSStream<MatchResult<E, M>>,
+        mut source: NATSStream<MatchResult<E>>,
         trace_capacity: usize,
         idle_ttl: Duration,
     ) -> Self {
@@ -67,10 +67,10 @@ impl eframe::App for RealtimeApp {
 
         for result in self.rx.try_iter().take(DRAIN_PER_FRAME) {
             if !self.centered
-                && let Some(element) = result.path.interpolated.first()
+                && let Some(layer) = result.diff.layers.first()
             {
                 self.map
-                    .center_at(lon_lat(element.point.x, element.point.y));
+                    .center_at(lon_lat(layer.position.x(), layer.position.y()));
                 self.centered = true;
             }
 

--- a/libs/routers_viewer/src/bin/realtime/main.rs
+++ b/libs/routers_viewer/src/bin/realtime/main.rs
@@ -16,14 +16,13 @@ use core::time::Duration;
 use anyhow::{Context, Result};
 use clap::Parser;
 use log::info;
-use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId};
+use routers_codec::osm::OsmEntryId;
 use routers_realtime::bus::NATSStream;
 use routers_realtime::event::MatchResult;
 
 use crate::app::RealtimeApp;
 
 type E = OsmEntryId;
-type M = OsmEdgeMetadata;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -65,7 +64,7 @@ async fn main() -> Result<()> {
         .subscribe(args.inbound_subject)
         .await
         .context("could not subscribe to NATS subject")?;
-    let source = NATSStream::<MatchResult<E, M>>::new(subscriber);
+    let source = NATSStream::<MatchResult<E>>::new(subscriber);
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()

--- a/libs/routers_viewer/src/bin/realtime/store.rs
+++ b/libs/routers_viewer/src/bin/realtime/store.rs
@@ -1,42 +1,50 @@
-use alloc::collections::VecDeque;
+use alloc::collections::{BTreeMap, VecDeque};
 use core::time::Duration;
 use std::collections::HashMap;
 use web_time::Instant;
 
 use geo::Point;
-use routers_realtime::event::{MatchResult, VehicleId};
+use routers_realtime::event::{MatchResult, MatchedDiff, VehicleId};
 
-use crate::{E, M};
+use crate::E;
 
-/// A vehicle's latest full matched solution, oldest point first. Each new
-/// result supersedes the previous one entirely.
+/// A vehicle's matched history, merged from diff emissions: one geometry
+/// segment per observation timestamp. Overlapping emissions supersede per
+/// layer — re-emission is convergence, not conflict — so the trace heals as
+/// later solves refine earlier layers.
 pub struct VehicleTrace {
-    pub segments: Vec<Point>,
+    /// Observation timestamp → the geometry driven into that observation
+    /// (its inbound road path, then its matched position).
+    layers: BTreeMap<i64, Vec<Point>>,
     pub last_seen: Instant,
 }
 
 impl VehicleTrace {
     fn new() -> Self {
         Self {
-            segments: Vec::new(),
+            layers: BTreeMap::new(),
             last_seen: Instant::now(),
         }
     }
 
-    fn assign(&mut self, mut segment: Vec<Point>, capacity: usize) {
-        // Keep only the newest `capacity` points; the segment runs
-        // oldest→newest, so trim from the front.
-        if segment.len() > capacity {
-            segment.drain(..segment.len() - capacity);
+    fn merge(&mut self, diff: &MatchedDiff<E>, capacity: usize) {
+        for layer in &diff.layers {
+            let mut segment = layer.path.clone();
+            segment.push(layer.position);
+            self.layers.insert(layer.timestamp, segment);
         }
 
-        self.segments = segment;
+        // Bound by observation count, trimming the oldest.
+        while self.layers.len() > capacity {
+            self.layers.pop_first();
+        }
+
         self.last_seen = Instant::now();
     }
 
-    /// The full tail as one point sequence, for rendering.
+    /// The full tail as one point sequence, oldest observation first.
     pub fn flattened(&self) -> Vec<Point> {
-        self.segments.clone()
+        self.layers.values().flatten().copied().collect()
     }
 }
 
@@ -46,9 +54,9 @@ pub struct StoreStats {
     pub total_events: u64,
 }
 
-/// Latest matched solution per vehicle. Memory is bounded on both axes:
-/// each vehicle retains at most `capacity` points, and vehicles that go
-/// quiet for longer than `idle_ttl` are evicted entirely.
+/// Merged matched history per vehicle. Memory is bounded on both axes:
+/// each vehicle retains at most `capacity` observations, and vehicles that
+/// go quiet for longer than `idle_ttl` are evicted entirely.
 pub struct TraceStore {
     capacity: usize,
     idle_ttl: Duration,
@@ -68,30 +76,23 @@ impl TraceStore {
         }
     }
 
-    pub fn ingest(&mut self, result: MatchResult<E, M>) {
+    pub fn ingest(&mut self, result: MatchResult<E>) {
         let now = Instant::now();
 
         self.event_bucket.push_back(now);
         self.total_events += 1;
 
-        // The matched solution arrives in chronological order, so the last
-        // point is the vehicle's current position, which the plugin marks
-        // with the head dot.
-        let segment: Vec<Point> = result
-            .path
-            .interpolated
-            .iter()
-            .map(|element| Point::from(element.point))
-            .collect();
-
-        if segment.is_empty() {
+        if result.diff.layers.is_empty() {
             return;
         }
 
+        // Layers merge by observation timestamp, so the newest one is the
+        // vehicle's current position, which the plugin marks with the head
+        // dot.
         self.traces
             .entry(result.vehicle_id)
             .or_insert_with(VehicleTrace::new)
-            .assign(segment, self.capacity);
+            .merge(&result.diff, self.capacity);
     }
 
     pub fn evict_idle(&mut self) {


### PR DESCRIPTION
**The matcher's result becomes the diff.** 

Every solve emits *everything a future solve could still change*: the trip’s trajectory since its last cut. So, re-emission is converge-able (by a downstream reconciler), not a conflict. 