### PR TITLE
feat: Orchestrator Routes Events

### DIFF
--- a/libs/routers_realtime/bin/matcher.rs
+++ b/libs/routers_realtime/bin/matcher.rs
@@ -117,14 +117,26 @@ impl Matching {
         );
         let _entered = span.enter();
 
-        let (mut trip, fresh) = match continuation {
+        let (mut trip, fresh, downgraded) = match continuation {
+            // A resume solved on another shard references edges this shard's
+            // padding may not cover: adopting it would route through nodes
+            // that do not exist here. Degrade to a restart over the trip's
+            // own observations — the emission re-covers them under a higher
+            // revision, so the reconciled history heals the seam.
+            Continuation::Resume { trip, fresh } if !matcher.supports(&trip) => {
+                span.record("continuation", "downgrade");
+                warn!("{vehicle_id}: resume references a foreign shard; restarting");
+
+                let fresh = trip.origins().iter().copied().chain(fresh).collect();
+                (matcher.begin(), fresh, true)
+            }
             Continuation::Resume { trip, fresh } => {
                 span.record("continuation", "resume");
-                (trip, fresh)
+                (trip, fresh, false)
             }
             Continuation::Restart { fresh } => {
                 span.record("continuation", "restart");
-                (matcher.begin(), fresh)
+                (matcher.begin(), fresh, false)
             }
         };
 
@@ -173,10 +185,11 @@ impl Matching {
         };
 
         // Emit everything a future solve could still change — the whole trip
-        // since its last cut. Revision 0 until durable ingest supplies stream
-        // sequences.
-        let diff = info_span!("emit")
+        // since its last cut. The owner stamps the real revision (the ingest
+        // stream sequence) before publishing.
+        let mut diff = info_span!("emit")
             .in_scope(|| MatchedDiff::new(&solution, &origins, self.network.as_ref(), 0));
+        diff.downgraded = downgraded;
         drop(solution);
         span.record("emitted", diff.layers.len());
 

--- a/libs/routers_realtime/bin/orchestrator.rs
+++ b/libs/routers_realtime/bin/orchestrator.rs
@@ -101,10 +101,12 @@ struct Args {
     #[arg(long, env, value_parser = humantime::parse_duration, default_value = "15m")]
     matched_retention: Duration,
 
-    /// The NATS subject the shard's matchers serve requests on.
-    /// For example, `events.match.{shard}`.
-    #[arg(short, long = "out", env)]
-    outbound_subject: String,
+    /// The subject prefix matchers serve requests on. Each request routes to
+    /// `<prefix>.<geohash>` — the geographic shard of the event's position —
+    /// so this pod's vehicles reach whichever matchers own the ground beneath
+    /// them. The orchestrator itself stays geography-blind beyond this.
+    #[arg(long = "match-prefix", env, default_value = "events.match")]
+    match_prefix: String,
 
     /// How long to wait for a matcher's reply before re-driving the request.
     #[arg(long, env, value_parser = humantime::parse_duration, default_value = "5s")]
@@ -179,7 +181,7 @@ struct Worker {
     client: async_nats::Client,
     stream: jetstream::Context,
     archive: mpsc::Sender<(RawEvent, oneshot::Sender<()>)>,
-    request_subject: String,
+    match_prefix: String,
 
     gap: chrono::TimeDelta,
     jump_distance: f64,
@@ -281,7 +283,7 @@ async fn main() -> anyhow::Result<()> {
             client: client.clone(),
             stream: stream.clone(),
             archive: archive_tx.clone(),
-            request_subject: args.outbound_subject.clone(),
+            match_prefix: args.match_prefix.clone(),
             gap,
             jump_distance: args.jump_distance,
             context_window: args.context_window,
@@ -478,12 +480,20 @@ impl Worker {
 
         let context = self.create_context(history, payload);
 
+        // Route to the ground beneath the event: the matcher owning the
+        // head's shard solves it, degrading a foreign resume itself.
+        let subject = format!(
+            "{}.{}",
+            self.match_prefix,
+            routers_realtime::event::shard_of(payload.point)
+        );
+
         // The vehicle's lane holds through the round trip: its next event
         // cannot overtake this one, so a stale solve can never overwrite a
         // fresh trip. Other vehicles overlap on other workers.
         let Some(reply) = solve(
             &self.client,
-            &self.request_subject,
+            &subject,
             &context,
             self.solve_timeout,
             self.solve_retries,

--- a/libs/routers_realtime/src/event.rs
+++ b/libs/routers_realtime/src/event.rs
@@ -240,12 +240,23 @@ pub struct RawEvent {
     pub timestamp: DateTime<Utc>,
 }
 
+/// The fleet's geographic shard precision. One source of truth: matcher
+/// subjects, storage tags, and shard files must all agree on it.
+pub const SHARD_PRECISION: u8 = 4;
+
+/// The geographic shard an observation belongs to. Orchestrators route match
+/// requests to `events.match.<shard_of(point)>`; matchers each serve the one
+/// shard they loaded.
+pub fn shard_of(point: Point) -> Geohash {
+    GeohashStrategy::with_precision(SHARD_PRECISION).locate(point)
+}
+
 impl Storable for RawEvent {
     type ShardId = Geohash;
     type Key = VehicleId;
 
     fn shard_id(&self) -> Self::ShardId {
-        GeohashStrategy::with_precision(4).locate(self.point)
+        shard_of(self.point)
     }
 
     fn key(&self) -> Self::Key {

--- a/libs/routers_transition/src/matcher/entity.rs
+++ b/libs/routers_transition/src/matcher/entity.rs
@@ -245,6 +245,18 @@ where
         }
     }
 
+    /// Whether every candidate the trip carries resolves against this
+    /// matcher's network. A trip resumed across a shard boundary references
+    /// edges of the shard it was solved on, which this shard's padding may
+    /// not cover — adopting it would route through nodes that do not exist
+    /// here. `false` means the trip must restart from its raw observations.
+    pub fn supports(&self, trip: &Trip<N::Entry>) -> bool {
+        trip.candidates().iter().all(|candidate| {
+            self.map.point(&candidate.edge.source).is_some()
+                && self.map.point(&candidate.edge.target).is_some()
+        })
+    }
+
     /// The convergence point of the trip's current solution: the latest layer
     /// no future push can change, asked of the same solver [`solve`] runs.
     /// `None` when the live paths never fuse; errors where a solve would

--- a/libs/routers_transition/tests/streaming.rs
+++ b/libs/routers_transition/tests/streaming.rs
@@ -460,6 +460,54 @@ fn reconcile_restarts_when_observations_disagree() {
     );
 }
 
+/// A trip is supported by the network it was solved on, and not by one that
+/// lacks its nodes — the gate a matcher uses to degrade a foreign resume.
+#[test]
+fn supports_rejects_a_foreign_trip() {
+    let home = bent_road();
+    let costing = Costing::default();
+    let m = Matcher::new(
+        &home,
+        &costing,
+        StandardGenerator::new(&home, &costing.emission),
+        AllCompute::default(),
+        &(),
+    );
+
+    let mut trip = m.begin();
+    for &origin in &origins_of(&trajectory().into_points())[..3] {
+        m.push(&mut trip, origin).expect("push must anchor");
+    }
+
+    assert!(
+        m.supports(&trip),
+        "the solving network supports its own trip"
+    );
+
+    // A different shard entirely: same ids do not exist here.
+    let foreign = MockNetworkBuilder::new()
+        .node(100, point!(x: 151.20, y: -33.87))
+        .node(101, point!(x: 151.21, y: -33.87))
+        .edge(100, 101)
+        .build();
+    let m2 = Matcher::new(
+        &foreign,
+        &costing,
+        StandardGenerator::new(&foreign, &costing.emission),
+        AllCompute::default(),
+        &(),
+    );
+
+    assert!(
+        !m2.supports(&trip),
+        "a network missing the trip's nodes must refuse it"
+    );
+    assert!(
+        m2.supports(&m2.begin()),
+        "an empty trip carries no foreign references"
+    );
+}
+
 /// `LayerId` indexes everything on a trip: origins, candidate layers, trellis.
 #[test]
 fn trip_accessors_are_layer_indexed() {


### PR DESCRIPTION
The orchestrator is vehicle-partitioned, so it now needs to reroute vehicles to `events.match.<shard_of(point)>`. The matchers keep serving exactly one shard subject each.

`Matcher::supports(trip)` checks every candidate edge's endpoints against the loaded network. Unsupported resumes degrade to a restart.