### PR TITLE
feat: Matcher Queue Group

### DIFF
--- a/libs/routers_realtime/bin/matcher.rs
+++ b/libs/routers_realtime/bin/matcher.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use routers_codec::osm::{OsmEdgeMetadata, OsmEntryId};
 use routers_network::Metadata;
 use routers_realtime::{
-    bus::{NATSSink, NATSStream},
-    event::{MatchContext, MatchResult, MatchedDiff},
+    bus::{self, Wire},
+    event::{MatchContext, MatchReply, MatchedDiff},
 };
 use routers_shard::{FileFetcher, Geohash, ShardLoader, ShardedNetwork};
 use routers_transition::{
@@ -43,13 +43,15 @@ struct Args {
     #[arg(short, env, long)]
     shard: Geohash,
 
-    // The inbound NATS subject to subscribe to, for matching events.
+    // The inbound NATS subject to serve match requests from.
     #[arg(short, env, long)]
     inbound_subject: String,
 
-    // The outbound NATS subject to publish matching results to.
-    #[arg(short, env, long)]
-    outbound_subject: String,
+    /// The queue group shared by this shard's matchers: NATS delivers each
+    /// request to exactly one member, so replicas divide the load instead of
+    /// duplicating it.
+    #[arg(short, env, long, default_value = "matchers")]
+    queue_group: String,
 
     /// The search distance to use for matching
     #[arg(long, env)]
@@ -81,15 +83,16 @@ struct Matching {
 
 impl Matching {
     /// Solve one context, recording its outcome onto a fresh `match_event`
-    /// span. Returns the result to publish, or `None` when there is nothing to
-    /// emit (no anchor, or a nominal/fatal solve failure).
+    /// span. Returns the reply to send: the emission and resume state, or
+    /// [`MatchReply::NoMatch`] when there is nothing to emit (no anchor, or a
+    /// nominal/fatal solve failure).
     fn solve(
         &self,
         MatchContext {
             vehicle_id,
             continuation,
         }: MatchContext<E>,
-    ) -> Option<MatchResult<E>> {
+    ) -> MatchReply<E> {
         let mut generator = StandardGenerator::new(self.network.as_ref(), &self.costing.emission);
         if let Some(distance) = self.search_distance {
             generator = generator.with_search_distance(distance);
@@ -145,7 +148,7 @@ impl Matching {
             span.record("outcome", "no_anchor");
             span.record("severity", "nominal");
             warn!("{vehicle_id}: no anchored layers to solve");
-            return None;
+            return MatchReply::NoMatch;
         }
 
         if let Err(err) = info_span!("solve").in_scope(|| matcher.solve(&mut trip)) {
@@ -153,7 +156,7 @@ impl Matching {
             span.record("outcome", outcome);
             span.record("severity", severity);
             error!("{vehicle_id}: unable to solve trip");
-            return None;
+            return MatchReply::NoMatch;
         }
 
         // Copied out: the snapshot's borrow spans the whole trip mutably.
@@ -165,7 +168,7 @@ impl Matching {
                 let (outcome, severity) = classify(err);
                 span.record("outcome", outcome);
                 span.record("severity", severity);
-                return None;
+                return MatchReply::NoMatch;
             }
         };
 
@@ -193,11 +196,7 @@ impl Matching {
         span.record("outcome", "success");
         span.record("severity", "ok");
 
-        Some(MatchResult {
-            vehicle_id,
-            diff,
-            trip,
-        })
+        MatchReply::Solved { diff, trip }
     }
 }
 
@@ -237,13 +236,12 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("could not connect to NATS")?;
 
+    // The queue group makes replicas additive: each request lands on exactly
+    // one member, so scaling a shard's matchers divides the load.
     let subscriber = client
-        .subscribe(args.inbound_subject)
+        .queue_subscribe(args.inbound_subject, args.queue_group)
         .await
         .context("could not subscribe to NATS subject")?;
-    let source = NATSStream::<MatchContext<E>>::new(subscriber);
-
-    let sink = NATSSink::<MatchResult<E>>::new(client, move |_| args.outbound_subject.clone());
 
     let matching = Arc::new(Matching {
         network,
@@ -254,23 +252,55 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Each context is solved on the blocking pool (solving is synchronous and
-    // CPU-bound); `buffer_unordered` keeps `workers` in flight at once. Results
-    // stream straight into the sink in completion order.
-    source
-        .map(|context| {
+    // CPU-bound); `for_each_concurrent` keeps `workers` in flight at once.
+    // Every request is answered on its reply inbox — a NoMatch is still an
+    // answer, so the asking orchestrator never waits out a timeout for an
+    // event that solved to nothing.
+    subscriber
+        .for_each_concurrent(args.workers, |message| {
             let matching = Arc::clone(&matching);
+            let client = client.clone();
+
             async move {
-                tokio::task::spawn_blocking(move || matching.solve(context))
+                bus::inbound(message.subject.as_str(), message.headers.as_ref());
+
+                let Some(inbox) = message.reply else {
+                    warn!("dropping request without a reply inbox — not a request?");
+                    return;
+                };
+
+                let context = match MatchContext::<E>::decode(&message.payload) {
+                    Ok(context) => context,
+                    Err(err) => {
+                        warn!("skipping undecodable context: {err}");
+                        return;
+                    }
+                };
+
+                let reply = tokio::task::spawn_blocking(move || matching.solve(context))
                     .await
-                    .ok()
-                    .flatten()
+                    .unwrap_or_else(|err| {
+                        error!("solve task panicked: {err}");
+                        MatchReply::NoMatch
+                    });
+
+                let payload = match reply.encode() {
+                    Ok(payload) => payload,
+                    Err(err) => {
+                        error!("could not encode reply: {err:#}");
+                        return;
+                    }
+                };
+
+                if let Err(err) = client
+                    .publish_with_headers(inbox, bus::outbound(), payload.into())
+                    .await
+                {
+                    error!("could not send reply: {err:#}");
+                }
             }
         })
-        .buffer_unordered(args.workers)
-        .filter_map(std::future::ready)
-        .map(Ok)
-        .forward(sink)
-        .await?;
+        .await;
 
     error!("source terminated");
     Ok(())

--- a/libs/routers_realtime/bin/orchestrator.rs
+++ b/libs/routers_realtime/bin/orchestrator.rs
@@ -6,8 +6,8 @@ use scc::hash_cache::Entry;
 
 use routers_codec::osm::OsmEntryId;
 use routers_realtime::{
-    bus::{NATSSink, NATSStream},
-    event::{MatchContext, MatchResult, Payload, RawEvent},
+    bus::{NATSSink, NATSStream, Wire},
+    event::{MatchContext, MatchReply, MatchedEvent, Payload, RawEvent},
     store::RedisStore,
 };
 use routers_transition::matcher::Trip;
@@ -25,20 +25,13 @@ use url::Url;
 
 type E = OsmEntryId;
 
-/// Everything the orchestrator reacts to: raw positions to assemble context
-/// for, and match results whose trip markers it commits to the store.
-enum Inbound {
-    Event(Payload),
-    Result(MatchResult<E>),
-}
-
-/// An [`Inbound`] handed to a worker, tagged with the wall-clock stamps the
+/// A [`Payload`] handed to a worker, tagged with the wall-clock stamps the
 /// dispatch loop captured: when it was queued (for channel-residency timing)
-/// and its wire send time (for end-to-end timing, and as the vehicle's origin).
+/// and its wire send time (for end-to-end timing).
 struct Dispatch {
     queued_at: web_time::SystemTime,
     sent_at: Option<web_time::SystemTime>,
-    inbound: Inbound,
+    payload: Payload,
 }
 
 #[derive(Parser, Debug)]
@@ -60,15 +53,26 @@ struct Args {
     #[arg(short, long = "in", env)]
     inbound_subject: String,
 
-    /// The NATS subject to emit match context messages out into.
-    /// For example, `events.match.{cell}.{rest}`.
+    /// The NATS subject the shard's matchers serve requests on.
+    /// For example, `events.match.{shard}`.
     #[arg(short, long = "out", env)]
     outbound_subject: String,
 
-    /// The NATS subject the matcher publishes results into. The orchestrator
-    /// commits each result's trip as the vehicle's resume state.
-    #[arg(long = "results", env)]
-    results_subject: String,
+    /// The NATS subject matched emissions publish into, for the reconciler
+    /// and any observer. For example, `events.matched.{shard}`.
+    #[arg(long = "matched", env)]
+    matched_subject: String,
+
+    /// How long to wait for a matcher's reply before re-driving the request.
+    #[arg(long, env, value_parser = humantime::parse_duration, default_value = "5s")]
+    solve_timeout: Duration,
+
+    /// Re-drives after the first attempt before the event is abandoned.
+    /// Replies are idempotent downstream (layers merge by timestamp and
+    /// resolve by revision), so a duplicate solve from a late reply is
+    /// convergence, not conflict.
+    #[arg(long, env, default_value_t = 3)]
+    solve_retries: usize,
 
     /// The number of context entries to retrieve from Redis for each vehicle.
     #[arg(short, long = "context-window", env, default_value = "10")]
@@ -85,10 +89,11 @@ struct Args {
     jump_distance: f64,
 
     /// How many workers to fan vehicles across. Each vehicle is pinned to one
-    /// by hash, so its events and results stay ordered on a worker that owns
-    /// their trip state outright — the maps need no locks, and the per-event
-    /// Redis fetch (the throughput bound) overlaps across vehicles.
-    #[arg(short, env, long, default_value = "8")]
+    /// by hash, so its events stay ordered on a worker that owns their trip
+    /// state outright — the maps need no locks. A worker now holds its lane
+    /// for a whole solve round trip, so this is the pod's in-flight solve
+    /// bound; workers are tokio tasks, priced accordingly.
+    #[arg(short, env, long, default_value = "64")]
     workers: usize,
 
     /// Vehicles each worker keeps trip state for, before the least recently
@@ -131,23 +136,12 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("could not connect to NATS")?;
 
-    let events = NATSStream::<Payload>::new(
+    let mut source = NATSStream::<Payload>::new(
         client
             .subscribe(args.inbound_subject)
             .await
             .context("could not subscribe to NATS event subject")?,
-    )
-    .map(Inbound::Event);
-
-    let results = NATSStream::<MatchResult<E>>::new(
-        client
-            .subscribe(args.results_subject)
-            .await
-            .context("could not subscribe to NATS results subject")?,
-    )
-    .map(Inbound::Result);
-
-    let mut source = futures::stream::select(events, results);
+    );
 
     let gap = chrono::Duration::from_std(args.gap).context("gap out of range")?;
 
@@ -166,23 +160,26 @@ async fn main() -> anyhow::Result<()> {
         txs.push(tx);
 
         let mut kv = store.clone();
+        let client = client.clone();
 
-        let subject = args.outbound_subject.clone();
-        let mut sink = NATSSink::<MatchContext<E>>::new(client.clone(), move |_| subject.clone());
+        let request_subject = args.outbound_subject.clone();
+        let matched_subject = args.matched_subject.clone();
+        let mut sink =
+            NATSSink::<MatchedEvent<E>>::new(client.clone(), move |_| matched_subject.clone());
 
         let context_window = args.context_window;
         let jump_distance = args.jump_distance;
         let vehicle_cache = args.vehicle_cache;
+        let solve_timeout = args.solve_timeout;
+        let solve_retries = args.solve_retries;
 
         handles.push(tokio::spawn(async move {
             let trips: HashCache<VehicleId, Trip<E>> = HashCache::with_capacity(0, vehicle_cache);
-            let origins: HashCache<VehicleId, web_time::SystemTime> =
-                HashCache::with_capacity(0, vehicle_cache);
 
             while let Some(Dispatch {
                 queued_at,
                 sent_at,
-                inbound,
+                payload,
             }) = rx.recv().await
             {
                 routers_realtime::bus::span_between(
@@ -191,99 +188,103 @@ async fn main() -> anyhow::Result<()> {
                     routers_realtime::bus::wallclock(),
                 );
 
-                match inbound {
-                    Inbound::Event(payload) => {
-                        if let Some(sent_at) = sent_at {
-                            match origins.entry(payload.vehicle_id.clone()) {
-                                Entry::Occupied(mut origin) => {
-                                    origin.put(sent_at);
-                                }
-                                Entry::Vacant(origin) => {
-                                    origin.put_entry(sent_at);
-                                }
-                            }
-                        }
+                let vehicle_id = payload.vehicle_id;
 
-                        let span = info_span!(
-                            "orchestrate",
-                            continuation = field::Empty,
-                            fresh = field::Empty,
-                            cut = field::Empty,
-                        );
+                let span = info_span!(
+                    "orchestrate",
+                    continuation = field::Empty,
+                    fresh = field::Empty,
+                    cut = field::Empty,
+                    attempts = field::Empty,
+                );
 
-                        let mut app = App {
-                            gap,
-                            context_window,
-                            jump_distance,
-                            trips: &trips,
-                            kv: &mut kv,
-                        };
+                let mut app = App {
+                    gap,
+                    context_window,
+                    jump_distance,
+                    trips: &trips,
+                    kv: &mut kv,
+                };
 
-                        match app
-                            .try_create_context(payload)
-                            .instrument(span.clone())
-                            .await
-                        {
-                            Ok(ctx) => {
-                                if let Err(err) = sink
-                                    .send(ctx)
-                                    .instrument(info_span!(parent: &span, "publish_context"))
-                                    .await
-                                {
-                                    error!("could not send match context: {err:#}");
-                                }
-                            }
-                            Err(err) => warn!("could not create match context: {err}"),
-                        }
+                let context = match app
+                    .try_create_context(payload)
+                    .instrument(span.clone())
+                    .await
+                {
+                    Ok(context) => context,
+                    Err(err) => {
+                        warn!("could not create match context: {err}");
+                        continue;
                     }
-                    Inbound::Result(result) => {
-                        let _span =
-                            info_span!("commit_result", layers = result.trip.layers()).entered();
+                };
 
-                        if let (Some((_, origin)), Some(matched_at)) =
-                            (origins.remove(&result.vehicle_id), sent_at)
-                        {
-                            routers_realtime::bus::span_between(
-                                "event_to_match",
-                                origin,
-                                matched_at,
-                            );
-                        }
+                // The vehicle's lane holds through the round trip: its next
+                // event cannot overtake this one, so a stale solve can never
+                // overwrite a fresh trip. Other vehicles overlap on other
+                // workers.
+                let Some(reply) = solve(
+                    &client,
+                    &request_subject,
+                    &context,
+                    solve_timeout,
+                    solve_retries,
+                    &span,
+                )
+                .instrument(span.clone())
+                .await
+                else {
+                    continue;
+                };
 
-                        match trips.entry(result.vehicle_id) {
-                            Entry::Occupied(mut trip) => {
-                                trip.put(result.trip);
+                if let MatchReply::Solved { diff, trip } = reply {
+                    info_span!(parent: &span, "commit_result", layers = trip.layers()).in_scope(
+                        || {
+                            if let Some(sent_at) = sent_at {
+                                routers_realtime::bus::span_between(
+                                    "event_to_match",
+                                    sent_at,
+                                    routers_realtime::bus::wallclock(),
+                                );
                             }
-                            Entry::Vacant(trip) => {
-                                trip.put_entry(result.trip);
+
+                            match trips.entry(vehicle_id) {
+                                Entry::Occupied(mut entry) => {
+                                    entry.put(trip);
+                                }
+                                Entry::Vacant(entry) => {
+                                    entry.put_entry(trip);
+                                }
                             }
-                        }
+                        },
+                    );
+
+                    if let Err(err) = sink
+                        .send(MatchedEvent { vehicle_id, diff })
+                        .instrument(info_span!(parent: &span, "publish_matched"))
+                        .await
+                    {
+                        error!("could not publish matched event: {err:#}");
                     }
                 }
             }
         }));
     }
 
-    while let Some(inbound) = source.next().await {
+    while let Some(payload) = source.next().await {
         // The wire stamp is only valid while this message is the stream's newest
         // yield, so capture it here rather than in the worker.
         let sent_at = routers_realtime::bus::last_sent_at();
 
-        let vehicle_id = match &inbound {
-            Inbound::Event(payload) => &payload.vehicle_id,
-            Inbound::Result(result) => &result.vehicle_id,
-        };
-
         // The stable path (not `DefaultHasher`): worker pinning is the same
         // per-vehicle spread the fleet's partition scheme derives, so the two
         // must never disagree on a Rust release boundary.
-        let worker = routers_realtime::partition::mix(vehicle_id.0) as usize % args.workers;
+        let worker = routers_realtime::partition::mix(payload.vehicle_id.0) as usize % args.workers;
 
         txs[worker]
             .send(Dispatch {
                 queued_at: routers_realtime::bus::wallclock(),
                 sent_at,
-                inbound,
+                payload,
             })
             .await
             .map_err(|_| anyhow::anyhow!("worker {worker} channel closed"))?;
@@ -296,6 +297,60 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Ask a matcher for one context's solve, re-driving on timeout or transport
+/// error. `None` when every attempt failed and the event is abandoned —
+/// until durable ingest lands, this path is exactly as lossy as the bus
+/// beneath it, just louder.
+async fn solve(
+    client: &async_nats::Client,
+    subject: &str,
+    context: &MatchContext<E>,
+    timeout: Duration,
+    retries: usize,
+    span: &tracing::Span,
+) -> Option<MatchReply<E>> {
+    let payload = match context.encode() {
+        Ok(payload) => payload,
+        Err(err) => {
+            error!("could not encode match context: {err:#}");
+            return None;
+        }
+    };
+
+    for attempt in 0..=retries {
+        if attempt > 0 {
+            tokio::time::sleep(Duration::from_millis(250) * attempt as u32).await;
+        }
+
+        let request = client.request_with_headers(
+            subject.to_string(),
+            routers_realtime::bus::outbound(),
+            payload.clone().into(),
+        );
+
+        match tokio::time::timeout(timeout, request).await {
+            Ok(Ok(message)) => {
+                span.record("attempts", attempt as u64 + 1);
+
+                match MatchReply::<E>::decode(&message.payload) {
+                    Ok(reply) => return Some(reply),
+                    // A decode failure is a version skew, not a transient:
+                    // re-driving it would only re-fail.
+                    Err(err) => {
+                        error!("undecodable reply: {err:#}");
+                        return None;
+                    }
+                }
+            }
+            Ok(Err(err)) => warn!("solve request failed (attempt {attempt}): {err}"),
+            Err(_) => warn!("solve request timed out (attempt {attempt})"),
+        }
+    }
+
+    error!("abandoning event after {} attempts", retries + 1);
+    None
 }
 
 impl App<'_> {

--- a/libs/routers_realtime/src/bus/mod.rs
+++ b/libs/routers_realtime/src/bus/mod.rs
@@ -3,7 +3,7 @@ mod trace;
 
 pub use nats::NATSSink;
 pub use nats::NATSStream;
-pub use trace::{last_sent_at, span_between, wallclock};
+pub use trace::{inbound, last_sent_at, outbound, span_between, wallclock};
 
 /// How a message crosses the bus.
 ///

--- a/libs/routers_realtime/src/bus/trace.rs
+++ b/libs/routers_realtime/src/bus/trace.rs
@@ -67,7 +67,7 @@ impl Extractor for HeadersRef<'_> {
 
 /// Headers for an outbound message: the current span's context (W3C
 /// `traceparent`) and the send time.
-pub(super) fn outbound() -> HeaderMap {
+pub fn outbound() -> HeaderMap {
     let mut headers = HeaderMap::new();
 
     let context = tracing::Span::current().context();
@@ -82,7 +82,7 @@ pub(super) fn outbound() -> HeaderMap {
     headers
 }
 
-pub(super) fn inbound(subject: &str, headers: Option<&HeaderMap>) {
+pub fn inbound(subject: &str, headers: Option<&HeaderMap>) {
     let Some(headers) = headers else { return };
     let Some(sent_at) = headers
         .get(SENT_AT)

--- a/libs/routers_realtime/src/event.rs
+++ b/libs/routers_realtime/src/event.rs
@@ -48,14 +48,30 @@ pub struct MatchContext<E: Entry> {
     pub vehicle_id: VehicleId,
 }
 
+/// The matcher's answer to one [`MatchContext`], returned on the request's
+/// reply inbox. Correlation is the inbox itself; the orchestrator that asked
+/// already knows the vehicle.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct MatchResult<E: Entry> {
+#[serde(bound(serialize = "E: Serialize", deserialize = "E: Deserialize<'de>"))]
+pub enum MatchReply<E: Entry> {
+    /// Solved: the emission, and the trip cut at its convergence point — the
+    /// resume state the orchestrator commits for the vehicle's next event.
+    Solved { diff: MatchedDiff<E>, trip: Trip<E> },
+
+    /// Nothing to emit: no anchored layers, or a nominal solve failure. The
+    /// orchestrator keeps its previous resume state; the event still enters
+    /// the raw history, so the next context carries it regardless.
+    NoMatch,
+}
+
+/// One vehicle's emission on the matched subject: what the reconciler (and
+/// any observer, e.g. the realtime viewer) consumes. The resume state stays
+/// on the control plane — nothing here carries a trip.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(bound(serialize = "E: Serialize", deserialize = "E: Deserialize<'de>"))]
+pub struct MatchedEvent<E: Entry> {
     pub vehicle_id: VehicleId,
     pub diff: MatchedDiff<E>,
-
-    /// The trip, cut at its convergence point — the resume state the
-    /// orchestrator commits for the vehicle's next event.
-    pub trip: Trip<E>,
 }
 
 /// One layer of matched history: the observation's identity (its timestamp),
@@ -153,7 +169,8 @@ pub struct Payload {
 
 // The match control plane is Rust-internal: postcard on the wire.
 postcard_wire!(MatchContext<E: Entry>);
-postcard_wire!(MatchResult<E: Entry>);
+postcard_wire!(MatchReply<E: Entry>);
+postcard_wire!(MatchedEvent<E: Entry>);
 
 /// The ingest surface crosses the bus as protobuf
 /// (`routers.realtime.v1.Payload`), so producers in any language can

--- a/libs/routers_viewer/src/bin/realtime/app.rs
+++ b/libs/routers_viewer/src/bin/realtime/app.rs
@@ -5,7 +5,7 @@ use eframe::CreationContext;
 use egui::SidePanel;
 use futures::StreamExt;
 use routers_realtime::bus::NATSStream;
-use routers_realtime::event::MatchResult;
+use routers_realtime::event::MatchedEvent;
 use walkers::{MapMemory, lon_lat};
 
 use routers_viewer::{ColourFactory, Component, Context, Map, Regular};
@@ -21,14 +21,14 @@ const DRAIN_PER_FRAME: usize = 2_000;
 pub struct RealtimeApp {
     map: Map,
     store: TraceStore,
-    rx: Receiver<MatchResult<E>>,
+    rx: Receiver<MatchedEvent<E>>,
     centered: bool,
 }
 
 impl RealtimeApp {
     pub fn new(
         ctx: &CreationContext<'_>,
-        mut source: NATSStream<MatchResult<E>>,
+        mut source: NATSStream<MatchedEvent<E>>,
         trace_capacity: usize,
         idle_ttl: Duration,
     ) -> Self {

--- a/libs/routers_viewer/src/bin/realtime/main.rs
+++ b/libs/routers_viewer/src/bin/realtime/main.rs
@@ -18,7 +18,7 @@ use clap::Parser;
 use log::info;
 use routers_codec::osm::OsmEntryId;
 use routers_realtime::bus::NATSStream;
-use routers_realtime::event::MatchResult;
+use routers_realtime::event::MatchedEvent;
 
 use crate::app::RealtimeApp;
 
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
         .subscribe(args.inbound_subject)
         .await
         .context("could not subscribe to NATS subject")?;
-    let source = NATSStream::<MatchResult<E>>::new(subscriber);
+    let source = NATSStream::<MatchedEvent<E>>::new(subscriber);
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()

--- a/libs/routers_viewer/src/bin/realtime/store.rs
+++ b/libs/routers_viewer/src/bin/realtime/store.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use web_time::Instant;
 
 use geo::Point;
-use routers_realtime::event::{MatchResult, MatchedDiff, VehicleId};
+use routers_realtime::event::{MatchedDiff, MatchedEvent, VehicleId};
 
 use crate::E;
 
@@ -76,7 +76,7 @@ impl TraceStore {
         }
     }
 
-    pub fn ingest(&mut self, result: MatchResult<E>) {
+    pub fn ingest(&mut self, result: MatchedEvent<E>) {
         let now = Instant::now();
 
         self.event_bucket.push_back(now);


### PR DESCRIPTION
**Matcher becomes request and reply using NATS.** 

## Race fixed

The orchestrator is partitioned on vehicle-id now, and so a vehicle's next event cannot “overtake” or be “observed out of order” of an existing solve.

This closes a pre-existing last-write-wins race. Where, the matcher `buffer_unordered` emitted in completion order; the orchestrator blindly committed whatever arrived last and stale trips overwrote fresh ones, widening with concurrency.