### PR TITLE
feat: Terraform Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,11 @@ conformance/external
 *.csv.zip
 
 .direnv/
+
+# Terraform/OpenTofu working directories. Provider binaries are ~60 MiB each
+# and are reinstalled by `tofu init`; the .terraform.lock.hcl beside them is
+# the part worth committing.
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan

--- a/infrastructure/terraform/Justfile
+++ b/infrastructure/terraform/Justfile
@@ -49,3 +49,23 @@ summary root="envs/dev/platform":
 plan-summary root="envs/dev/platform" *args:
     {{ tofu }} -chdir="{{ root }}" init -backend=false -input=false > /dev/null
     {{ tofu }} -chdir="{{ root }}" plan {{ args }}
+
+# Estimated monthly spend for the applied fleet, by node pool and by service.
+# The rates are inputs carrying the region and the date they were read, so
+# confirm against the billing account before anything depends on the total.
+cost root="envs/dev/platform":
+    {{ tofu }} -chdir="{{ root }}" output -raw cost_report
+
+# The same estimate at another commitment tier or target, without applying:
+#
+#   just terraform::cost-what-if 'pricing_commitment=cud_3y'
+#   just terraform::cost-what-if 'throughput_target_eps=5000000'
+#
+# `output` reads state, so an override has to be evaluated rather than read
+# back — which also makes this work before the first apply.
+cost-what-if override root="envs/dev/platform":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {{ tofu }} -chdir="{{ root }}" init -backend=false -input=false > /dev/null
+    echo 'module.capacity.cost_report' \
+        | {{ tofu }} -chdir="{{ root }}" console -var '{{ override }}'

--- a/infrastructure/terraform/Justfile
+++ b/infrastructure/terraform/Justfile
@@ -1,0 +1,51 @@
+# OpenTofu is assumed on PATH. The capacity module needs no credentials at all;
+# the others use mock providers in their tests, so nothing here reaches GCP.
+
+tofu := env("TOFU", "tofu")
+
+modules := "modules/capacity modules/platform"
+roots := "envs/dev/platform envs/dev/workloads"
+validate-only := "modules/devstack modules/realtime"
+
+# Everything that can be checked without a cloud account.
+default: fmt-check validate test
+
+# The sizing model plus the mock-provider suites.
+test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for d in {{ modules }} {{ roots }}; do
+        if compgen -G "$d/tests/*.tftest.hcl" > /dev/null; then
+            echo "==> $d"
+            {{ tofu }} -chdir="$d" init -backend=false -input=false > /dev/null
+            {{ tofu }} -chdir="$d" test
+        fi
+    done
+
+validate:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for d in {{ modules }} {{ roots }} {{ validate-only }}; do
+        echo "==> $d"
+        {{ tofu }} -chdir="$d" init -backend=false -input=false > /dev/null
+        {{ tofu }} -chdir="$d" validate
+    done
+
+fmt:
+    {{ tofu }} fmt -recursive .
+
+fmt-check:
+    {{ tofu }} fmt -recursive -check .
+
+# The sizing report for an environment, e.g. `just summary envs/dev/platform`.
+# Read this before an apply: the model reports shortfalls as warnings rather
+# than errors, so a plan succeeds while telling you it will not reach the
+# target.
+summary root="envs/dev/platform":
+    {{ tofu }} -chdir="{{ root }}" output -raw capacity_summary
+
+# The sizing report without applying anything, straight from the model. Useful
+# for asking "what would 5M need" by overriding the target.
+plan-summary root="envs/dev/platform" *args:
+    {{ tofu }} -chdir="{{ root }}" init -backend=false -input=false > /dev/null
+    {{ tofu }} -chdir="{{ root }}" plan {{ args }}

--- a/infrastructure/terraform/envs/dev/platform/.terraform.lock.hcl
+++ b/infrastructure/terraform/envs/dev/platform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.50"
+  hashes = [
+    "h1:ULGxKibTy8Z9F3roMLNFiPgw+MDs7FYuOdiy+Oispi8=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}

--- a/infrastructure/terraform/envs/dev/platform/main.tf
+++ b/infrastructure/terraform/envs/dev/platform/main.tf
@@ -1,0 +1,109 @@
+# GCP substrate for the dev environment: network, cluster, node pools,
+# registry and the shard bucket.
+#
+# Split from ../workloads because the kubernetes and helm providers there need
+# a cluster endpoint to configure themselves, and a provider cannot be
+# configured from a value that does not exist yet. Apply this root first.
+
+locals {
+  # One shard per line, as emitted by
+  # `cargo run -p routers_shard --bin generate-shards`. Read from a file rather
+  # than inlined: at a finer precision this list is thousands of entries.
+  shards = compact(split("\n", trimspace(file(var.shards_file))))
+}
+
+module "capacity" {
+  source = "../../../modules/capacity"
+
+  shards                = local.shards
+  shard_precision       = var.shard_precision
+  coverage_cells        = var.coverage_cells
+  throughput_target_eps = var.throughput_target_eps
+  design_target_eps     = var.design_target_eps
+  vertical_profile      = var.vertical_profile
+  streams               = var.streams
+  machines              = var.machines
+}
+
+module "platform" {
+  source = "../../../modules/platform"
+
+  project_id   = var.project_id
+  region       = var.region
+  env          = var.env
+  cluster_name = var.cluster_name
+  network_name = var.network_name
+
+  subnet_cidr             = var.subnet_cidr
+  pods_secondary_cidr     = var.pods_secondary_cidr
+  services_secondary_cidr = var.services_secondary_cidr
+  master_authorized_cidrs = var.master_authorized_cidrs
+
+  # Straight from the sizing model, so the fleet that gets built is the fleet
+  # that was sized. Taints keep each pool for its own workload.
+  node_pools = {
+    for name, pool in module.capacity.pools : name => {
+      machine_type   = pool.machine_type
+      min_node_count = pool.min_node_count
+      max_node_count = pool.max_node_count
+      taints = [{
+        key    = "routers.dev/pool"
+        value  = name
+        effect = "NO_SCHEDULE"
+      }]
+    }
+  }
+
+  shard_bucket_name   = var.shard_bucket_name
+  deletion_protection = var.deletion_protection
+  labels              = var.labels
+}
+
+# The sizing model reports rather than fails, because a plan that stops at the
+# first problem hides the others. These surface as warnings on every plan; read
+# them before applying.
+check "capacity_is_deliverable" {
+  assert {
+    condition     = module.capacity.meets_target
+    error_message = "The sizing model does not meet the target:\n${module.capacity.summary}"
+  }
+
+  assert {
+    condition     = length(module.capacity.unschedulable_shapes) == 0
+    error_message = "Pod shapes larger than their node: ${join(", ", module.capacity.unschedulable_shapes)}."
+  }
+
+  assert {
+    condition     = length(module.capacity.out_of_coverage_shards) == 0
+    error_message = "${length(module.capacity.out_of_coverage_shards)} shards fall outside coverage_cells, and each would become an idle matcher."
+  }
+}
+
+# The two quantities that cannot be corrected once events exist. Everything
+# else in the model is a variable change; these are a migration, so they are
+# checked against the design target rather than today's.
+check "the_wire_law_survives_the_design_target" {
+  assert {
+    condition = module.capacity.design_target.streams_ok
+    error_message = join(" ", [
+      "The pinned stream count cannot absorb the design target:",
+      "${module.capacity.design_target.writes_per_stream} writes/s per stream",
+      "against a ${module.capacity.streams.raw}-stream topology.",
+      "A revision is a stream sequence, so raising this later resets sequence",
+      "domains and breaks every revision comparison across the boundary.",
+      "Raise `streams` to ${module.capacity.design_target.streams_required} now, while the streams are still empty.",
+    ])
+  }
+
+  assert {
+    condition     = module.capacity.design_target.fleet_fits
+    error_message = "The design target needs a fleet of ${module.capacity.design_target.fleet_required} against ${module.capacity.fleet.partitions} partitions. A partition is the smallest unit an owner can hold, so the answer is a larger vertical profile, not more pods."
+  }
+}
+
+check "the_binaries_agree_on_precision" {
+  assert {
+    condition     = module.capacity.precision_prerequisite == ""
+    error_message = module.capacity.precision_prerequisite
+  }
+}

--- a/infrastructure/terraform/envs/dev/platform/outputs.tf
+++ b/infrastructure/terraform/envs/dev/platform/outputs.tf
@@ -1,0 +1,34 @@
+output "capacity_summary" {
+  description = "The sizing report. `tofu output -raw capacity_summary`."
+  value       = module.capacity.summary
+}
+
+output "cluster_name" {
+  value = module.platform.cluster_name
+}
+
+output "image_registry" {
+  description = "Pass to the workloads root as image_registry."
+  value       = module.platform.image_registry
+}
+
+output "shard_bucket" {
+  value = module.platform.shard_bucket
+}
+
+output "shard_cache_service_account_email" {
+  value = module.platform.shard_cache_service_account_email
+}
+
+output "pool_node_selectors" {
+  value = module.platform.pool_node_selectors
+}
+
+output "pool_tolerations" {
+  value = module.platform.pool_tolerations
+}
+
+output "addressing" {
+  description = "Pod range headroom. `pod_range_node_capacity` must stay above `max_nodes`."
+  value       = module.platform.addressing
+}

--- a/infrastructure/terraform/envs/dev/platform/outputs.tf
+++ b/infrastructure/terraform/envs/dev/platform/outputs.tf
@@ -3,6 +3,16 @@ output "capacity_summary" {
   value       = module.capacity.summary
 }
 
+output "cost_report" {
+  description = "Estimated monthly spend for the sized fleet. `just cost`, or `just cost-what-if 'pricing_commitment=cud_3y'` to compare tiers without applying."
+  value       = module.capacity.cost_report
+}
+
+output "cost" {
+  description = "The same estimate as structured data, broken down by node pool and by service."
+  value       = module.capacity.cost
+}
+
 output "cluster_name" {
   value = module.platform.cluster_name
 }

--- a/infrastructure/terraform/envs/dev/platform/shards.txt
+++ b/infrastructure/terraform/envs/dev/platform/shards.txt
@@ -1,0 +1,6 @@
+r3gq
+r3gr
+r3gw
+r3gx
+r652
+r658

--- a/infrastructure/terraform/envs/dev/platform/tests/platform.tftest.hcl
+++ b/infrastructure/terraform/envs/dev/platform/tests/platform.tftest.hcl
@@ -1,0 +1,141 @@
+# Wiring test for the platform root. Mock providers stand in for GCP, so this
+# runs with no credentials and no billing: it checks that the modules compose
+# and that the guards fire, not that Google accepts the resources.
+
+mock_provider "google" {
+  # Mocks invent random strings for computed attributes, and several of these
+  # feed arguments the provider validates with a regexp. Shape them like the
+  # real thing so the test fails on wiring rather than on the mock.
+  # The account id must be 6-30 characters for the IAM member's regexp to
+  # accept the resulting resource name.
+  mock_resource "google_service_account" {
+    defaults = {
+      name  = "projects/routers-test/serviceAccounts/dev-shard-cache@routers-test.iam.gserviceaccount.com"
+      email = "dev-shard-cache@routers-test.iam.gserviceaccount.com"
+    }
+  }
+
+  mock_resource "google_artifact_registry_repository" {
+    defaults = {
+      name = "routers"
+    }
+  }
+}
+
+variables {
+  project_id        = "routers-test"
+  shard_bucket_name = "routers-test-shards"
+}
+
+run "sizing_flows_into_node_pools" {
+  command = plan
+
+  expect_failures = [check.capacity_is_deliverable]
+
+  # A pool per capacity shape, and nothing hand-written.
+  assert {
+    condition     = length(keys(module.capacity.pools)) == 4
+    error_message = "Expected 4 pools, got ${join(", ", keys(module.capacity.pools))}."
+  }
+
+  assert {
+    condition     = length(module.capacity.unschedulable_shapes) == 0
+    error_message = "Every pod shape must fit one node: ${join(", ", module.capacity.unschedulable_shapes)}."
+  }
+
+  # The pipeline pool now holds one shape. The historian it used to share with
+  # the orchestrators was absorbed into them.
+  assert {
+    condition     = length(module.capacity.pools["pipeline"].packing) == 1
+    error_message = "The pipeline pool should carry only orchestrators, got ${length(module.capacity.pools["pipeline"].packing)} shapes."
+  }
+
+  # Matchers autoscale, so their pool's ceiling must exceed its floor; the
+  # fleet does not, so its ceiling is only rollout and headroom slack.
+  assert {
+    condition     = module.capacity.pools["matcher"].max_node_count > module.capacity.pools["matcher"].min_node_count
+    error_message = "The matcher pool must have room for its HPA to scale into."
+  }
+}
+
+# The two quantities a migration cannot avoid. These are the reason the root
+# carries a design target at all.
+run "the_pinned_wire_law_survives_the_design_target" {
+  command = plan
+
+  expect_failures = [check.capacity_is_deliverable]
+
+  assert {
+    condition     = module.capacity.design_target.streams_ok
+    error_message = "The pinned ${module.capacity.streams.raw} streams must absorb the design target, at ${module.capacity.design_target.writes_per_stream} writes/s each."
+  }
+
+  assert {
+    condition     = module.capacity.design_target.fleet_fits
+    error_message = "The design target needs a fleet of ${module.capacity.design_target.fleet_required}, past the ${module.capacity.fleet.partitions} partitions available."
+  }
+
+  assert {
+    condition     = module.capacity.streams.raw_sufficient
+    error_message = module.capacity.raw_stream_prerequisite
+  }
+}
+
+run "the_deployed_precision_agrees_with_the_binaries" {
+  command = plan
+
+  expect_failures = [check.capacity_is_deliverable]
+
+  assert {
+    condition     = module.capacity.precision_prerequisite == ""
+    error_message = module.capacity.precision_prerequisite
+  }
+
+  assert {
+    condition     = module.capacity.shard_precision == 4
+    error_message = "Expected precision 4, got ${module.capacity.shard_precision}."
+  }
+}
+
+# The shipped defaults reach every ceiling they can. The one they cannot is the
+# matched stream, which is a singleton in `ingest.rs` — so this pins that as
+# the *only* outstanding shortfall, and will fail once it is fixed, which is
+# when the assertion should become `meets_target`.
+run "the_matched_stream_is_the_only_outstanding_shortfall" {
+  command = plan
+
+  expect_failures = [check.capacity_is_deliverable]
+
+  assert {
+    condition     = !module.capacity.streams.matched_sufficient
+    error_message = "The matched stream now absorbs the target. Split MATCHED_STREAM landed: raise matched_streams and assert meets_target here instead."
+  }
+
+  assert {
+    condition     = module.capacity.matcher.capacity_eps >= module.capacity.required_eps
+    error_message = "Matchers must cover the target:\n${module.capacity.summary}"
+  }
+
+  assert {
+    condition     = module.capacity.fleet.capacity_eps >= module.capacity.required_eps
+    error_message = "The fleet must cover the target:\n${module.capacity.summary}"
+  }
+
+  assert {
+    condition     = module.capacity.valkey_client_prerequisite == ""
+    error_message = module.capacity.valkey_client_prerequisite
+  }
+}
+
+# The addressing plan has to hold the autoscaler ceiling, not the steady state:
+# the range is exhausted at the peak.
+run "the_pod_range_holds_the_node_ceiling" {
+  command = plan
+
+  expect_failures = [check.capacity_is_deliverable]
+
+  assert {
+    condition     = module.platform.addressing.pod_range_node_capacity >= module.platform.addressing.max_nodes
+    error_message = "The pod range holds ${module.platform.addressing.pod_range_node_capacity} nodes but the pools can reach ${module.platform.addressing.max_nodes}."
+  }
+}

--- a/infrastructure/terraform/envs/dev/platform/variables.tf
+++ b/infrastructure/terraform/envs/dev/platform/variables.tf
@@ -1,0 +1,141 @@
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type    = string
+  default = "australia-southeast1"
+}
+
+variable "env" {
+  type    = string
+  default = "dev"
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "routers"
+}
+
+variable "network_name" {
+  type    = string
+  default = "routers"
+}
+
+variable "subnet_cidr" {
+  type    = string
+  default = "10.0.0.0/20"
+}
+
+variable "pods_secondary_cidr" {
+  description = "Sized for the node ceiling, not the steady state. At 110 pods per node a /14 holds 1024 nodes; the platform module fails the plan if the pools can outgrow it."
+  type        = string
+  default     = "10.16.0.0/14"
+}
+
+variable "services_secondary_cidr" {
+  type    = string
+  default = "10.32.0.0/20"
+}
+
+variable "master_authorized_cidrs" {
+  description = "Networks allowed to reach the control plane. Empty closes it to everything outside Google Cloud, including CI."
+  type = list(object({
+    cidr_block   = string
+    display_name = string
+  }))
+  default = []
+}
+
+variable "shard_bucket_name" {
+  type = string
+}
+
+# --- Sizing -----------------------------------------------------------------
+
+variable "shards_file" {
+  description = "File holding one geohash shard per line, at shard_precision."
+  type        = string
+  default     = "shards.txt"
+}
+
+variable "shard_precision" {
+  description = "Must match the length of every entry in shards_file, and the `event::SHARD_PRECISION` compiled into the binaries."
+  type        = number
+  default     = 4
+}
+
+variable "coverage_cells" {
+  description = "Allowlist of geohash prefixes for the service region. Catches a shard list generated over the wrong extent before it becomes a fleet of idle matchers."
+  type        = list(string)
+  default     = []
+}
+
+variable "throughput_target_eps" {
+  description = <<-EOT
+    The rate to size for. Set to production's current load rather than a
+    development figure, so the plan is honest about node counts and cost.
+
+    Note what it does against the six shipped shards: 800k + headroom over six
+    geographic subjects is ~167k evt/s each, which the model covers with ~28
+    matcher replicas per shard. That is legitimate — a shard's replicas are a
+    NATS queue group, so they divide its requests — but every replica loads that
+    shard's whole `.shard.rt` file, so the memory cost is linear in replicas.
+    Regenerating `shards.txt` over the real coverage at a finer precision trades
+    that duplication for more subjects, and is the better shape past a point;
+    `max_matcher_replicas_per_shard` in the capacity module is where that point
+    is expressed.
+  EOT
+  type        = number
+  default     = 800000
+}
+
+variable "design_target_eps" {
+  description = "The rate the deployment is designed to reach. Only the wire-law quantities — `streams` and the partition count — must satisfy it today, because both are a migration to change and everything else is a variable."
+  type        = number
+  default     = 5000000
+}
+
+variable "streams" {
+  description = <<-EOT
+    Raw JetStream streams the vehicle partition space divides across. Pinned for
+    the life of the deployment: a revision is a stream sequence, so remapping
+    partitions resets sequence domains.
+
+    64 puts the design target at ~98k writes/s per stream, inside a single raft
+    leader's ceiling. 32 would put it at ~195k, over it.
+  EOT
+  type        = number
+  default     = 64
+}
+
+variable "vertical_profile" {
+  type    = string
+  default = "standard"
+}
+
+variable "machines" {
+  description = "Machine shape per node pool. Keys must match the capacity module's pools: matcher, pipeline, infra, system."
+  type = map(object({
+    machine_type = string
+    vcpu         = number
+    memory_gib   = number
+  }))
+
+  default = {
+    matcher  = { machine_type = "c4-highcpu-32", vcpu = 32, memory_gib = 64 }
+    pipeline = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
+    infra    = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+    system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+  }
+}
+
+variable "deletion_protection" {
+  type    = bool
+  default = true
+}
+
+variable "labels" {
+  type    = map(string)
+  default = {}
+}

--- a/infrastructure/terraform/envs/dev/platform/variables.tf
+++ b/infrastructure/terraform/envs/dev/platform/variables.tf
@@ -137,8 +137,8 @@ variable "machines" {
   default = {
     matcher  = { machine_type = "c4-highcpu-32", vcpu = 32, memory_gib = 64 }
     pipeline = { machine_type = "c4-highcpu-16", vcpu = 16, memory_gib = 32 }
-    infra    = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
-    system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+    infra    = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 60 }
+    system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 30 }
   }
 }
 

--- a/infrastructure/terraform/envs/dev/platform/variables.tf
+++ b/infrastructure/terraform/envs/dev/platform/variables.tf
@@ -115,7 +115,19 @@ variable "vertical_profile" {
 }
 
 variable "machines" {
-  description = "Machine shape per node pool. Keys must match the capacity module's pools: matcher, pipeline, infra, system."
+  description = <<-EOT
+    Machine shape per node pool. Keys must match the capacity module's pools:
+    matcher, pipeline, infra, system. `vcpu` and `memory_gib` must match
+    `machine_type` — the model derives allocatable capacity from them, so an
+    overstated figure plans too few nodes and the shortfall appears as Pending
+    pods rather than as a wrong number here.
+
+    Every pool is CPU-bound at these pod shapes, which is why the two carrying
+    the pipeline are highcpu: a standard node's extra memory would be paid for
+    and left idle. The infra pool is the exception and is deliberately not
+    packed tight — see `nats.spread_nodes`, which floors its node count so the
+    brokers can spread across failure domains.
+  EOT
   type = map(object({
     machine_type = string
     vcpu         = number
@@ -124,8 +136,8 @@ variable "machines" {
 
   default = {
     matcher  = { machine_type = "c4-highcpu-32", vcpu = 32, memory_gib = 64 }
-    pipeline = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
-    infra    = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+    pipeline = { machine_type = "c4-highcpu-16", vcpu = 16, memory_gib = 32 }
+    infra    = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
     system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
   }
 }

--- a/infrastructure/terraform/envs/dev/platform/versions.tf
+++ b/infrastructure/terraform/envs/dev/platform/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.8"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.50"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/infrastructure/terraform/envs/dev/workloads/.terraform.lock.hcl
+++ b/infrastructure/terraform/envs/dev/workloads/.terraform.lock.hcl
@@ -1,0 +1,60 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.50"
+  hashes = [
+    "h1:ULGxKibTy8Z9F3roMLNFiPgw+MDs7FYuOdiy+Oispi8=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version     = "3.2.0"
+  constraints = "~> 3.0, ~> 3.2"
+  hashes = [
+    "h1:IytRFhZXOMPVB36GainacnNoBtiibAdVMdezG2DPVag=",
+    "zh:1a214581dee54ec4e9afa4050e54f6c187aed4b51b2d2ac929c58706b65e1159",
+    "zh:2f8ba94af93011768ed1fffd4d25b980cd764f2d49c9f13475512ec48464da0b",
+    "zh:36373bca4f374e95f654def79e0b12df0c8f2e01c634db80ff2737ded29062e3",
+    "zh:3a26b5c3e47b2bbc01faa0fa9fe816ea4f74f1f8f4555dfad7f62ee38266aaff",
+    "zh:51bc637700f13cfc1f7c6a8c03a4b5b5755338419912d945dbfe5ccb0ddbf614",
+    "zh:53f32f91afcb682209de124d8a994e591687023ae7c0dfed6184c5511778b16b",
+    "zh:6f4434327ed466b2b5be0d5f4aa537bca71ebd7f7fe05468065aeda52dfc8896",
+    "zh:7394e8c6f5027fa21699e46c9a45bee1ce87fd8dd98f2e89e8d414ec70c8e4e1",
+    "zh:d90b855a0990e3aa6445afe66de730c2f4651f39699c6b6345ca02f9af2a1a08",
+    "zh:d9b7246e6af0f75155ed532855014f888e9e5613242c89e321b4e0f9b54f5726",
+    "zh:dabd399ca36172c15d176a24cf199ac886ef191f7131e806d76a8dc209e5beb8",
+    "zh:e57987397be46dc123365f16c3bec4dd0615453c8bfdcfc1b7c9f3202a09c516",
+    "zh:ec88430b833b943b38d02f70b33250c72bb6ffa3b3d22360990a41390161a2b2",
+    "zh:f8ea01b57982e9ed9ad3a750b1caba261a478f5b0ddcac78a4502d886fd2fc74",
+    "zh:fb63819037158205ebf42b649c3a8ec308234ffe987a5dbd4444e1e0683f1170",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.38"
+  hashes = [
+    "h1:eCV78xGlh9eay+62U4gAgCEMohuiBJXN9XTIZNn+rX4=",
+    "zh:1096b41c4e5b2ee6c1980916fb9a8579bc1892071396f7a9432be058aabf3cbc",
+    "zh:2959fde9ae3d1deb5e317df0d7b02ea4977951ee6b9c4beb083c148ca8f3681c",
+    "zh:5082f98fcb3389c73339365f7df39fc6912bf2bd1a46d5f97778f441a67fd337",
+    "zh:620fd5d0fbc2d7a24ac6b420a4922e6093020358162a62fa8cbd37b2bac1d22e",
+    "zh:7f47c2de179bba35d759147c53082cad6c3449d19b0ec0c5a4ca8db5b06393e1",
+    "zh:89c3aa2a87e29febf100fd21cead34f9a4c0e6e7ae5f383b5cef815c677eb52a",
+    "zh:96eecc9f94938a0bc35b8a63d2c4a5f972395e44206620db06760b730d0471fc",
+    "zh:e15567c1095f898af173c281b66bffdc4f3068afdd9f84bb5b5b5521d9f29584",
+    "zh:ecc6b912629734a9a41a7cf1c4c73fb13b4b510afc9e7b2e0011d290bcd6d77f",
+  ]
+}

--- a/infrastructure/terraform/envs/dev/workloads/main.tf
+++ b/infrastructure/terraform/envs/dev/workloads/main.tf
@@ -1,0 +1,128 @@
+# In-cluster half of the dev environment: NATS with JetStream, Valkey,
+# observability, and the routers-realtime release.
+#
+# Applied after ../platform, which owns the cluster this points at. The sizing
+# model is recomputed here rather than read from the other root's state — it is
+# pure arithmetic over the same inputs, so the two agree by construction and
+# neither root needs a backend to publish to the other.
+
+locals {
+  shards = compact(split("\n", trimspace(file(var.shards_file))))
+}
+
+module "capacity" {
+  source = "../../../modules/capacity"
+
+  shards                = local.shards
+  shard_precision       = var.shard_precision
+  coverage_cells        = var.coverage_cells
+  throughput_target_eps = var.throughput_target_eps
+  design_target_eps     = var.design_target_eps
+  vertical_profile      = var.vertical_profile
+  streams               = var.streams
+  machines              = var.machines
+}
+
+module "devstack" {
+  source = "../../../modules/devstack"
+
+  namespace = var.dependency_namespace
+
+  nats_replicas            = module.capacity.nats.replicas_total
+  jetstream_file_store_gib = module.capacity.nats.file_store_gib
+
+  valkey_primaries  = module.capacity.valkey.primaries
+  valkey_io_threads = module.capacity.valkey.io_threads
+
+  collector_replicas = module.capacity.telemetry.collector_replicas
+
+  # Dependencies share the infra pool; observability has its own.
+  node_selector = { "routers.dev/pool" = "infra" }
+  tolerations = [{
+    key      = "routers.dev/pool"
+    operator = "Equal"
+    value    = "infra"
+    effect   = "NoSchedule"
+  }]
+
+  observability_node_selector = { "routers.dev/pool" = "system" }
+  observability_tolerations = [{
+    key      = "routers.dev/pool"
+    operator = "Equal"
+    value    = "system"
+    effect   = "NoSchedule"
+  }]
+
+  valkey_image = var.valkey_image
+}
+
+module "realtime" {
+  source = "../../../modules/realtime"
+
+  namespace  = var.namespace
+  chart_path = "${path.module}/../../../../chart"
+
+  shards          = local.shards
+  shard_precision = var.shard_precision
+
+  # Both from the sizing model, so the deployed topology and the model that
+  # justified it cannot drift. `streams` is also what the orchestrator creates
+  # its streams with, so it must match ../platform's value exactly.
+  streams    = var.streams
+  fleet_size = module.capacity.fleet.size
+
+  matcher_replicas     = module.capacity.matcher.replicas
+  matcher_replicas_max = module.capacity.matcher.replicas_max
+
+  nats_url    = module.devstack.nats_url
+  valkey_urls = module.devstack.valkey_urls
+  otlp_url    = module.devstack.otlp_url
+
+  profile = module.capacity.profile
+
+  telemetry_sample_ratio = tostring(module.capacity.telemetry.sample_ratio)
+
+  image_registry    = var.image_registry
+  image_tag         = var.image_tag
+  image_pull_policy = var.image_pull_policy
+
+  shard_cache_mode          = "gcsfuse"
+  shard_cache_bucket        = var.shard_bucket
+  service_account_create    = true
+  service_account_name      = var.workload_service_account
+  gcp_service_account_email = var.shard_cache_service_account_email
+
+  matcher_node_selector  = { "routers.dev/pool" = "matcher" }
+  pipeline_node_selector = { "routers.dev/pool" = "pipeline" }
+
+  matcher_tolerations = [{
+    key      = "routers.dev/pool"
+    operator = "Equal"
+    value    = "matcher"
+    effect   = "NoSchedule"
+  }]
+
+  pipeline_tolerations = [{
+    key      = "routers.dev/pool"
+    operator = "Equal"
+    value    = "pipeline"
+    effect   = "NoSchedule"
+  }]
+}
+
+check "capacity_is_deliverable" {
+  assert {
+    condition     = module.capacity.meets_target
+    error_message = "The sizing model does not meet the target:\n${module.capacity.summary}"
+  }
+}
+
+# The one shortfall the current binaries cannot be configured out of. Reported
+# here as well as in the model, because this is the root that deploys the thing
+# doing the publishing.
+check "the_matched_stream_can_absorb_the_emissions" {
+  assert {
+    condition     = module.capacity.streams.matched_sufficient
+    error_message = module.capacity.matched_stream_prerequisite
+  }
+}

--- a/infrastructure/terraform/envs/dev/workloads/main.tf
+++ b/infrastructure/terraform/envs/dev/workloads/main.tf
@@ -40,6 +40,13 @@ module "devstack" {
   jetstream_provisioned_throughput_mib = var.jetstream_provisioned_throughput_mib
   jetstream_provisioned_iops           = var.jetstream_provisioned_iops
 
+  # The infra pool's machine type caps what any volume attached to it can
+  # actually deliver, so provisioning past this would be bought and not
+  # received. c4-standard-16 sustains 100,000 IOPS and 1,600 MiB/s across
+  # every disk on the node, its boot disk included.
+  jetstream_instance_iops_limit           = 100000
+  jetstream_instance_throughput_limit_mib = 1600
+
   valkey_primaries  = module.capacity.valkey.primaries
   valkey_io_threads = module.capacity.valkey.io_threads
 

--- a/infrastructure/terraform/envs/dev/workloads/main.tf
+++ b/infrastructure/terraform/envs/dev/workloads/main.tf
@@ -88,6 +88,7 @@ module "realtime" {
   fleet_size = module.capacity.fleet.size
 
   matcher_replicas     = module.capacity.matcher.replicas
+  matcher_memory_mib   = module.capacity.matcher.memory_mib
   matcher_replicas_max = module.capacity.matcher.replicas_max
 
   nats_url    = module.devstack.nats_url

--- a/infrastructure/terraform/envs/dev/workloads/main.tf
+++ b/infrastructure/terraform/envs/dev/workloads/main.tf
@@ -31,6 +31,15 @@ module "devstack" {
   nats_replicas            = module.capacity.nats.replicas_total
   jetstream_file_store_gib = module.capacity.nats.file_store_gib
 
+  # Capacity and performance are provisioned separately, because they are
+  # separate constraints: the volume is sized for the retention window and
+  # provisioned for the write rate. A class whose speed scales with its size
+  # would tie the two together.
+  jetstream_required_throughput_mib    = module.capacity.jetstream_disk.write_mib_per_server
+  jetstream_required_iops              = module.capacity.jetstream_disk.iops_per_server
+  jetstream_provisioned_throughput_mib = var.jetstream_provisioned_throughput_mib
+  jetstream_provisioned_iops           = var.jetstream_provisioned_iops
+
   valkey_primaries  = module.capacity.valkey.primaries
   valkey_io_threads = module.capacity.valkey.io_threads
 

--- a/infrastructure/terraform/envs/dev/workloads/outputs.tf
+++ b/infrastructure/terraform/envs/dev/workloads/outputs.tf
@@ -1,0 +1,51 @@
+output "capacity_summary" {
+  description = "The sizing report. `tofu output -raw capacity_summary`."
+  value       = module.capacity.summary
+}
+
+output "nats_url" {
+  value = module.devstack.nats_url
+}
+
+output "valkey_urls" {
+  value = module.devstack.valkey_urls
+}
+
+output "releases" {
+  description = "Every Helm release across both modules."
+  value       = concat(module.devstack.release_names, module.realtime.release_names)
+}
+
+output "dependency_totals" {
+  value = module.devstack.totals
+}
+
+output "topology" {
+  description = <<-EOT
+    What was deployed on each axis. The two are independent: matchers divide
+    geography, the fleet divides the vehicle partition space, and only the
+    request subject connects them.
+  EOT
+  value = {
+    shards       = module.realtime.shard_count
+    matcher_pods = module.realtime.expected_pod_count.matchers
+    matcher_max  = module.realtime.expected_pod_count.matchers_max
+    fleet_size   = module.capacity.fleet.size
+    partitions   = module.capacity.fleet.partitions
+    per_pod      = module.capacity.fleet.partitions_per_pod
+    raw_streams  = module.capacity.streams.raw
+    file_store   = "${module.capacity.nats.file_store_gib}Gi per server"
+  }
+}
+
+output "prerequisites" {
+  description = "Non-empty entries are shortfalls the deployment cannot be configured out of. Read them before applying."
+  value = {
+    for name, message in {
+      matched_stream = module.capacity.matched_stream_prerequisite
+      raw_streams    = module.capacity.raw_stream_prerequisite
+      precision      = module.capacity.precision_prerequisite
+      valkey_client  = module.capacity.valkey_client_prerequisite
+    } : name => message if message != ""
+  }
+}

--- a/infrastructure/terraform/envs/dev/workloads/tests/workloads.tftest.hcl
+++ b/infrastructure/terraform/envs/dev/workloads/tests/workloads.tftest.hcl
@@ -1,0 +1,185 @@
+# Wiring test for the workloads root. Mock providers stand in for GCP, Helm and
+# Kubernetes, so this runs with no cluster: it checks that the sizing model
+# reaches the release intact, not that Helm installs anything.
+
+mock_provider "google" {
+  mock_data "google_container_cluster" {
+    defaults = {
+      endpoint = "10.0.0.1"
+      # Every field of the block is required, even the legacy certificate ones
+      # the cluster disables.
+      master_auth = [{
+        cluster_ca_certificate    = "bW9jaw=="
+        client_certificate        = ""
+        client_key                = ""
+        client_certificate_config = []
+      }]
+    }
+  }
+}
+
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+
+variables {
+  project_id                        = "routers-test"
+  image_registry                    = "australia-southeast1-docker.pkg.dev/routers-test/routers"
+  image_tag                         = "sha256-abc123"
+  shard_bucket                      = "routers-test-shards"
+  shard_cache_service_account_email = "dev-shard-cache@routers-test.iam.gserviceaccount.com"
+
+  # The devstack refuses an unpinned Valkey image, because the Bitnami chart
+  # default is a floating tag from a relocated catalogue.
+  valkey_image = {
+    registry   = "australia-southeast1-docker.pkg.dev"
+    repository = "routers-test/routers/valkey"
+    tag        = "8.1.1-debian-12-r0"
+  }
+}
+
+# Every run below deploys the shipped 800k target, which the current binaries
+# cannot fully absorb: `ingest::MATCHED_STREAM` is one stream, so one raft
+# leader carries every emission. `tofu test` treats a failing check as an error
+# (a plan only warns), so the two checks that report it are declared expected.
+#
+# This is deliberately not hidden behind a tolerant condition. When the matched
+# stream is partitioned in `ingest.rs` and `matched_streams` is raised, these
+# expectations start failing — which is the prompt to delete them.
+
+
+# One release, and only one. The orchestrator fleet is a single StatefulSet
+# over the vehicle partition space, so a second release rendering it would hand
+# the same partitions to two owners.
+run "the_whole_deployment_is_one_release" {
+  command = plan
+
+  expect_failures = [
+    check.capacity_is_deliverable,
+    check.the_matched_stream_can_absorb_the_emissions,
+  ]
+
+  assert {
+    condition     = length(module.realtime.release_names) == 1
+    error_message = "Expected exactly one release, got ${join(", ", module.realtime.release_names)}."
+  }
+
+  assert {
+    condition     = module.realtime.shard_count == 6
+    error_message = "Expected 6 shards deployed, got ${module.realtime.shard_count}."
+  }
+}
+
+# The two axes must arrive independently: geography sets the matcher count, the
+# partition space sets the fleet, and neither is derived from the other.
+run "both_axes_reach_the_release" {
+  command = plan
+
+  expect_failures = [
+    check.capacity_is_deliverable,
+    check.the_matched_stream_can_absorb_the_emissions,
+  ]
+
+  assert {
+    condition     = module.realtime.expected_pod_count.orchestrators == module.capacity.fleet.size
+    error_message = "The fleet size must reach the release unchanged: ${module.realtime.expected_pod_count.orchestrators} against ${module.capacity.fleet.size}."
+  }
+
+  assert {
+    condition     = module.realtime.expected_pod_count.matchers == module.realtime.shard_count * module.capacity.matcher.replicas
+    error_message = "Matcher pods must be shards times the modelled replicas."
+  }
+
+  # The fleet must divide the partition space, or the binary's last pod takes
+  # the remainder and owns more vehicles than its peers.
+  assert {
+    condition     = module.capacity.fleet.partitions % module.capacity.fleet.size == 0
+    error_message = "A fleet of ${module.capacity.fleet.size} does not divide ${module.capacity.fleet.partitions} partitions."
+  }
+
+  # Matchers can grow past their floor; the fleet cannot grow at all without
+  # re-slicing ownership.
+  assert {
+    condition     = module.realtime.expected_pod_count.matchers_max > module.realtime.expected_pod_count.matchers
+    error_message = "The matcher HPA needs a ceiling above its floor."
+  }
+}
+
+# A shard is one subject token now. The old scheme split the geohash so a
+# wildcard could address a whole cell, which nothing needs any more: the
+# orchestrator resolves a shard per event and addresses it directly, and raw and
+# matched events are keyed by vehicle partition rather than by geography.
+run "a_shard_is_a_single_subject_token" {
+  command = plan
+
+  expect_failures = [
+    check.capacity_is_deliverable,
+    check.the_matched_stream_can_absorb_the_emissions,
+  ]
+
+  assert {
+    condition     = module.realtime.subjects.match["r3gq"] == "events.match.r3gq"
+    error_message = "Expected events.match.r3gq, got ${module.realtime.subjects.match["r3gq"]}."
+  }
+
+  assert {
+    condition     = module.realtime.subjects.raw == "events.raw.p.<partition>"
+    error_message = "Raw events must be partitioned by vehicle, not by geography."
+  }
+}
+
+# Every primary must reach the workloads, or the fleet the devstack built is
+# larger than the client can address.
+run "the_whole_valkey_fleet_reaches_the_workloads" {
+  command = plan
+
+  expect_failures = [
+    check.capacity_is_deliverable,
+    check.the_matched_stream_can_absorb_the_emissions,
+  ]
+
+  assert {
+    condition     = length(split(",", module.realtime.redis_value)) == module.capacity.valkey.primaries
+    error_message = "REDIS carries ${length(split(",", module.realtime.redis_value))} URLs for ${module.capacity.valkey.primaries} primaries."
+  }
+}
+
+# The file store is sized from the model, and the matched stream dominates it —
+# so a number that looks large is the retention policy, not a mistake.
+run "the_jetstream_file_store_is_sized_from_the_model" {
+  command = plan
+
+  expect_failures = [
+    check.capacity_is_deliverable,
+    check.the_matched_stream_can_absorb_the_emissions,
+  ]
+
+  assert {
+    condition     = module.capacity.nats.file_store_gib >= 1
+    error_message = "The file store must be sized for the retained backlog."
+  }
+
+  assert {
+    condition     = module.capacity.streams.raw == var.streams
+    error_message = "The stream count the orchestrator creates must match the one that was sized."
+  }
+}
+
+# The known shortfall, pinned so it is visible rather than forgotten.
+run "the_outstanding_prerequisite_is_the_matched_stream" {
+  command = plan
+
+  expect_failures = [
+    check.capacity_is_deliverable,
+    check.the_matched_stream_can_absorb_the_emissions,
+  ]
+
+  assert {
+    condition     = length(keys(output.prerequisites)) == 1
+    error_message = "Expected exactly one outstanding prerequisite, got: ${join(", ", keys(output.prerequisites))}."
+  }
+
+  assert {
+    condition     = contains(keys(output.prerequisites), "matched_stream")
+    error_message = "The matched stream shortfall must be reported: ${join(", ", keys(output.prerequisites))}."
+  }
+}

--- a/infrastructure/terraform/envs/dev/workloads/variables.tf
+++ b/infrastructure/terraform/envs/dev/workloads/variables.tf
@@ -1,0 +1,138 @@
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type    = string
+  default = "australia-southeast1"
+}
+
+variable "cluster_name" {
+  description = "Cluster from the ../platform root. Looked up by data source, so that root must be applied first."
+  type        = string
+  default     = "routers"
+}
+
+variable "namespace" {
+  description = "Namespace for the routers workloads."
+  type        = string
+  default     = "routers"
+}
+
+variable "dependency_namespace" {
+  description = "Namespace for NATS, Valkey and observability. Kept apart so a teardown of one does not touch the other."
+  type        = string
+  default     = "routers-dev"
+}
+
+# --- Sizing, matching ../platform -------------------------------------------
+
+variable "shards_file" {
+  type    = string
+  default = "../platform/shards.txt"
+}
+
+variable "shard_precision" {
+  description = "Must match ../platform, the shard file entries, and the precision compiled into the binaries."
+  type        = number
+  default     = 4
+}
+
+variable "coverage_cells" {
+  type    = list(string)
+  default = []
+}
+
+variable "throughput_target_eps" {
+  description = "Must match ../platform, or the node pools were sized for a different fleet from the one this deploys."
+  type        = number
+  default     = 800000
+}
+
+variable "design_target_eps" {
+  description = "Must match ../platform. Only the wire-law quantities are held to it."
+  type        = number
+  default     = 5000000
+}
+
+variable "streams" {
+  description = <<-EOT
+    Raw JetStream streams, and the value the orchestrator creates them with.
+
+    Must match ../platform exactly, and must never change once events exist: a
+    revision is a stream sequence, so remapping partitions to a different stream
+    count resets sequence domains and breaks revision comparison across the
+    boundary.
+  EOT
+  type        = number
+  default     = 64
+}
+
+variable "vertical_profile" {
+  type    = string
+  default = "standard"
+}
+
+variable "machines" {
+  type = map(object({
+    machine_type = string
+    vcpu         = number
+    memory_gib   = number
+  }))
+
+  default = {
+    matcher  = { machine_type = "c4-highcpu-32", vcpu = 32, memory_gib = 64 }
+    pipeline = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
+    infra    = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+    system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+  }
+}
+
+# --- From the ../platform outputs -------------------------------------------
+
+variable "image_registry" {
+  description = "`tofu -chdir=../platform output -raw image_registry`."
+  type        = string
+}
+
+variable "shard_bucket" {
+  description = "`tofu -chdir=../platform output -raw shard_bucket`."
+  type        = string
+}
+
+variable "shard_cache_service_account_email" {
+  description = "`tofu -chdir=../platform output -raw shard_cache_service_account_email`."
+  type        = string
+}
+
+variable "workload_service_account" {
+  description = "Kubernetes service account the workloads run as. Must match the platform module's workload_identity_service_account, or the binding does not apply to these pods."
+  type        = string
+  default     = "routers-matcher"
+}
+
+# --- Images -----------------------------------------------------------------
+
+variable "image_tag" {
+  description = "Pin a digest or an immutable tag, so a rollout is reproducible and a rollback has something to return to."
+  type        = string
+}
+
+variable "image_pull_policy" {
+  type    = string
+  default = "IfNotPresent"
+}
+
+variable "valkey_image" {
+  description = <<-EOT
+    Worth setting. The Bitnami chart defaults to a floating `latest` tag, and
+    Bitnami moved its free public catalogue to `bitnamilegacy/*` during 2025, so
+    the default may not resolve to the image you expect.
+  EOT
+  type = object({
+    registry   = optional(string, "")
+    repository = optional(string, "")
+    tag        = optional(string, "")
+  })
+  default = {}
+}

--- a/infrastructure/terraform/envs/dev/workloads/variables.tf
+++ b/infrastructure/terraform/envs/dev/workloads/variables.tf
@@ -73,7 +73,29 @@ variable "vertical_profile" {
   default = "standard"
 }
 
+# --- JetStream storage ------------------------------------------------------
+
+variable "jetstream_provisioned_throughput_mib" {
+  description = <<-EOT
+    MiB/s provisioned per NATS server's file store volume.
+
+    Set above the model's derived demand, not equal to it: the derived figure
+    is a mean, and ingest is burstier than a mean — a matcher shard recovering
+    from a restart re-drives its backlog as fast as the orchestrators can push
+    it. The devstack fails the plan if this drops below what the model needs.
+  EOT
+  type        = number
+  default     = 750
+}
+
+variable "jetstream_provisioned_iops" {
+  description = "IOPS provisioned per file store volume. Rarely the binding constraint — JetStream appends sequentially, so throughput runs out first."
+  type        = number
+  default     = 30000
+}
+
 variable "machines" {
+  description = "Machine shape per node pool. Must match ../platform, which built the pools from these; this root only recomputes the model to size what it deploys onto them."
   type = map(object({
     machine_type = string
     vcpu         = number
@@ -82,8 +104,8 @@ variable "machines" {
 
   default = {
     matcher  = { machine_type = "c4-highcpu-32", vcpu = 32, memory_gib = 64 }
-    pipeline = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
-    infra    = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+    pipeline = { machine_type = "c4-highcpu-16", vcpu = 16, memory_gib = 32 }
+    infra    = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
     system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
   }
 }

--- a/infrastructure/terraform/envs/dev/workloads/variables.tf
+++ b/infrastructure/terraform/envs/dev/workloads/variables.tf
@@ -105,8 +105,8 @@ variable "machines" {
   default = {
     matcher  = { machine_type = "c4-highcpu-32", vcpu = 32, memory_gib = 64 }
     pipeline = { machine_type = "c4-highcpu-16", vcpu = 16, memory_gib = 32 }
-    infra    = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
-    system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+    infra    = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 60 }
+    system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 30 }
   }
 }
 

--- a/infrastructure/terraform/envs/dev/workloads/versions.tf
+++ b/infrastructure/terraform/envs/dev/workloads/versions.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.50"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.2"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Read back rather than passed in, so the Helm providers configure themselves
+# from the live cluster instead of from another root's state file.
+data "google_container_cluster" "cluster" {
+  project  = var.project_id
+  name     = var.cluster_name
+  location = var.region
+}
+
+data "google_client_config" "default" {}
+
+locals {
+  cluster_host = "https://${data.google_container_cluster.cluster.endpoint}"
+  cluster_ca   = base64decode(data.google_container_cluster.cluster.master_auth[0].cluster_ca_certificate)
+}
+
+provider "kubernetes" {
+  host                   = local.cluster_host
+  cluster_ca_certificate = local.cluster_ca
+  token                  = data.google_client_config.default.access_token
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = local.cluster_host
+    cluster_ca_certificate = local.cluster_ca
+    token                  = data.google_client_config.default.access_token
+  }
+}

--- a/infrastructure/terraform/modules/capacity/cost.tf
+++ b/infrastructure/terraform/modules/capacity/cost.tf
@@ -70,20 +70,33 @@ locals {
   # pool's CPU demand. Three of the four pools carry a single service and the
   # attribution is exact; only `infra` splits, between the brokers and the
   # keyspace.
-  service_pools = {
-    matcher      = "matcher"
-    orchestrator = "pipeline"
-    nats         = "infra"
-    valkey       = "infra"
-    telemetry    = "system"
-  }
+  service_pools = (
+    var.pool_layout == "dedicated"
+    ? {
+      matcher      = "matcher"
+      orchestrator = "pipeline"
+      nats         = "infra"
+      valkey       = "infra"
+      telemetry    = "system"
+    }
+    : {
+      matcher      = "shared"
+      orchestrator = "shared"
+      nats         = "shared"
+      valkey       = "shared"
+      telemetry    = "shared"
+    }
+  )
 
   service_cpu_millis = {
     matcher      = local.matcher_pods * local.profile.matcher_cpu_millis
     orchestrator = local.fleet * local.profile.orchestrator_cpu_millis
     nats         = local.nats_replicas_total * var.nats_cpu_millis
     valkey       = local.valkey_pods_total * var.valkey_cpu_millis
-    telemetry    = local.demand["system"].cpu_millis
+    telemetry = (
+      local.collector_replicas * var.collector_cpu_millis
+      + (var.observability_enabled ? 4000 : 0)
+    )
   }
 
   service_monthly = {

--- a/infrastructure/terraform/modules/capacity/cost.tf
+++ b/infrastructure/terraform/modules/capacity/cost.tf
@@ -1,0 +1,111 @@
+# What the sized fleet costs per month.
+#
+# Kept in the model rather than in a spreadsheet for the same reason the node
+# counts are: it is derived from the same pod shapes, so it cannot describe a
+# fleet other than the one that would be built. Change the target and the cost
+# moves with it.
+#
+# Every rate is an input, not a constant — see `prices`, which carries the
+# region and the date they were read. Prices go stale; arithmetic does not.
+#
+# Deliberately not modelled: network egress, Cloud Logging ingestion, the
+# shard bucket (a few GiB of objects), and Artifact Registry storage. Each is
+# small against a fleet this size, and egress in particular is a traffic
+# question rather than a capacity one.
+
+locals {
+  hours_per_month = 730
+
+  # Cost is quoted at the autoscaler floor, which is the steady state. The
+  # matcher pool's ceiling is reported separately: it is the HPA's, and a
+  # burst pays for itself only while it lasts.
+  pool_monthly = {
+    for pool, nodes in local.node_counts :
+    pool => nodes * var.prices.machines[var.machines[pool].machine_type][var.pricing_commitment]
+  }
+
+  pool_monthly_max = {
+    for pool, nodes in local.node_counts_max :
+    pool => nodes * var.prices.machines[var.machines[pool].machine_type][var.pricing_commitment]
+  }
+
+  compute_monthly     = sum(values(local.pool_monthly))
+  compute_monthly_max = sum(values(local.pool_monthly_max))
+
+  # --- Storage ------------------------------------------------------------
+
+  # Every node carries a boot disk, and on a Hyperdisk-only series that disk
+  # is Hyperdisk Balanced at the class baseline — no provisioned performance,
+  # so capacity only.
+  boot_disk_monthly = local.total_nodes * var.boot_disk_gib * var.prices.hyperdisk_balanced_gib
+
+  # The file store, one volume per NATS server. Baseline IOPS and throughput
+  # come with the volume, so only the excess is billable — which is most of
+  # it here, because the brokers need far more than a baseline volume gives.
+  jetstream_capacity_monthly = (
+    local.nats_replicas_total * local.file_store_gib_server * var.prices.hyperdisk_balanced_gib
+  )
+
+  jetstream_iops_billable = max(0, var.provisioned_iops - var.prices.hyperdisk_free_iops)
+  jetstream_mib_billable  = max(0, var.provisioned_throughput_mib - var.prices.hyperdisk_free_mib)
+
+  jetstream_performance_monthly = local.nats_replicas_total * (
+    local.jetstream_iops_billable * var.prices.hyperdisk_iops
+    + local.jetstream_mib_billable * var.prices.hyperdisk_mib
+  )
+
+  jetstream_monthly = local.jetstream_capacity_monthly + local.jetstream_performance_monthly
+  storage_monthly   = local.boot_disk_monthly + local.jetstream_monthly
+
+  # --- Cluster ------------------------------------------------------------
+
+  cluster_monthly = var.prices.gke_cluster_hour * local.hours_per_month
+
+  total_monthly     = local.compute_monthly + local.storage_monthly + local.cluster_monthly
+  total_monthly_max = local.compute_monthly_max + local.storage_monthly + local.cluster_monthly
+
+  # --- Per service --------------------------------------------------------
+
+  # A pool's nodes are bought whole, so a service's share is its share of the
+  # pool's CPU demand. Three of the four pools carry a single service and the
+  # attribution is exact; only `infra` splits, between the brokers and the
+  # keyspace.
+  service_pools = {
+    matcher      = "matcher"
+    orchestrator = "pipeline"
+    nats         = "infra"
+    valkey       = "infra"
+    telemetry    = "system"
+  }
+
+  service_cpu_millis = {
+    matcher      = local.matcher_pods * local.profile.matcher_cpu_millis
+    orchestrator = local.fleet * local.profile.orchestrator_cpu_millis
+    nats         = local.nats_replicas_total * var.nats_cpu_millis
+    valkey       = local.valkey_pods_total * var.valkey_cpu_millis
+    telemetry    = local.demand["system"].cpu_millis
+  }
+
+  service_monthly = {
+    for service, pool in local.service_pools :
+    service => (
+      local.pool_monthly[pool]
+      * local.service_cpu_millis[service]
+      / local.demand[pool].cpu_millis
+    )
+  }
+
+  # The storage a service is responsible for, as opposed to the nodes it runs
+  # on. Only the brokers hold a volume of their own.
+  service_storage_monthly = {
+    matcher      = 0
+    orchestrator = 0
+    nats         = local.jetstream_monthly
+    valkey       = 0
+    telemetry    = 0
+  }
+
+  cost_per_million_events = (
+    local.total_monthly / (var.throughput_target_eps * 3600 * local.hours_per_month / 1000000)
+  )
+}

--- a/infrastructure/terraform/modules/capacity/main.tf
+++ b/infrastructure/terraform/modules/capacity/main.tf
@@ -152,6 +152,39 @@ locals {
   file_store_bytes_server = ceil(local.jetstream_disk_bytes / local.nats_replicas_total)
   file_store_gib_server   = max(1, ceil(local.file_store_bytes_server / 1073741824))
 
+  # What the file store has to sustain, as opposed to how much it has to hold.
+  # These are different constraints and only one of them is capacity: a volume
+  # sized for the retention window can still be far too slow for the write
+  # rate, which is why the storage class provisions performance explicitly
+  # rather than inheriting it from the size.
+  #
+  # The matched stream dominates the bytes. An emission carries the entire cut
+  # trip rather than a delta — the property that lets competing solves resolve
+  # by revision — so it costs an order of magnitude more per message than the
+  # raw event that produced it.
+  jetstream_write_bytes_rate = (
+    (local.required_eps * var.raw_event_bytes + local.required_eps * var.matched_event_bytes)
+    * var.jetstream_stream_replicas
+  )
+
+  jetstream_write_mib_server = ceil(
+    local.jetstream_write_bytes_rate / local.nats_replicas_total / 1048576
+  )
+
+  # JetStream appends and fsyncs in batches rather than once per message, so
+  # the operation count is well under the message rate. The divisor is the
+  # softest number here.
+  jetstream_iops_server = ceil(
+    (local.required_eps * 2 * var.jetstream_stream_replicas)
+    / local.nats_replicas_total / var.jetstream_messages_per_write
+  )
+
+  # Fault tolerance is a property of how the servers are spread, not of how
+  # many there are. A node may hold at most half the cluster short of one, or
+  # losing it costs quorum — so the pool needs at least this many nodes for the
+  # hard spread constraint to be satisfiable.
+  nats_spread_nodes = ceil(local.nats_replicas_total / 2)
+
   # --- Valkey -------------------------------------------------------------
 
   # One fleet, hashed by vehicle, sized from the total command rate because
@@ -341,17 +374,26 @@ locals {
   # Shapes are summed rather than bin-packed together, so a mixed pool carries
   # slack. That is the conservative direction, and the pools that dominate the
   # fleet hold one shape each.
-  node_counts = {
+  node_counts_packed = {
     for pool, shapes in local.packing : pool => max(1, sum([
       for s in shapes : s.per_node < 1 ? s.count : ceil(s.count / s.per_node)
     ]))
   }
 
-  node_counts_max = {
+  # Packing alone would happily put every NATS server on one large node, which
+  # is efficient and destroys the cluster's fault tolerance. The infra pool
+  # therefore has a floor independent of how well its pods pack.
+  node_counts = merge(local.node_counts_packed, {
+    infra = max(local.node_counts_packed["infra"], local.nats_spread_nodes)
+  })
+
+  node_counts_max = merge({
     for pool, shapes in local.packing : pool => max(1, sum([
       for s in shapes : s.per_node < 1 ? s.count_max : ceil(s.count_max / s.per_node)
     ]))
-  }
+    }, {
+    infra = max(local.node_counts_packed["infra"], local.nats_spread_nodes)
+  })
 
   demand = {
     for pool, shapes in local.shapes : pool => {

--- a/infrastructure/terraform/modules/capacity/main.tf
+++ b/infrastructure/terraform/modules/capacity/main.tf
@@ -88,7 +88,33 @@ locals {
     d if d <= var.partitions && var.partitions % d == 0
   ]
 
-  fleet_required = max(1, ceil(local.required_eps / local.profile.orchestrator_eps))
+  # Two independent ceilings on one pod, because the orchestrator is mostly an
+  # I/O scheduler rather than a compute service. Whichever is lower is the
+  # pod's rate, and which one it is decides how to fix a shortfall: raising
+  # concurrency is a config change, raising compute is a bill.
+  orchestrator_io_eps = floor(
+    local.profile.orchestrator_workers * 1000 / local.profile.orchestrator_round_trip_ms
+  )
+
+  # A millicore-second is 1000 CPU-microseconds, so a pod's budget in events is
+  # its request over the per-event cost.
+  orchestrator_cpu_eps = floor(
+    local.profile.orchestrator_cpu_millis * 1000 / local.profile.orchestrator_cpu_micros_per_event
+  )
+
+  orchestrator_eps   = min(local.orchestrator_io_eps, local.orchestrator_cpu_eps)
+  orchestrator_bound = local.orchestrator_io_eps <= local.orchestrator_cpu_eps ? "concurrency" : "compute"
+
+  # Cores bought and unreachable because the pod cannot hold enough work in
+  # flight to use them. This is the waste a single fused `orchestrator_eps`
+  # made invisible.
+  orchestrator_stranded_cpu_millis = (
+    local.orchestrator_bound == "concurrency"
+    ? local.profile.orchestrator_cpu_millis * (1 - local.orchestrator_io_eps / local.orchestrator_cpu_eps)
+    : 0
+  )
+
+  fleet_required = max(1, ceil(local.required_eps / local.orchestrator_eps))
   fleet_eligible = [for d in local.fleet_divisors : d if d >= local.fleet_required]
 
   # No eligible divisor means the target needs more pods than there are
@@ -97,7 +123,7 @@ locals {
   fleet = length(local.fleet_eligible) > 0 ? local.fleet_eligible[0] : var.partitions
 
   partitions_per_pod        = var.partitions / local.fleet
-  orchestrator_capacity_eps = local.fleet * local.profile.orchestrator_eps
+  orchestrator_capacity_eps = local.fleet * local.orchestrator_eps
 
   # One pod per partition is the hard ceiling: a partition is the smallest
   # thing an owner can hold, so past this the answer is a fatter profile.
@@ -248,8 +274,8 @@ locals {
     streams_required  = ceil(local.design_required_eps / var.jetstream_writes_per_stream)
     streams_ok        = (local.design_required_eps / var.streams) <= var.jetstream_writes_per_stream
 
-    fleet_required   = ceil(local.design_required_eps / local.profile.orchestrator_eps)
-    fleet_fits       = ceil(local.design_required_eps / local.profile.orchestrator_eps) <= var.partitions
+    fleet_required   = ceil(local.design_required_eps / local.orchestrator_eps)
+    fleet_fits       = ceil(local.design_required_eps / local.orchestrator_eps) <= var.partitions
     matcher_pods     = local.shard_count * max(1, ceil((local.design_required_eps / local.shard_count) / local.profile.matcher_eps))
     valkey_primaries = max(1, ceil((local.design_required_eps * var.valkey_ops_per_event) / var.valkey_ops_per_primary))
 

--- a/infrastructure/terraform/modules/capacity/main.tf
+++ b/infrastructure/terraform/modules/capacity/main.tf
@@ -38,6 +38,23 @@ locals {
 
   # --- Matchers -----------------------------------------------------------
 
+  # A matcher's memory is a property of its geography, not of its vertical
+  # profile: the profile decides how fast a pod solves, the shard decides how
+  # much graph it has to hold. Measured rather than assumed — `r1` is 413 MiB
+  # on disk and 3.31 GB resident, so the file understates the pod by 7.6x.
+  #
+  # Sized for the largest shard because the chart gives every matcher
+  # Deployment one limit, and a pod that cannot load its graph does not
+  # degrade, it is OOM-killed at startup and never serves a request.
+  matcher_graph_mib  = ceil(var.largest_shard_file_mib * var.shard_memory_expansion)
+  matcher_memory_mib = local.matcher_graph_mib + var.matcher_working_set_mib
+
+  # Every replica of a shard loads that shard's whole graph, so the fleet's
+  # memory is the pod count times the graph — which is why coarse geography is
+  # expensive. Pod count is fixed by throughput, so a bigger shard cannot be
+  # offset by having fewer of them.
+  matcher_graph_mib_total = local.matcher_pods * local.matcher_graph_mib
+
   # The mean is all this model can compute; `hot_shard_replica_factor` is what
   # covers the difference between it and a geographic distribution.
   mean_shard_eps = local.required_eps / local.shard_count
@@ -333,7 +350,7 @@ locals {
       count_max  = local.shard_count * local.matcher_replicas_max
       pods       = 1
       cpu_millis = local.profile.matcher_cpu_millis
-      memory_mib = local.profile.matcher_memory_mib
+      memory_mib = local.matcher_memory_mib
     }]
 
     # One shape now: the historian this pipeline absorbed is gone, and the

--- a/infrastructure/terraform/modules/capacity/main.tf
+++ b/infrastructure/terraform/modules/capacity/main.tf
@@ -350,7 +350,7 @@ locals {
   # is what the pool must be able to grow to, which sets the ceiling — for
   # matchers that is the HPA's, so a hot shard finds nodes rather than leaving
   # replicas Pending, without paying for them while traffic is even.
-  shapes = {
+  shapes_dedicated = {
     matcher = [{
       name       = "matcher"
       count      = local.matcher_pods
@@ -392,27 +392,35 @@ locals {
       },
     ]
 
-    system = [
-      {
+    system = concat(
+      [{
         name       = "otel-collector"
         count      = local.collector_replicas
         count_max  = local.collector_replicas
         pods       = 1
         cpu_millis = var.collector_cpu_millis
         memory_mib = var.collector_memory_mib
-      },
-      {
-        # prometheus, grafana, alertmanager, the operator, kube-state-metrics
-        # and the dashboard sidecars, as one lumped allowance.
+      }],
+      # prometheus, grafana, alertmanager, the operator, kube-state-metrics
+      # and the dashboard sidecars, as one lumped allowance.
+      var.observability_enabled ? [{
         name       = "observability"
         count      = 1
         count_max  = 1
         pods       = 6
         cpu_millis = 4000
         memory_mib = 16384
-      },
-    ]
+      }] : [],
+    )
   }
+
+  # Under `shared` every shape lands in one pool, so the per-shape node floor
+  # collapses from one each to one overall.
+  shapes = (
+    var.pool_layout == "dedicated"
+    ? local.shapes_dedicated
+    : { shared = flatten(values(local.shapes_dedicated)) }
+  )
 
   # How many of each shape fit one node, bounded by whichever of CPU, memory or
   # the pod budget binds first.
@@ -439,25 +447,54 @@ locals {
   # Shapes are summed rather than bin-packed together, so a mixed pool carries
   # slack. That is the conservative direction, and the pools that dominate the
   # fleet hold one shape each.
+  # Per shape, rounded up: a pool holding several shapes carries the slack of
+  # each, which is the conservative direction and barely matters when a pool
+  # holds one shape and thousands of pods.
+  #
+  # It matters enormously when a pool holds six shapes and seven pods, so the
+  # shared layout costs them together instead: total demand over one node's
+  # capacity, whichever of CPU, memory or the pod budget binds. That is a lower
+  # bound rather than a packing — fragmentation can still cost a node — but at
+  # this size the per-shape rounding is the whole answer, and summing it would
+  # report six nodes for a deployment that fits on one.
   node_counts_packed = {
-    for pool, shapes in local.packing : pool => max(1, sum([
-      for s in shapes : s.per_node < 1 ? s.count : ceil(s.count / s.per_node)
-    ]))
+    for pool, shapes in local.packing : pool => (
+      var.pool_layout == "shared"
+      ? max(1,
+        ceil(sum([for s in shapes : s.count * s.cpu_millis]) / local.allocatable[pool].cpu_millis),
+        ceil(sum([for s in shapes : s.count * s.memory_mib]) / local.allocatable[pool].memory_mib),
+        ceil(sum([for s in shapes : s.count * s.pods]) / local.allocatable[pool].pods),
+      )
+      : max(1, sum([
+        for s in shapes : s.per_node < 1 ? s.count : ceil(s.count / s.per_node)
+      ]))
+    )
   }
 
   # Packing alone would happily put every NATS server on one large node, which
-  # is efficient and destroys the cluster's fault tolerance. The infra pool
-  # therefore has a floor independent of how well its pods pack.
+  # is efficient and destroys the cluster's fault tolerance. The pool holding
+  # the brokers therefore has a floor independent of how well its pods pack.
+  broker_pool  = var.pool_layout == "dedicated" ? "infra" : "shared"
+  matcher_pool = var.pool_layout == "dedicated" ? "matcher" : "shared"
+
   node_counts = merge(local.node_counts_packed, {
-    infra = max(local.node_counts_packed["infra"], local.nats_spread_nodes)
+    (local.broker_pool) = max(local.node_counts_packed[local.broker_pool], local.nats_spread_nodes)
   })
 
   node_counts_max = merge({
-    for pool, shapes in local.packing : pool => max(1, sum([
-      for s in shapes : s.per_node < 1 ? s.count_max : ceil(s.count_max / s.per_node)
-    ]))
+    for pool, shapes in local.packing : pool => (
+      var.pool_layout == "shared"
+      ? max(1,
+        ceil(sum([for s in shapes : s.count_max * s.cpu_millis]) / local.allocatable[pool].cpu_millis),
+        ceil(sum([for s in shapes : s.count_max * s.memory_mib]) / local.allocatable[pool].memory_mib),
+        ceil(sum([for s in shapes : s.count_max * s.pods]) / local.allocatable[pool].pods),
+      )
+      : max(1, sum([
+        for s in shapes : s.per_node < 1 ? s.count_max : ceil(s.count_max / s.per_node)
+      ]))
+    )
     }, {
-    infra = max(local.node_counts_packed["infra"], local.nats_spread_nodes)
+    (local.broker_pool) = max(local.node_counts_packed[local.broker_pool], local.nats_spread_nodes)
   })
 
   demand = {

--- a/infrastructure/terraform/modules/capacity/main.tf
+++ b/infrastructure/terraform/modules/capacity/main.tf
@@ -1,0 +1,388 @@
+# The sizing model. Pure arithmetic, no resources, so it plans without
+# credentials and `tofu test` exercises it directly.
+#
+# The pipeline scales along two independent axes, because its two services
+# partition on different things:
+#
+#   matchers       geographic. One Deployment per shard, replicas behind a
+#                  NATS queue group, so replica count divides a shard's load
+#                  rather than duplicating it. Levers: shard_precision
+#                  (horizontal) and replicas per shard (also horizontal).
+#
+#   orchestrators  vehicle-partitioned. One StatefulSet whose pods take
+#                  disjoint ordinal slices of `partitions`, which is wire law.
+#                  Lever: fleet size, bounded by the partition count.
+#
+# Neither axis constrains the other: a matcher is a pure request/reply solver
+# that holds nothing between requests, and an orchestrator owns vehicles
+# wherever they drive. What couples them is one line of routing —
+# `events.match.<shard_of(point)>` — and `binary_shard_precision` is how this
+# model checks the two agree on it.
+#
+# Two quantities are wire law and cannot be tuned after events exist:
+# `partitions`, because producers hash into it, and `streams`, because a
+# revision is a stream sequence. Both are checked against the design target
+# rather than the current one, since exceeding them later costs a migration.
+
+locals {
+  profile      = var.profiles[var.vertical_profile]
+  shard_count  = length(var.shards)
+  required_eps = var.throughput_target_eps * (1 + var.headroom_ratio)
+
+  # Shards outside the declared service region. A shard list generated over
+  # the wrong extent otherwise becomes a fleet of idle matchers.
+  out_of_coverage = length(var.coverage_cells) == 0 ? [] : [
+    for s in var.shards : s
+    if !anytrue([for c in var.coverage_cells : startswith(s, c)])
+  ]
+
+  # --- Matchers -----------------------------------------------------------
+
+  # The mean is all this model can compute; `hot_shard_replica_factor` is what
+  # covers the difference between it and a geographic distribution.
+  mean_shard_eps = local.required_eps / local.shard_count
+
+  matcher_replicas_per_shard = max(1, ceil(local.mean_shard_eps / local.profile.matcher_eps))
+  matcher_replicas_max       = ceil(local.matcher_replicas_per_shard * var.hot_shard_replica_factor)
+
+  matcher_pods         = local.shard_count * local.matcher_replicas_per_shard
+  matcher_capacity_eps = local.matcher_pods * local.profile.matcher_eps
+
+  # Replicas are the first lever and shards the second, so a shard deficit is
+  # not "too few shards to carry the load" — replicas carry it — but "one
+  # shard now needs more replicas than a single queue group should hold".
+  shards_required = ceil(
+    local.required_eps / (local.profile.matcher_eps * var.max_matcher_replicas_per_shard)
+  )
+  shard_deficit = max(0, local.shards_required - local.shard_count)
+
+  precision_levels_needed = local.shard_deficit == 0 ? 0 : ceil(
+    log(local.shards_required / local.shard_count, var.shard_fanout_per_precision)
+  )
+  recommended_precision = min(12, var.shard_precision + local.precision_levels_needed)
+
+  # --- Orchestrator fleet -------------------------------------------------
+
+  # Pods take contiguous ordinal blocks of the partition space, the last one
+  # absorbing the remainder, so a fleet that does not divide `partitions`
+  # leaves one pod carrying more than the rest. Snapping to a divisor keeps
+  # every slice equal — and every divisor of a power-of-two partition count is
+  # itself a power of two.
+  fleet_divisors = [
+    for d in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] :
+    d if d <= var.partitions && var.partitions % d == 0
+  ]
+
+  fleet_required = max(1, ceil(local.required_eps / local.profile.orchestrator_eps))
+  fleet_eligible = [for d in local.fleet_divisors : d if d >= local.fleet_required]
+
+  # No eligible divisor means the target needs more pods than there are
+  # partitions to divide. Pinned at the ceiling so the rest of the model stays
+  # arithmetically sound; `fleet_fits_the_partition_space` reports it.
+  fleet = length(local.fleet_eligible) > 0 ? local.fleet_eligible[0] : var.partitions
+
+  partitions_per_pod        = var.partitions / local.fleet
+  orchestrator_capacity_eps = local.fleet * local.profile.orchestrator_eps
+
+  # One pod per partition is the hard ceiling: a partition is the smallest
+  # thing an owner can hold, so past this the answer is a fatter profile.
+  fleet_fits_the_partition_space = local.fleet_required <= var.partitions
+
+  # --- JetStream ----------------------------------------------------------
+
+  # Per stream, because a stream has one raft leader and that leader is where
+  # its writes serialise. This is the constraint the stream count exists to
+  # divide, and the one that cannot be relieved later without a migration.
+  raw_writes_per_stream = local.required_eps / var.streams
+  raw_streams_required  = ceil(local.required_eps / var.jetstream_writes_per_stream)
+  raw_streams_ok        = local.raw_writes_per_stream <= var.jetstream_writes_per_stream
+
+  # Emissions carry the whole cut trip, so this stream's byte rate is a
+  # multiple of the raw one even though its message rate matches.
+  matched_writes_per_stream = local.required_eps / var.matched_streams
+  matched_streams_required  = ceil(local.required_eps / var.jetstream_writes_per_stream)
+  matched_streams_ok        = local.matched_writes_per_stream <= var.jetstream_writes_per_stream
+
+  # One durable pull consumer per partition, each filtering one subject. The
+  # count per stream is worth watching independently of throughput: consumer
+  # state is raft state, and it is held by the stream's leader.
+  partitions_per_stream = ceil(var.partitions / var.streams)
+
+  # A work queue deletes on ack, so this is the abnormal case: how much disk
+  # an outage's worth of unacked events needs.
+  raw_disk_bytes = (
+    local.required_eps * var.raw_event_bytes
+    * var.raw_backlog_seconds * var.jetstream_stream_replicas
+  )
+
+  matched_disk_bytes = (
+    local.required_eps * var.matched_event_bytes
+    * var.matched_retention_seconds * var.jetstream_stream_replicas
+  )
+
+  jetstream_disk_bytes = local.raw_disk_bytes + local.matched_disk_bytes
+
+  # --- NATS ---------------------------------------------------------------
+
+  # Deliveries that never touch a stream: the solve request and its reply.
+  core_delivery_rate = local.required_eps * var.nats_core_hops
+
+  # Raw ingest plus the matched emission, amplified by stream replication.
+  jetstream_write_rate = local.required_eps * 2 * var.jetstream_stream_replicas
+
+  nats_replicas_floor = max(
+    var.nats_min_replicas,
+    ceil(local.core_delivery_rate / var.nats_msgs_per_server),
+    ceil(local.jetstream_write_rate / var.jetstream_writes_per_server),
+  )
+
+  # Rounded up to odd. JetStream elects a leader per stream, and an even
+  # membership gains no fault tolerance over the odd one below it while adding
+  # a vote to every quorum.
+  nats_replicas_total = (
+    local.nats_replicas_floor % 2 == 0
+    ? local.nats_replicas_floor + 1
+    : local.nats_replicas_floor
+  )
+
+  # Stream leaders spread across the cluster, so a server holds roughly this
+  # share of the total data. Sized per server because the file store is a PVC
+  # per pod.
+  stream_leaders_total    = var.streams + var.matched_streams
+  file_store_bytes_server = ceil(local.jetstream_disk_bytes / local.nats_replicas_total)
+  file_store_gib_server   = max(1, ceil(local.file_store_bytes_server / 1073741824))
+
+  # --- Valkey -------------------------------------------------------------
+
+  # One fleet, hashed by vehicle, sized from the total command rate because
+  # every primary is interchangeable. Deliberately off the geohash hierarchy:
+  # the keyspace is `vehicle:<id>:positions`, and partitioning it
+  # geographically would break the trip continuity it exists to provide.
+  valkey_ops_rate        = local.required_eps * var.valkey_ops_per_event
+  valkey_primaries_total = max(1, ceil(local.valkey_ops_rate / var.valkey_ops_per_primary))
+  valkey_pods_total      = local.valkey_primaries_total * (1 + var.valkey_replicas_per_primary)
+
+  single_valkey_ceiling_eps = var.valkey_ops_per_primary / var.valkey_ops_per_event
+
+  valkey_client_is_sufficient = (
+    var.valkey_client_mode == "pooled-hash" || local.valkey_primaries_total == 1
+  )
+
+  # --- Telemetry ----------------------------------------------------------
+
+  span_rate          = local.required_eps * var.spans_per_event * var.telemetry_sample_ratio
+  collector_replicas = max(1, ceil(local.span_rate / var.collector_spans_per_replica))
+
+  # --- Verdict ------------------------------------------------------------
+
+  meets_target = (
+    local.matcher_capacity_eps >= local.required_eps
+    && local.orchestrator_capacity_eps >= local.required_eps
+    && local.fleet_fits_the_partition_space
+    && local.raw_streams_ok
+    && local.matched_streams_ok
+    && local.valkey_client_is_sufficient
+    && var.shard_precision == var.binary_shard_precision
+  )
+
+  # --- The design target --------------------------------------------------
+
+  # What the wire-law quantities would have to survive at the endpoint, not at
+  # today's load. `streams` and `partitions` are pinned for the life of the
+  # deployment, so they are the only numbers that must be right now: every
+  # other line here is a variable change away.
+  design_required_eps = var.design_target_eps * (1 + var.headroom_ratio)
+
+  design = {
+    target_eps        = var.design_target_eps
+    required_eps      = local.design_required_eps
+    writes_per_stream = local.design_required_eps / var.streams
+    streams_required  = ceil(local.design_required_eps / var.jetstream_writes_per_stream)
+    streams_ok        = (local.design_required_eps / var.streams) <= var.jetstream_writes_per_stream
+
+    fleet_required   = ceil(local.design_required_eps / local.profile.orchestrator_eps)
+    fleet_fits       = ceil(local.design_required_eps / local.profile.orchestrator_eps) <= var.partitions
+    matcher_pods     = local.shard_count * max(1, ceil((local.design_required_eps / local.shard_count) / local.profile.matcher_eps))
+    valkey_primaries = max(1, ceil((local.design_required_eps * var.valkey_ops_per_event) / var.valkey_ops_per_primary))
+
+    matched_streams_required = ceil(local.design_required_eps / var.jetstream_writes_per_stream)
+  }
+
+  # --- Node packing -------------------------------------------------------
+
+  # GKE reserves CPU and memory on published sliding scales, both large enough
+  # at these node sizes that ignoring them over-commits every pool.
+  allocatable = {
+    for name, m in var.machines : name => {
+      machine_type = m.machine_type
+      vcpu         = m.vcpu
+      memory_gib   = m.memory_gib
+
+      # 6% of core 1, 1% of core 2, 0.5% of cores 3-4, 0.25% of the rest.
+      cpu_millis = floor(
+        (m.vcpu * 1000)
+        -(60
+          + 10 * min(1, max(0, m.vcpu - 1))
+          + 5 * min(2, max(0, m.vcpu - 2))
+        + 2.5 * max(0, m.vcpu - 4))
+        -var.daemonset_cpu_millis
+      )
+
+      # 25% of the first 4GiB, 20% of the next 4, 10% of the next 8, 6% of the
+      # next 112, 2% beyond, plus the 100MiB eviction threshold.
+      memory_mib = floor(
+        (m.memory_gib * 1024)
+        -(min(4, m.memory_gib) * 1024 * 0.25
+          + min(4, max(0, m.memory_gib - 4)) * 1024 * 0.20
+          + min(8, max(0, m.memory_gib - 8)) * 1024 * 0.10
+          + min(112, max(0, m.memory_gib - 16)) * 1024 * 0.06
+          + max(0, m.memory_gib - 128) * 1024 * 0.02
+        + 100)
+        -var.daemonset_memory_mib
+      )
+
+      pods = var.max_pods_per_node - var.daemonset_pods_per_node
+    }
+  }
+
+  # Pools are sized from pod *shapes*, not aggregate demand. Aggregate CPU over
+  # node CPU permits fractional pods: a 2000m pod on a 31250m node fits 15
+  # times, not 15.6, so 1042 of them need 70 nodes and not 67.
+  # `count` is the steady state, which sets the autoscaler floor. `count_max`
+  # is what the pool must be able to grow to, which sets the ceiling — for
+  # matchers that is the HPA's, so a hot shard finds nodes rather than leaving
+  # replicas Pending, without paying for them while traffic is even.
+  shapes = {
+    matcher = [{
+      name       = "matcher"
+      count      = local.matcher_pods
+      count_max  = local.shard_count * local.matcher_replicas_max
+      pods       = 1
+      cpu_millis = local.profile.matcher_cpu_millis
+      memory_mib = local.profile.matcher_memory_mib
+    }]
+
+    # One shape now: the historian this pipeline absorbed is gone, and the
+    # orchestrator fleet is the only thing here. It has no autoscaler — the
+    # fleet size is wire-adjacent, since resizing re-slices the partition
+    # space — so its floor and ceiling are the same.
+    pipeline = [{
+      name       = "orchestrator"
+      count      = local.fleet
+      count_max  = local.fleet
+      pods       = 1
+      cpu_millis = local.profile.orchestrator_cpu_millis
+      memory_mib = local.profile.orchestrator_memory_mib
+    }]
+
+    infra = [
+      {
+        name       = "nats"
+        count      = local.nats_replicas_total
+        count_max  = local.nats_replicas_total
+        pods       = 1
+        cpu_millis = var.nats_cpu_millis
+        memory_mib = var.nats_memory_mib
+      },
+      {
+        name       = "valkey"
+        count      = local.valkey_pods_total
+        count_max  = local.valkey_pods_total
+        pods       = 1
+        cpu_millis = var.valkey_cpu_millis
+        memory_mib = var.valkey_memory_mib
+      },
+    ]
+
+    system = [
+      {
+        name       = "otel-collector"
+        count      = local.collector_replicas
+        count_max  = local.collector_replicas
+        pods       = 1
+        cpu_millis = var.collector_cpu_millis
+        memory_mib = var.collector_memory_mib
+      },
+      {
+        # prometheus, grafana, alertmanager, the operator, kube-state-metrics
+        # and the dashboard sidecars, as one lumped allowance.
+        name       = "observability"
+        count      = 1
+        count_max  = 1
+        pods       = 6
+        cpu_millis = 4000
+        memory_mib = 16384
+      },
+    ]
+  }
+
+  # How many of each shape fit one node, bounded by whichever of CPU, memory or
+  # the pod budget binds first.
+  packing = {
+    for pool, shapes in local.shapes : pool => [
+      for s in shapes : merge(s, {
+        per_node = min(
+          floor(local.allocatable[pool].cpu_millis / s.cpu_millis),
+          floor(local.allocatable[pool].memory_mib / s.memory_mib),
+          floor(local.allocatable[pool].pods / s.pods),
+        )
+      })
+    ]
+  }
+
+  # A shape that fits zero times per node stays Pending forever while the
+  # autoscaler adds nodes that cannot host it.
+  unschedulable_shapes = flatten([
+    for pool, shapes in local.packing : [
+      for s in shapes : "${pool}/${s.name}" if s.count > 0 && s.per_node < 1
+    ]
+  ])
+
+  # Shapes are summed rather than bin-packed together, so a mixed pool carries
+  # slack. That is the conservative direction, and the pools that dominate the
+  # fleet hold one shape each.
+  node_counts = {
+    for pool, shapes in local.packing : pool => max(1, sum([
+      for s in shapes : s.per_node < 1 ? s.count : ceil(s.count / s.per_node)
+    ]))
+  }
+
+  node_counts_max = {
+    for pool, shapes in local.packing : pool => max(1, sum([
+      for s in shapes : s.per_node < 1 ? s.count_max : ceil(s.count_max / s.per_node)
+    ]))
+  }
+
+  demand = {
+    for pool, shapes in local.shapes : pool => {
+      pods       = sum([for s in shapes : s.count * s.pods])
+      cpu_millis = sum([for s in shapes : s.count * s.cpu_millis])
+      memory_mib = sum([for s in shapes : s.count * s.memory_mib])
+    }
+  }
+
+  # The ceiling leaves room for whatever autoscaling the pool's workloads do,
+  # for the headroom burst, and for rollout surge — where a replacement pod
+  # schedules before the old one goes.
+  pools = {
+    for pool, nodes in local.node_counts : pool => {
+      machine_type    = local.allocatable[pool].machine_type
+      node_count      = nodes
+      min_node_count  = nodes
+      max_node_count  = ceil(local.node_counts_max[pool] * (1 + var.headroom_ratio)) + 1
+      allocatable     = local.allocatable[pool]
+      demand          = local.demand[pool]
+      packing         = local.packing[pool]
+      pods_per_node   = ceil(local.demand[pool].pods / nodes)
+      cpu_utilisation = local.demand[pool].cpu_millis / (nodes * local.allocatable[pool].cpu_millis)
+    }
+  }
+
+  total_nodes = sum(values(local.node_counts))
+  total_vcpu  = sum([for pool, n in local.node_counts : n * var.machines[pool].vcpu])
+  total_pods  = sum([for pool, d in local.demand : d.pods])
+
+  # A /16 gives 65k addresses, so at 110 pods per node it caps the fleet near
+  # 256 nodes.
+  pod_ips_required = local.total_nodes * var.max_pods_per_node
+}

--- a/infrastructure/terraform/modules/capacity/main.tf
+++ b/infrastructure/terraform/modules/capacity/main.tf
@@ -50,8 +50,16 @@ locals {
   # Sized for the largest shard because the chart gives every matcher
   # Deployment one limit, and a pod that cannot load its graph does not
   # degrade — it is OOM-killed at startup and never serves a request.
+  #
+  # A pod holds one graph per shard it serves, so arity multiplies the scaling
+  # term. Whether it multiplies the fixed one is unresolved — see
+  # `shard_memory_fixed_is_per_process` — and the conservative default says it
+  # does, leaving arity to win on pod count alone.
   matcher_graph_mib = ceil(
-    var.largest_shard_file_mib * var.shard_memory_slope + var.shard_memory_fixed_mib
+    var.largest_shard_file_mib * local.matcher_shards_per_pod * var.shard_memory_slope
+    + var.shard_memory_fixed_mib * (
+      var.shard_memory_fixed_is_per_process ? 1 : local.matcher_shards_per_pod
+    )
   )
 
   matcher_memory_mib = local.matcher_graph_mib + var.matcher_working_set_mib
@@ -66,10 +74,31 @@ locals {
   # covers the difference between it and a geographic distribution.
   mean_shard_eps = local.required_eps / local.shard_count
 
-  matcher_replicas_per_shard = max(1, ceil(local.mean_shard_eps / local.profile.matcher_eps))
-  matcher_replicas_max       = ceil(local.matcher_replicas_per_shard * var.hot_shard_replica_factor)
+  # The two directions of the shard-to-pod mapping, resolved by which side has
+  # the spare capacity. A pod worth 6000 evt/s against a shard carrying 39
+  # should hold more geography; against a shard carrying 39000 it should be one
+  # of seven. Both are the same statement about throughput, so one expression
+  # covers the whole range and the crossover needs no special case.
+  matcher_shards_per_pod = max(1, min(
+    var.max_shards_per_matcher,
+    floor(local.profile.matcher_eps / local.mean_shard_eps),
+  ))
 
-  matcher_pods         = local.shard_count * local.matcher_replicas_per_shard
+  # Deployments, each serving `matcher_shards_per_pod` shards. Equal to the
+  # shard count whenever arity is 1, which is what ships today.
+  matcher_groups = ceil(local.shard_count / local.matcher_shards_per_pod)
+  group_eps      = local.mean_shard_eps * local.matcher_shards_per_pod
+  matcher_pods   = local.matcher_groups * local.matcher_replicas_per_group
+
+  # Above 1 shard per pod this is always 1 by construction: a group is only
+  # grouped because its load fits one pod.
+  matcher_replicas_per_group = max(1, ceil(local.group_eps / local.profile.matcher_eps))
+
+  # Kept under the old name because it is what the chart renders per
+  # Deployment, and a Deployment is a group.
+  matcher_replicas_per_shard = local.matcher_replicas_per_group
+  matcher_replicas_max       = ceil(local.matcher_replicas_per_group * var.hot_shard_replica_factor)
+
   matcher_capacity_eps = local.matcher_pods * local.profile.matcher_eps
 
   # The fewest matcher pods the target could ever need, ignoring geography

--- a/infrastructure/terraform/modules/capacity/main.tf
+++ b/infrastructure/terraform/modules/capacity/main.tf
@@ -48,6 +48,21 @@ locals {
   matcher_pods         = local.shard_count * local.matcher_replicas_per_shard
   matcher_capacity_eps = local.matcher_pods * local.profile.matcher_eps
 
+  # The fewest matcher pods the target could ever need, ignoring geography
+  # entirely. Worth stating because the intuition it corrects is a strong one:
+  # shards do not multiply the pod count, they divide it, and the two cancel —
+  # `shard_count * (required / shard_count / matcher_eps)` is just
+  # `required / matcher_eps`.
+  #
+  # What does not cancel is the rounding. Each shard rounds its replicas up to
+  # a whole pod, so the fleet pays that remainder once per shard, and finer
+  # geography costs pods rather than saving them. Past `pods_floor` shards
+  # every shard is at its one-replica minimum and the pod count simply follows
+  # the shard count.
+  matcher_pods_floor = max(1, ceil(local.required_eps / local.profile.matcher_eps))
+
+  matcher_rounding_overhead = local.matcher_pods / local.matcher_pods_floor
+
   # Replicas are the first lever and shards the second, so a shard deficit is
   # not "too few shards to carry the load" — replicas carry it — but "one
   # shard now needs more replicas than a single queue group should hold".

--- a/infrastructure/terraform/modules/capacity/main.tf
+++ b/infrastructure/terraform/modules/capacity/main.tf
@@ -40,13 +40,20 @@ locals {
 
   # A matcher's memory is a property of its geography, not of its vertical
   # profile: the profile decides how fast a pod solves, the shard decides how
-  # much graph it has to hold. Measured rather than assumed — `r1` is 413 MiB
-  # on disk and 3.31 GB resident, so the file understates the pod by 7.6x.
+  # much graph it has to hold.
+  #
+  # Two terms, not one ratio, because the two measurements disagree about the
+  # ratio and agree about the line: r1 expands 7.6x and r3gr 11.8x, which is a
+  # fixed overhead showing through rather than a varying expansion. A single
+  # factor taken from either would misjudge the other by a third.
   #
   # Sized for the largest shard because the chart gives every matcher
   # Deployment one limit, and a pod that cannot load its graph does not
-  # degrade, it is OOM-killed at startup and never serves a request.
-  matcher_graph_mib  = ceil(var.largest_shard_file_mib * var.shard_memory_expansion)
+  # degrade — it is OOM-killed at startup and never serves a request.
+  matcher_graph_mib = ceil(
+    var.largest_shard_file_mib * var.shard_memory_slope + var.shard_memory_fixed_mib
+  )
+
   matcher_memory_mib = local.matcher_graph_mib + var.matcher_working_set_mib
 
   # Every replica of a shard loads that shard's whole graph, so the fleet's

--- a/infrastructure/terraform/modules/capacity/outputs.tf
+++ b/infrastructure/terraform/modules/capacity/outputs.tf
@@ -312,6 +312,76 @@ output "totals" {
   }
 }
 
+output "cost" {
+  description = <<-EOT
+    Estimated monthly spend in USD, at the autoscaler floor.
+
+    `by_pool` is what is actually bought — nodes come whole. `by_service`
+    attributes those nodes by CPU share, which is exact for the three pools
+    carrying one service each and a split only for `infra`, between the
+    brokers and the keyspace.
+
+    `compute_max` is the matcher HPA's ceiling rather than a forecast: it is
+    what a sustained fleet-wide burst would cost, and it is paid only while
+    the burst lasts.
+  EOT
+  value = {
+    currency   = "USD"
+    region     = "australia-southeast1"
+    commitment = var.pricing_commitment
+
+    by_pool    = local.pool_monthly
+    by_service = local.service_monthly
+
+    compute     = local.compute_monthly
+    compute_max = local.compute_monthly_max
+
+    storage = {
+      boot_disks            = local.boot_disk_monthly
+      jetstream_capacity    = local.jetstream_capacity_monthly
+      jetstream_performance = local.jetstream_performance_monthly
+      total                 = local.storage_monthly
+    }
+
+    cluster_fee = local.cluster_monthly
+
+    total     = local.total_monthly
+    total_max = local.total_monthly_max
+
+    per_million_events = local.cost_per_million_events
+  }
+}
+
+output "cost_report" {
+  description = "The cost breakdown as a table. `tofu output -raw cost_report` in an env root."
+  value = <<-EOT
+    ${var.pricing_commitment} rates, australia-southeast1, USD/month at ${local.hours_per_month}h
+
+    by node pool
+    ${join("\n    ", [
+  for p, v in local.pool_monthly :
+  format("%-10s %3d x %-16s %10s", p, local.node_counts[p], var.machines[p].machine_type, format("$%.0f", v))
+  ])}
+    ${format("%-32s %10s", "compute subtotal", format("$%.0f", local.compute_monthly))}
+
+    by service (nodes attributed by cpu share)
+    ${join("\n    ", [
+  for s, v in local.service_monthly :
+  format("%-32s %10s", s, format("$%.0f", v + local.service_storage_monthly[s]))
+])}
+
+    storage
+    ${format("%-32s %10s", "boot disks (${local.total_nodes} x ${var.boot_disk_gib}GiB)", format("$%.0f", local.boot_disk_monthly))}
+    ${format("%-32s %10s", "jetstream capacity (${local.nats_replicas_total} x ${local.file_store_gib_server}GiB)", format("$%.0f", local.jetstream_capacity_monthly))}
+    ${format("%-32s %10s", "jetstream iops + throughput", format("$%.0f", local.jetstream_performance_monthly))}
+
+    ${format("%-32s %10s", "gke cluster fee", format("$%.0f", local.cluster_monthly))}
+    ${format("%-32s %10s", "TOTAL", format("$%.0f", local.total_monthly))}
+    ${format("%-32s %10s", "at the matcher HPA ceiling", format("$%.0f", local.total_monthly_max))}
+    ${format("%-32s %10s", "per million events", format("$%.4f", local.cost_per_million_events))}
+  EOT
+}
+
 output "summary" {
   description = "Human-readable sizing report. `tofu output -raw capacity_summary` in an env root."
   value       = <<-EOT

--- a/infrastructure/terraform/modules/capacity/outputs.tf
+++ b/infrastructure/terraform/modules/capacity/outputs.tf
@@ -171,6 +171,32 @@ output "nats" {
     file_store_gib = local.file_store_gib_server
     cpu_millis     = var.nats_cpu_millis
     memory_mib     = var.nats_memory_mib
+
+    # How many nodes the infra pool must have for the servers to spread. A
+    # node may hold at most half the cluster short of one, or losing it costs
+    # quorum on every stream that node was leading.
+    spread_nodes = local.nats_spread_nodes
+  }
+}
+
+output "jetstream_disk" {
+  description = <<-EOT
+    What the file store must sustain per server, as opposed to how much it must
+    hold. Capacity and performance are separate constraints here, and a pd-*
+    class conflates them: its throughput scales with size, so the broker's
+    write ceiling would depend on the retention window rather than on traffic.
+    The devstack provisions both explicitly from these figures.
+
+    Throughput usually binds before IOPS — JetStream appends sequentially — and
+    the matched stream is most of the bytes, because an emission carries the
+    whole cut trip rather than a delta.
+  EOT
+  value = {
+    write_mib_per_server = local.jetstream_write_mib_server
+    iops_per_server      = local.jetstream_iops_server
+    write_bytes_rate     = local.jetstream_write_bytes_rate
+    gib_per_server       = local.file_store_gib_server
+    messages_per_write   = var.jetstream_messages_per_write
   }
 }
 
@@ -286,7 +312,8 @@ output "summary" {
     fleet         ${local.fleet} pods x ${local.partitions_per_pod} partitions = ${var.partitions}, capacity ${format("%d", floor(local.orchestrator_capacity_eps))} evt/s
     streams       ${var.streams} raw (${format("%d", floor(local.raw_writes_per_stream))} writes/s each, ceiling ${var.jetstream_writes_per_stream}), ${local.partitions_per_stream} consumers each
                   ${var.matched_streams} matched (${format("%d", floor(local.matched_writes_per_stream))} writes/s each)
-    nats          ${local.nats_replicas_total} servers, ${local.stream_leaders_total} stream leaders, ${local.file_store_gib_server} GiB file store each
+    nats          ${local.nats_replicas_total} servers over >=${local.nats_spread_nodes} nodes, ${local.stream_leaders_total} stream leaders
+    file store    ${local.file_store_gib_server} GiB per server at ${local.jetstream_write_mib_server} MiB/s, ${local.jetstream_iops_server} IOPS
     valkey        ${local.valkey_primaries_total} primaries + ${local.valkey_primaries_total * var.valkey_replicas_per_primary} replicas, ${var.valkey_client_mode}, ${var.valkey_io_threads} io-threads
     collectors    ${local.collector_replicas} at ${var.telemetry_sample_ratio} sample ratio (${format("%d", floor(local.span_rate))} spans/s)
 

--- a/infrastructure/terraform/modules/capacity/outputs.tf
+++ b/infrastructure/terraform/modules/capacity/outputs.tf
@@ -34,6 +34,14 @@ output "matcher" {
     `replicas` is the floor derived from the mean rate; `replicas_max` is the
     HPA ceiling, which is what absorbs the difference between a mean and a
     geographic distribution.
+
+    `pods_floor` is the count throughput alone demands. Shards do not multiply
+    the pod count — they divide it, and the two cancel — so the gap between
+    `pods` and `pods_floor` is pure per-shard rounding, and finer geography
+    widens it. Precision is worth spending on shard-file size and on how
+    finely load can be isolated, not on pod count, and it is worth spending
+    carefully: a finer grid means more trips crossing a shard boundary, and
+    every crossing degrades a resume to a restart.
   EOT
   value = {
     shards         = local.shard_count
@@ -41,9 +49,13 @@ output "matcher" {
     replicas_max   = local.matcher_replicas_max
     pods           = local.matcher_pods
     pods_max       = local.shard_count * local.matcher_replicas_max
+    pods_floor     = local.matcher_pods_floor
     eps_per_pod    = local.profile.matcher_eps
     capacity_eps   = local.matcher_capacity_eps
     mean_shard_eps = local.mean_shard_eps
+
+    # 1.0 means the geography costs nothing over the throughput floor.
+    rounding_overhead = local.matcher_rounding_overhead
   }
 }
 
@@ -309,6 +321,7 @@ output "summary" {
 
     matchers      ${local.shard_count} shards x ${local.matcher_replicas_per_shard} replicas = ${local.matcher_pods} pods (HPA to ${local.matcher_replicas_max}/shard, ${local.shard_count * local.matcher_replicas_max} pods)
                   ${format("%d", floor(local.mean_shard_eps))} evt/s mean per shard, capacity ${format("%d", floor(local.matcher_capacity_eps))} evt/s
+                  throughput floor is ${local.matcher_pods_floor} pods; this geography costs ${format("%.2f", local.matcher_rounding_overhead)}x that
     fleet         ${local.fleet} pods x ${local.partitions_per_pod} partitions = ${var.partitions}, capacity ${format("%d", floor(local.orchestrator_capacity_eps))} evt/s
     streams       ${var.streams} raw (${format("%d", floor(local.raw_writes_per_stream))} writes/s each, ceiling ${var.jetstream_writes_per_stream}), ${local.partitions_per_stream} consumers each
                   ${var.matched_streams} matched (${format("%d", floor(local.matched_writes_per_stream))} writes/s each)

--- a/infrastructure/terraform/modules/capacity/outputs.tf
+++ b/infrastructure/terraform/modules/capacity/outputs.tf
@@ -56,7 +56,41 @@ output "matcher" {
 
     # 1.0 means the geography costs nothing over the throughput floor.
     rounding_overhead = local.matcher_rounding_overhead
+
+    # Memory is set by geography, not by the profile: the graph a shard makes
+    # a pod hold. `graph_mib_total` is the fleet-wide duplication — every
+    # replica loads its shard's whole graph, and the pod count is fixed by
+    # throughput, so a bigger shard cannot be offset by having fewer of them.
+    memory_mib      = local.matcher_memory_mib
+    graph_mib       = local.matcher_graph_mib
+    graph_mib_total = local.matcher_graph_mib_total
   }
+}
+
+output "shard_memory_note" {
+  description = <<-EOT
+    How a shard's size lands on the fleet, and which resource ends up binding
+    the matcher pool.
+
+    Worth reading before changing precision. Pod count is throughput's to
+    decide, so coarsening the grid does not buy fewer pods — it makes each one
+    hold a bigger graph, and the pool tips from CPU-bound to memory-bound.
+  EOT
+  value = join(" ", [
+    "The largest shard is ${var.largest_shard_file_mib} MiB on disk and",
+    "${local.matcher_graph_mib} MiB resident at ${var.shard_memory_expansion}x,",
+    "so every matcher is sized at ${local.matcher_memory_mib} MiB including its working set.",
+    "Across ${local.matcher_pods} pods that is ${format("%.1f", local.matcher_graph_mib_total / 1024)} GiB of graph,",
+    "most of it the same shards loaded again per replica.",
+    "One node fits ${floor(local.allocatable["matcher"].memory_mib / local.matcher_memory_mib)} by memory",
+    "and ${floor(local.allocatable["matcher"].cpu_millis / local.profile.matcher_cpu_millis)} by CPU,",
+    "so the pool is ${
+      floor(local.allocatable["matcher"].memory_mib / local.matcher_memory_mib) <
+      floor(local.allocatable["matcher"].cpu_millis / local.profile.matcher_cpu_millis)
+      ? "memory-bound — a finer grid would shrink the graph and recover nodes"
+      : "CPU-bound, so the graph is currently free"
+    }.",
+  ])
 }
 
 output "shards_required" {

--- a/infrastructure/terraform/modules/capacity/outputs.tf
+++ b/infrastructure/terraform/modules/capacity/outputs.tf
@@ -83,11 +83,11 @@ output "shard_memory_note" {
     "so every matcher is sized at ${local.matcher_memory_mib} MiB including its working set.",
     "Across ${local.matcher_pods} pods that is ${format("%.1f", local.matcher_graph_mib_total / 1024)} GiB of graph,",
     "most of it the same shards loaded again per replica.",
-    "One node fits ${floor(local.allocatable["matcher"].memory_mib / local.matcher_memory_mib)} by memory",
-    "and ${floor(local.allocatable["matcher"].cpu_millis / local.profile.matcher_cpu_millis)} by CPU,",
+    "One node fits ${floor(local.allocatable[local.matcher_pool].memory_mib / local.matcher_memory_mib)} by memory",
+    "and ${floor(local.allocatable[local.matcher_pool].cpu_millis / local.profile.matcher_cpu_millis)} by CPU,",
     "so the pool is ${
-      floor(local.allocatable["matcher"].memory_mib / local.matcher_memory_mib) <
-      floor(local.allocatable["matcher"].cpu_millis / local.profile.matcher_cpu_millis)
+      floor(local.allocatable[local.matcher_pool].memory_mib / local.matcher_memory_mib) <
+      floor(local.allocatable[local.matcher_pool].cpu_millis / local.profile.matcher_cpu_millis)
       ? "memory-bound: a finer grid would shrink the graph and recover nodes"
       : "CPU-bound, and the graph costs nothing"
     }.",

--- a/infrastructure/terraform/modules/capacity/outputs.tf
+++ b/infrastructure/terraform/modules/capacity/outputs.tf
@@ -1,0 +1,308 @@
+output "shard_count" {
+  description = "Shards deployed; the number of matcher Deployments."
+  value       = local.shard_count
+}
+
+output "shard_precision" {
+  description = "Geohash precision, passed through to the matcher's PRECISION."
+  value       = var.shard_precision
+}
+
+output "profile" {
+  description = "Resolved vertical profile: per-pod resources, worker counts and per-pod throughput."
+  value       = local.profile
+}
+
+output "required_eps" {
+  description = "Target plus headroom; what every capacity figure must reach."
+  value       = local.required_eps
+}
+
+output "meets_target" {
+  description = "Whether matchers, the fleet, the stream topology and Valkey all reach the target. Env roots assert on this."
+  value       = local.meets_target
+}
+
+# --- Matchers ---------------------------------------------------------------
+
+output "matcher" {
+  description = <<-EOT
+    The geographic half. Replicas divide a shard's load rather than duplicating
+    it, because matchers serve their shard subject through a NATS queue group,
+    so `replicas` is a real horizontal lever and not just redundancy.
+
+    `replicas` is the floor derived from the mean rate; `replicas_max` is the
+    HPA ceiling, which is what absorbs the difference between a mean and a
+    geographic distribution.
+  EOT
+  value = {
+    shards         = local.shard_count
+    replicas       = local.matcher_replicas_per_shard
+    replicas_max   = local.matcher_replicas_max
+    pods           = local.matcher_pods
+    pods_max       = local.shard_count * local.matcher_replicas_max
+    eps_per_pod    = local.profile.matcher_eps
+    capacity_eps   = local.matcher_capacity_eps
+    mean_shard_eps = local.mean_shard_eps
+  }
+}
+
+output "shards_required" {
+  description = "Shards needed at this profile for one shard's load to stay inside its HPA ceiling. Below the current count, replicas are the lever instead."
+  value       = local.shards_required
+}
+
+output "shard_deficit" {
+  description = "Shards missing before a single shard's mean load exceeds what its replicas can serve; zero when replicas suffice."
+  value       = local.shard_deficit
+}
+
+output "recommended_precision" {
+  description = "Precision that would close the shard deficit. Regenerate the shard cache at this precision before adopting it."
+  value       = local.recommended_precision
+}
+
+# --- Orchestrator fleet -----------------------------------------------------
+
+output "fleet" {
+  description = <<-EOT
+    The vehicle-partitioned half: a StatefulSet whose pods take disjoint
+    ordinal slices of the partition space.
+
+    `size` is snapped to a divisor of `partitions` so every slice is equal —
+    the binary gives the last pod the remainder, which would otherwise make it
+    the hot one. Resizing re-slices the whole space, so it is a quiesced
+    operation, or a window of double ownership that revisions make wasteful
+    rather than wrong.
+  EOT
+  value = {
+    size               = local.fleet
+    required           = local.fleet_required
+    partitions         = var.partitions
+    partitions_per_pod = local.partitions_per_pod
+    eps_per_pod        = local.profile.orchestrator_eps
+    capacity_eps       = local.orchestrator_capacity_eps
+    fits_partitions    = local.fleet_fits_the_partition_space
+  }
+}
+
+# --- Streams ----------------------------------------------------------------
+
+output "streams" {
+  description = <<-EOT
+    The JetStream ingest topology, and the one part of this model that cannot
+    be corrected later: a revision is a stream sequence, so moving a partition
+    between streams resets its sequence domain.
+
+    `writes_per_stream` against `jetstream_writes_per_stream` is the binding
+    constraint, because a stream has a single raft leader.
+  EOT
+  value = {
+    raw                   = var.streams
+    matched               = var.matched_streams
+    partitions_per_stream = local.partitions_per_stream
+    consumers_per_stream  = local.partitions_per_stream
+    stream_replicas       = var.jetstream_stream_replicas
+
+    raw_writes_per_stream = local.raw_writes_per_stream
+    raw_streams_required  = local.raw_streams_required
+    raw_sufficient        = local.raw_streams_ok
+
+    matched_writes_per_stream = local.matched_writes_per_stream
+    matched_streams_required  = local.matched_streams_required
+    matched_sufficient        = local.matched_streams_ok
+
+    disk_bytes_total      = local.jetstream_disk_bytes
+    file_store_gib_server = local.file_store_gib_server
+  }
+}
+
+output "matched_stream_prerequisite" {
+  description = <<-EOT
+    Non-empty when the matched stream cannot absorb the emission rate.
+
+    Every partition publishes into `ingest::MATCHED_STREAM`, which is one
+    stream and so one raft leader. Splitting it is a small change — it carries
+    no sequence law, because revisions are minted on the raw side — but it is a
+    code change, not a variable.
+  EOT
+  value = local.matched_streams_ok ? "" : join(" ", [
+    "The matched stream must absorb ${format("%d", floor(local.required_eps))} emissions/s,",
+    "but one stream sustains ${var.jetstream_writes_per_stream}.",
+    "That needs ${local.matched_streams_required} streams;",
+    "`ingest.rs` publishes every partition into a single MATCHED_STREAM.",
+    "Partition it the way the raw side already is — it carries no sequence law,",
+    "since revisions come from the ingest streams — then raise matched_streams.",
+  ])
+}
+
+output "raw_stream_prerequisite" {
+  description = "Non-empty when the pinned raw stream count cannot absorb ingest. Unlike the matched stream this cannot be fixed after events exist."
+  value = local.raw_streams_ok ? "" : join(" ", [
+    "Raw ingest is ${format("%d", floor(local.raw_writes_per_stream))} writes/s per stream",
+    "across ${var.streams} streams, over the ${var.jetstream_writes_per_stream} one leader sustains.",
+    "Raise streams to ${local.raw_streams_required} BEFORE any events exist:",
+    "revisions are stream sequences, so remapping partitions later resets",
+    "sequence domains and breaks every revision comparison across the boundary.",
+  ])
+}
+
+# --- Dependencies -----------------------------------------------------------
+
+output "nats" {
+  description = <<-EOT
+    The single NATS cluster, now carrying JetStream as well as core routing.
+    Sized from whichever binds first: routed deliveries, or persisted writes.
+
+    Replica count is odd because JetStream elects a leader per stream, and an
+    even membership adds a vote to every quorum without buying fault tolerance
+    over the odd number below it.
+  EOT
+  value = {
+    replicas_total = local.nats_replicas_total
+
+    core_delivery_rate = local.core_delivery_rate
+    msgs_per_server    = var.nats_msgs_per_server
+
+    jetstream_write_rate = local.jetstream_write_rate
+    writes_per_server    = var.jetstream_writes_per_server
+    stream_leaders       = local.stream_leaders_total
+
+    file_store_gib = local.file_store_gib_server
+    cpu_millis     = var.nats_cpu_millis
+    memory_mib     = var.nats_memory_mib
+  }
+}
+
+output "valkey" {
+  description = <<-EOT
+    The Valkey fleet. One logical keyspace, sharded by `hash(vehicle_id)`
+    rather than by geography, so no boundary affects history continuity.
+
+    Halved against the previous topology: the orchestrator absorbed the
+    historian's batched write and its per-event read is gone, so an event costs
+    one `XADD` where it used to cost a read and a write.
+  EOT
+  value = {
+    client_mode          = var.valkey_client_mode
+    primaries            = local.valkey_primaries_total
+    pods                 = local.valkey_pods_total
+    replicas_per_primary = var.valkey_replicas_per_primary
+    ops_rate             = local.valkey_ops_rate
+    ops_per_event        = var.valkey_ops_per_event
+    ops_per_primary      = var.valkey_ops_per_primary
+    io_threads           = var.valkey_io_threads
+    cpu_millis           = var.valkey_cpu_millis
+    memory_mib           = var.valkey_memory_mib
+  }
+}
+
+output "valkey_client_prerequisite" {
+  description = "Non-empty when the fleet is larger than the client can address. Adding primaries does not help: the client must be able to reach them."
+  value = local.valkey_client_is_sufficient ? "" : join(" ", [
+    "valkey_client_mode is 'single' but the target needs ${local.valkey_primaries_total} primaries.",
+    "Clients would reach one primary and the deployment would cap at",
+    "${local.single_valkey_ceiling_eps} evt/s.",
+    "Switch to 'pooled-hash': RedisStore already spreads vehicles across the",
+    "whole fleet by rendezvous hash.",
+  ])
+}
+
+output "single_valkey_ceiling_eps" {
+  description = "Event rate one primary serves, and the whole deployment's ceiling under `valkey_client_mode = \"single\"`."
+  value       = local.single_valkey_ceiling_eps
+}
+
+output "telemetry" {
+  description = "Collector sizing and the sample ratio the services must apply. Rendered into the workloads as the standard OTEL_TRACES_SAMPLER env pair."
+  value = {
+    sample_ratio       = var.telemetry_sample_ratio
+    span_rate          = local.span_rate
+    collector_replicas = local.collector_replicas
+    cpu_millis         = var.collector_cpu_millis
+    memory_mib         = var.collector_memory_mib
+  }
+}
+
+output "out_of_coverage_shards" {
+  description = "Shards not nesting under any `coverage_cells` entry. Must be empty when coverage is declared."
+  value       = local.out_of_coverage
+}
+
+output "precision_prerequisite" {
+  description = "Non-empty when the deployed shard precision disagrees with the one compiled into the binaries, which would send every request to a subject no matcher serves."
+  value = var.shard_precision == var.binary_shard_precision ? "" : join(" ", [
+    "shard_precision is ${var.shard_precision} but the binaries route with",
+    "event::SHARD_PRECISION = ${var.binary_shard_precision}.",
+    "The orchestrator derives a request subject from the compiled constant, so",
+    "every solve would address `events.match.<${var.binary_shard_precision}-char>`",
+    "while matchers serve `<${var.shard_precision}-char>` subjects and nothing replies.",
+    "Change the constant and rebuild, or deploy shards at precision ${var.binary_shard_precision}.",
+  ])
+}
+
+# --- The design target ------------------------------------------------------
+
+output "design_target" {
+  description = <<-EOT
+    What the design target would need, for comparison against what is pinned
+    now. `streams_ok` and `fleet_fits` are the two that matter: both quantities
+    are wire law, so they are cheap today and a migration later.
+  EOT
+  value       = local.design
+}
+
+# --- Nodes ------------------------------------------------------------------
+
+output "pools" {
+  description = "Node pool sizing per pool: machine type, autoscaler floor and ceiling, allocatable capacity, and the demand behind it."
+  value       = local.pools
+}
+
+output "unschedulable_shapes" {
+  description = "Pod shapes larger than one node's allocatable capacity, as \"<pool>/<shape>\". Must be empty."
+  value       = local.unschedulable_shapes
+}
+
+output "totals" {
+  description = "Fleet totals, for cost estimation and for sizing the pod CIDR."
+  value = {
+    nodes            = local.total_nodes
+    vcpu             = local.total_vcpu
+    pods             = local.total_pods
+    pod_ips_required = local.pod_ips_required
+  }
+}
+
+output "summary" {
+  description = "Human-readable sizing report. `tofu output -raw capacity_summary` in an env root."
+  value       = <<-EOT
+    target        ${format("%d", var.throughput_target_eps)} evt/s (+${format("%d", floor(var.headroom_ratio * 100))}% headroom = ${format("%d", floor(local.required_eps))})
+    profile       ${var.vertical_profile} (matcher ${local.profile.matcher_eps} evt/s x ${local.profile.matcher_workers}w, orchestrator ${local.profile.orchestrator_eps} evt/s x ${local.profile.orchestrator_workers}w)
+    verdict       ${local.meets_target ? "MEETS TARGET" : "SHORT"}
+
+    matchers      ${local.shard_count} shards x ${local.matcher_replicas_per_shard} replicas = ${local.matcher_pods} pods (HPA to ${local.matcher_replicas_max}/shard, ${local.shard_count * local.matcher_replicas_max} pods)
+                  ${format("%d", floor(local.mean_shard_eps))} evt/s mean per shard, capacity ${format("%d", floor(local.matcher_capacity_eps))} evt/s
+    fleet         ${local.fleet} pods x ${local.partitions_per_pod} partitions = ${var.partitions}, capacity ${format("%d", floor(local.orchestrator_capacity_eps))} evt/s
+    streams       ${var.streams} raw (${format("%d", floor(local.raw_writes_per_stream))} writes/s each, ceiling ${var.jetstream_writes_per_stream}), ${local.partitions_per_stream} consumers each
+                  ${var.matched_streams} matched (${format("%d", floor(local.matched_writes_per_stream))} writes/s each)
+    nats          ${local.nats_replicas_total} servers, ${local.stream_leaders_total} stream leaders, ${local.file_store_gib_server} GiB file store each
+    valkey        ${local.valkey_primaries_total} primaries + ${local.valkey_primaries_total * var.valkey_replicas_per_primary} replicas, ${var.valkey_client_mode}, ${var.valkey_io_threads} io-threads
+    collectors    ${local.collector_replicas} at ${var.telemetry_sample_ratio} sample ratio (${format("%d", floor(local.span_rate))} spans/s)
+
+    ${local.raw_streams_ok ? "streams       raw sufficient" : format("STREAMS       raw SHORT: need %d, have %d -- pin before events exist", local.raw_streams_required, var.streams)}
+    ${local.matched_streams_ok ? "streams       matched sufficient" : format("STREAMS       matched SHORT: need %d, have %d -- partition MATCHED_STREAM in ingest.rs", local.matched_streams_required, var.matched_streams)}
+    ${local.fleet_fits_the_partition_space ? "fleet         fits the partition space" : format("FLEET         SHORT: needs %d pods for %d partitions -- use a larger profile", local.fleet_required, var.partitions)}
+    ${local.shard_deficit > 0 ? format("shards        short by %d; try precision %d", local.shard_deficit, local.recommended_precision) : "shards        sufficient"}
+    ${local.valkey_client_is_sufficient ? "valkey        sufficient" : format("VALKEY        client mode 'single' caps this at %d evt/s; needs pooled-hash for %d primaries", local.single_valkey_ceiling_eps, local.valkey_primaries_total)}
+    ${var.shard_precision == var.binary_shard_precision ? "precision     agrees with the binaries" : format("PRECISION     %d disagrees with the compiled %d -- requests would reach no matcher", var.shard_precision, var.binary_shard_precision)}
+
+    design target ${format("%d", var.design_target_eps)} evt/s would need:
+                  ${local.design.matcher_pods} matcher pods, a fleet of ${local.design.fleet_required}, ${local.design.valkey_primaries} valkey primaries
+                  ${local.design.streams_required} raw streams (${format("%d", floor(local.design.writes_per_stream))} writes/s each at the pinned ${var.streams}) ${local.design.streams_ok ? "-- pinned count survives" : "-- PINNED COUNT IS SHORT"}
+                  ${local.design.matched_streams_required} matched streams
+
+    nodes         ${local.total_nodes} total, ${local.total_vcpu} vCPU, ${local.pod_ips_required} pod IPs
+    ${join("\n    ", [for p, v in local.pools : format("%-14s%2d-%2d x %-20s %4d pods, cpu %d%%", p, v.min_node_count, v.max_node_count, v.machine_type, v.demand.pods, floor(v.cpu_utilisation * 100))])}
+  EOT
+}

--- a/infrastructure/terraform/modules/capacity/outputs.tf
+++ b/infrastructure/terraform/modules/capacity/outputs.tf
@@ -57,6 +57,13 @@ output "matcher" {
     # 1.0 means the geography costs nothing over the throughput floor.
     rounding_overhead = local.matcher_rounding_overhead
 
+    # The shard-to-pod arity, and the Deployments it produces. Above 1 a pod
+    # serves several shards because its capacity exceeds theirs; at 1 the
+    # relationship inverts and `replicas` splits a single shard instead.
+    shards_per_pod = local.matcher_shards_per_pod
+    groups         = local.matcher_groups
+    group_eps      = local.group_eps
+
     # Memory is set by geography, not by the profile: the graph a shard makes
     # a pod hold. `graph_mib_total` is the fleet-wide duplication — every
     # replica loads its shard's whole graph, and the pod count is fixed by

--- a/infrastructure/terraform/modules/capacity/outputs.tf
+++ b/infrastructure/terraform/modules/capacity/outputs.tf
@@ -78,7 +78,8 @@ output "shard_memory_note" {
   EOT
   value = join(" ", [
     "The largest shard is ${var.largest_shard_file_mib} MiB on disk and",
-    "${local.matcher_graph_mib} MiB resident at ${var.shard_memory_expansion}x,",
+    "${local.matcher_graph_mib} MiB resident — ${var.shard_memory_slope}x the file plus",
+    "${var.shard_memory_fixed_mib} MiB that does not scale with it —",
     "so every matcher is sized at ${local.matcher_memory_mib} MiB including its working set.",
     "Across ${local.matcher_pods} pods that is ${format("%.1f", local.matcher_graph_mib_total / 1024)} GiB of graph,",
     "most of it the same shards loaded again per replica.",
@@ -87,8 +88,8 @@ output "shard_memory_note" {
     "so the pool is ${
       floor(local.allocatable["matcher"].memory_mib / local.matcher_memory_mib) <
       floor(local.allocatable["matcher"].cpu_millis / local.profile.matcher_cpu_millis)
-      ? "memory-bound — a finer grid would shrink the graph and recover nodes"
-      : "CPU-bound, so the graph is currently free"
+      ? "memory-bound: a finer grid would shrink the graph and recover nodes"
+      : "CPU-bound, and the graph costs nothing"
     }.",
   ])
 }

--- a/infrastructure/terraform/modules/capacity/outputs.tf
+++ b/infrastructure/terraform/modules/capacity/outputs.tf
@@ -92,10 +92,32 @@ output "fleet" {
     required           = local.fleet_required
     partitions         = var.partitions
     partitions_per_pod = local.partitions_per_pod
-    eps_per_pod        = local.profile.orchestrator_eps
+    eps_per_pod        = local.orchestrator_eps
     capacity_eps       = local.orchestrator_capacity_eps
     fits_partitions    = local.fleet_fits_the_partition_space
+
+    # Which ceiling the pod actually hits, and what the other one would allow.
+    # `concurrency` means the fix is a worker count, not a bigger pod.
+    bound               = local.orchestrator_bound
+    io_eps              = local.orchestrator_io_eps
+    cpu_eps             = local.orchestrator_cpu_eps
+    workers             = local.profile.orchestrator_workers
+    round_trip_ms       = local.profile.orchestrator_round_trip_ms
+    stranded_cpu_millis = local.orchestrator_stranded_cpu_millis
   }
+}
+
+output "orchestrator_efficiency_note" {
+  description = "Non-empty when the fleet is bought CPU it cannot reach, because concurrency rather than compute is what binds each pod."
+  value = local.orchestrator_bound != "concurrency" ? "" : join(" ", [
+    "Each orchestrator is concurrency-bound at ${local.orchestrator_io_eps} evt/s,",
+    "against the ${local.orchestrator_cpu_eps} evt/s its CPU request could serve.",
+    "That strands ${format("%.0f", local.orchestrator_stranded_cpu_millis)}m per pod across a fleet of ${local.fleet}.",
+    "Workers are tokio tasks holding a lane across a round trip, not threads,",
+    "so raising orchestrator_workers costs memory rather than cores —",
+    "and VEHICLE_CACHE is per worker, so lower it in step or the pod's",
+    "lane memory grows with the same change.",
+  ])
 }
 
 # --- Streams ----------------------------------------------------------------
@@ -386,7 +408,7 @@ output "summary" {
   description = "Human-readable sizing report. `tofu output -raw capacity_summary` in an env root."
   value       = <<-EOT
     target        ${format("%d", var.throughput_target_eps)} evt/s (+${format("%d", floor(var.headroom_ratio * 100))}% headroom = ${format("%d", floor(local.required_eps))})
-    profile       ${var.vertical_profile} (matcher ${local.profile.matcher_eps} evt/s x ${local.profile.matcher_workers}w, orchestrator ${local.profile.orchestrator_eps} evt/s x ${local.profile.orchestrator_workers}w)
+    profile       ${var.vertical_profile} (matcher ${local.profile.matcher_eps} evt/s x ${local.profile.matcher_workers}w, orchestrator ${local.orchestrator_eps} evt/s x ${local.profile.orchestrator_workers}w, ${local.orchestrator_bound}-bound)
     verdict       ${local.meets_target ? "MEETS TARGET" : "SHORT"}
 
     matchers      ${local.shard_count} shards x ${local.matcher_replicas_per_shard} replicas = ${local.matcher_pods} pods (HPA to ${local.matcher_replicas_max}/shard, ${local.shard_count * local.matcher_replicas_max} pods)

--- a/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
+++ b/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
@@ -1,0 +1,372 @@
+# The sizing model is pure arithmetic, so it is testable outright: no
+# providers, no credentials, no cluster. Run with `tofu test` from this module.
+#
+# Each run pins a number something downstream depends on. If a calibration
+# changes on purpose the expected value changes with it; if one changes by
+# accident this catches it before a plan does.
+
+variables {
+  machines = {
+    matcher  = { machine_type = "c4-highcpu-32", vcpu = 32, memory_gib = 64 }
+    pipeline = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
+    infra    = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+    system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+  }
+
+  shard_precision = 4
+}
+
+# 256 precision-4 shards: eight three-character prefixes fanned across the
+# geohash alphabet. It comes from a module because a test `variables` block
+# cannot call functions, and `apply` because a plan would leave the output
+# unknown.
+run "shards" {
+  command = apply
+
+  module {
+    source = "./tests/setup"
+  }
+
+  variables {
+    prefixes = ["r3g", "r65", "r3f", "r3u", "qd0", "qd1", "r6h", "r3e"]
+  }
+
+  assert {
+    condition     = length(output.shards) == 256
+    error_message = "The fixture must generate 256 shards, got ${length(output.shards)}."
+  }
+}
+
+# GKE's published reservation formulae, checked against a shape easy to verify
+# by hand. Every pool size divides by these.
+run "gke_allocatable_matches_published_reservations" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 100000
+  }
+
+  # c4-highcpu-32: 6% of core 1 + 1% of core 2 + 0.5% of cores 3-4
+  # + 0.25% of the remaining 28 = 150m. Less the 600m DaemonSet allowance.
+  assert {
+    condition     = output.pools["matcher"].allocatable.cpu_millis == 31250
+    error_message = "CPU reservation drifted: got ${output.pools["matcher"].allocatable.cpu_millis}m, expected 31250m."
+  }
+
+  # 64 GiB = 65536 MiB. Reserved = 25% of 4GiB (1024) + 20% of 4GiB (819.2)
+  # + 10% of 8GiB (819.2) + 6% of 48GiB (2949.12) + 100 MiB eviction.
+  # Less the 1200 MiB DaemonSet allowance.
+  assert {
+    condition     = output.pools["matcher"].allocatable.memory_mib == 58624
+    error_message = "Memory reservation drifted: got ${output.pools["matcher"].allocatable.memory_mib} MiB, expected 58624 MiB."
+  }
+
+  assert {
+    condition     = length(output.unschedulable_shapes) == 0
+    error_message = "Every pod shape must fit one node: ${join(", ", output.unschedulable_shapes)}."
+  }
+}
+
+# The two halves scale on different axes and must not be derived from each
+# other: matchers from geography, the fleet from the vehicle partition space.
+run "the_two_halves_scale_independently" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 800000
+  }
+
+  # 800k + 25% = 1M, over 256 shards = 3906 evt/s each, inside one replica's
+  # 6000. Replicas are the first lever, so this stays at the floor.
+  assert {
+    condition     = output.matcher.replicas == 1
+    error_message = "Expected 1 replica per shard at 3906 evt/s mean, got ${output.matcher.replicas}."
+  }
+
+  assert {
+    condition     = output.matcher.pods == 256
+    error_message = "Expected 256 matcher pods, got ${output.matcher.pods}."
+  }
+
+  # The HPA ceiling is what covers a hot shard, since the model can only see
+  # the mean.
+  assert {
+    condition     = output.matcher.replicas_max == 4
+    error_message = "Expected an HPA ceiling of 4 replicas, got ${output.matcher.replicas_max}."
+  }
+
+  # 1M / 8000 per pod = 125, snapped up to 128 so every pod takes exactly 8
+  # partitions. The fleet is independent of the shard count entirely.
+  assert {
+    condition     = output.fleet.size == 128
+    error_message = "Expected a fleet of 128, got ${output.fleet.size}."
+  }
+
+  assert {
+    condition     = output.fleet.partitions_per_pod == 8
+    error_message = "Expected 8 partitions per pod, got ${output.fleet.partitions_per_pod}."
+  }
+}
+
+# Every fleet size must divide the partition space exactly. The binary gives
+# the last pod the remainder, so a non-divisor would quietly make one pod the
+# hot one.
+run "fleet_snaps_to_a_divisor_of_the_partition_space" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 800000
+  }
+
+  assert {
+    condition     = output.fleet.partitions % output.fleet.size == 0
+    error_message = "Fleet of ${output.fleet.size} does not divide ${output.fleet.partitions} partitions."
+  }
+
+  assert {
+    condition     = output.fleet.size * output.fleet.partitions_per_pod == output.fleet.partitions
+    error_message = "Fleet slices do not cover the partition space exactly."
+  }
+
+  assert {
+    condition     = output.fleet.size >= output.fleet.required
+    error_message = "Snapping must round up: fleet ${output.fleet.size} is under the required ${output.fleet.required}."
+  }
+}
+
+# A profile too small to reach the target within one pod per partition. The
+# answer is a bigger profile, and the model must say so rather than plan a
+# fleet larger than the space it divides.
+run "a_fleet_cannot_exceed_the_partition_space" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 50000000
+    vertical_profile      = "small"
+  }
+
+  assert {
+    condition     = !output.fleet.fits_partitions
+    error_message = "50M evt/s at the small profile must exceed the partition space."
+  }
+
+  assert {
+    condition     = output.fleet.size == output.fleet.partitions
+    error_message = "An over-target fleet must pin at the partition count, got ${output.fleet.size}."
+  }
+
+  assert {
+    condition     = !output.meets_target
+    error_message = "A fleet that cannot fit the partition space must not meet the target."
+  }
+}
+
+# The stream count is the one quantity a migration cannot avoid, so what
+# matters is whether the pinned value survives the *design* target rather than
+# today's. 5M + 25% over 64 streams is ~98k writes/s each.
+run "the_pinned_stream_count_survives_the_design_target" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 800000
+    design_target_eps     = 5000000
+  }
+
+  assert {
+    condition     = output.streams.raw == 64
+    error_message = "Expected 64 raw streams pinned, got ${output.streams.raw}."
+  }
+
+  assert {
+    condition     = output.design_target.streams_ok
+    error_message = "64 streams must absorb the design target: ${output.design_target.writes_per_stream} writes/s per stream exceeds the ceiling."
+  }
+
+  assert {
+    condition     = output.streams.raw_sufficient
+    error_message = "64 streams must absorb the current target: ${output.raw_stream_prerequisite}"
+  }
+
+  # 1024 partitions over 64 streams: each stream carries 16 subjects and so 16
+  # durable consumers, whose state its leader holds.
+  assert {
+    condition     = output.streams.consumers_per_stream == 16
+    error_message = "Expected 16 consumers per stream, got ${output.streams.consumers_per_stream}."
+  }
+
+  # Half the streams would put the design target over a single leader's
+  # ceiling, which is the reason the pinned value is not 32.
+  assert {
+    condition     = output.design_target.streams_required > 32
+    error_message = "The design target should need more than 32 streams, or the pinned 64 is not justified."
+  }
+}
+
+# The matched stream is a singleton in `ingest.rs`, which caps the deployment
+# well under either target. The model must name it rather than let a cluster
+# discover it.
+run "the_singleton_matched_stream_is_reported" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 800000
+  }
+
+  assert {
+    condition     = !output.streams.matched_sufficient
+    error_message = "One matched stream cannot absorb 1M emissions/s; the model should say so."
+  }
+
+  assert {
+    condition     = output.streams.matched_streams_required == 7
+    error_message = "Expected 7 matched streams required, got ${output.streams.matched_streams_required}."
+  }
+
+  assert {
+    condition     = length(output.matched_stream_prerequisite) > 0
+    error_message = "The prerequisite must carry the remediation, not just a boolean."
+  }
+
+  assert {
+    condition     = !output.meets_target
+    error_message = "A saturated matched stream must fail the verdict."
+  }
+}
+
+# A rate low enough that one stream is enough end to end, which is the only
+# configuration the current binary fully satisfies.
+run "a_small_target_is_deliverable_as_the_code_stands" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 100000
+    design_target_eps     = 100000
+  }
+
+  assert {
+    condition     = output.streams.matched_sufficient
+    error_message = "125k emissions/s must fit one stream at a 150k ceiling."
+  }
+
+  assert {
+    condition     = output.meets_target
+    error_message = "This shape should be deliverable:\n${output.summary}"
+  }
+}
+
+# Precision is compiled into the binaries' routing, so a mismatch is not a
+# warning — every request would address a subject no matcher serves.
+run "a_precision_mismatch_is_fatal" {
+  command = plan
+
+  variables {
+    shards                 = run.shards.shards
+    throughput_target_eps  = 100000
+    binary_shard_precision = 6
+  }
+
+  assert {
+    condition     = !output.meets_target
+    error_message = "Deployed precision 4 against a compiled 6 must not meet the target."
+  }
+
+  assert {
+    condition     = length(output.precision_prerequisite) > 0
+    error_message = "The mismatch must be reported with its remediation."
+  }
+}
+
+# Valkey halved when the orchestrator absorbed the historian: one XADD per
+# event, where the old topology also read per event.
+run "valkey_costs_one_command_per_event" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 800000
+  }
+
+  assert {
+    condition     = output.valkey.ops_per_event == 1
+    error_message = "Expected 1 command per event, got ${output.valkey.ops_per_event}."
+  }
+
+  # 1M ops/s over 500k per primary.
+  assert {
+    condition     = output.valkey.primaries == 2
+    error_message = "Expected 2 primaries for 1M ops/s, got ${output.valkey.primaries}."
+  }
+
+  assert {
+    condition     = output.valkey_client_prerequisite == ""
+    error_message = "pooled-hash must satisfy a multi-primary fleet."
+  }
+}
+
+# `single` reaches one primary, so a fleet larger than one is unreachable and
+# adding primaries cannot help.
+run "the_single_valkey_client_caps_the_deployment" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 800000
+    valkey_client_mode    = "single"
+  }
+
+  assert {
+    condition     = !output.meets_target
+    error_message = "A 2-primary fleet under 'single' must not meet the target."
+  }
+
+  assert {
+    condition     = length(output.valkey_client_prerequisite) > 0
+    error_message = "The client-mode ceiling must be reported."
+  }
+}
+
+# One shard cannot be scaled without limit: every replica loads that shard's
+# whole file, so past a point the geography must be subdivided instead.
+run "a_shard_that_cannot_be_scaled_recommends_a_finer_precision" {
+  command = plan
+
+  variables {
+    shards                         = ["r3gq"]
+    throughput_target_eps          = 800000
+    max_matcher_replicas_per_shard = 32
+  }
+
+  assert {
+    condition     = output.shard_deficit > 0
+    error_message = "1M evt/s onto one shard must exceed a 32-replica queue group."
+  }
+
+  assert {
+    condition     = output.recommended_precision > 4
+    error_message = "A shard deficit must recommend a finer precision, got ${output.recommended_precision}."
+  }
+}
+
+# Coverage is how a shard list generated over the wrong extent is caught before
+# it becomes a fleet of idle matchers.
+run "coverage_catches_shards_outside_the_service_region" {
+  command = plan
+
+  variables {
+    shards                = ["r3gq", "9q8y"]
+    throughput_target_eps = 10000
+    coverage_cells        = ["r3", "r6"]
+  }
+
+  assert {
+    condition     = join(",", output.out_of_coverage_shards) == "9q8y"
+    error_message = "Expected 9q8y outside coverage, got ${join(",", output.out_of_coverage_shards)}."
+  }
+}

--- a/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
+++ b/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
@@ -505,34 +505,57 @@ run "finer_geography_costs_pods_rather_than_saving_them" {
   }
 }
 
-# A matcher's memory is its shard's graph, measured rather than assumed: `r1`
-# is 413 MiB on disk and 3.31 GB resident. The file understates the pod by
-# 7.6x, which is why sizing a matcher from its shard file would OOM it.
-run "matcher_memory_is_derived_from_the_measured_shard" {
+# A matcher's memory is its shard's graph, and the model is a line fitted
+# through two real shards rather than a ratio. These pin it against both, which
+# is the whole justification for the two-term form: a single expansion factor
+# cannot reproduce them, because they disagree about the factor (7.6x and
+# 11.8x) while agreeing about the line.
+run "the_memory_model_reproduces_the_small_shard" {
   command = plan
 
   variables {
-    shards                 = ["r3gq", "r3gr", "r3gw", "r3gx", "r652", "r658"]
-    throughput_target_eps  = 800000
-    largest_shard_file_mib = 413
-  }
+    shards                = ["r3gq", "r3gr", "r3gw", "r3gx", "r652", "r658"]
+    throughput_target_eps = 800000
 
-  # 413 MiB at 7.6x.
-  assert {
-    condition     = output.matcher.graph_mib == 3139
-    error_message = "Expected a 3139 MiB resident graph, got ${output.matcher.graph_mib}."
-  }
-
-  # The graph plus the working set, and above the 3072 MiB the chart used to
-  # hardcode — which the graph alone would already have exceeded.
-  assert {
-    condition     = output.matcher.memory_mib == 4163
-    error_message = "Expected 4163 MiB per matcher, got ${output.matcher.memory_mib}."
+    # r3gr over Sydney: 21.2 MB on disk, 250 MB resident.
+    largest_shard_file_mib = 20.2
   }
 
   assert {
-    condition     = output.matcher.memory_mib > 3072
-    error_message = "A shard this size no longer fits the chart's old flat 3072 MiB limit, and the model must say so."
+    condition     = abs(output.matcher.graph_mib - 238) <= 5
+    error_message = "The fit must land on r3gr's measured 238 MiB, got ${output.matcher.graph_mib}."
+  }
+
+  # With a shard this size the pod is mostly working set, so CPU binds and the
+  # graph is effectively free.
+  assert {
+    condition     = length(regexall("CPU-bound", output.shard_memory_note)) > 0
+    error_message = "A precision-4 graph should leave the pool CPU-bound: ${output.shard_memory_note}"
+  }
+}
+
+run "the_memory_model_reproduces_the_large_shard" {
+  command = plan
+
+  variables {
+    shards                = ["r3gq", "r3gr", "r3gw", "r3gx", "r652", "r658"]
+    throughput_target_eps = 800000
+
+    # r1, the largest in Australia at precision 2: 433 MB on disk, 3.31 GB
+    # resident. The same line, twenty times the shard.
+    largest_shard_file_mib = 412.9
+  }
+
+  assert {
+    condition     = abs(output.matcher.graph_mib - 3157) <= 30
+    error_message = "The fit must land on r1's measured 3157 MiB, got ${output.matcher.graph_mib}."
+  }
+
+  # The graph alone exceeds the flat 3072 MiB the chart used to hardcode, so a
+  # matcher holding this shard was never going to start.
+  assert {
+    condition     = output.matcher.graph_mib > 3072
+    error_message = "r1's graph must be shown to exceed the old flat limit, got ${output.matcher.graph_mib}."
   }
 
   # Every replica loads its shard's whole graph, so the fleet holds the same
@@ -541,37 +564,12 @@ run "matcher_memory_is_derived_from_the_measured_shard" {
     condition     = output.matcher.graph_mib_total == output.matcher.pods * output.matcher.graph_mib
     error_message = "Fleet-wide graph memory must be the pod count times the graph."
   }
-}
 
-# A bigger shard cannot be offset by having fewer of them, because throughput
-# fixes the pod count. Coarsening therefore multiplies memory without reducing
-# pods, and tips the pool from CPU-bound to memory-bound.
-run "a_coarser_grid_costs_memory_without_saving_pods" {
-  command = plan
-
-  variables {
-    shards                 = ["r3gq", "r3gr", "r3gw", "r3gx", "r652", "r658"]
-    throughput_target_eps  = 800000
-    largest_shard_file_mib = 6.5
-  }
-
-  # A precision-4 shard is ~1/64 of a precision-2 one, so the pod shrinks to
-  # roughly its working set.
-  assert {
-    condition     = output.matcher.memory_mib < 1200
-    error_message = "A fine-grained shard should leave the working set dominant, got ${output.matcher.memory_mib}."
-  }
-
-  # The pod count is identical to the coarse case: geography never moved it.
+  # The pod count is identical to the small-shard case: geography never moved
+  # it, so a bigger shard multiplies memory with nothing removed to hold it.
   assert {
     condition     = output.matcher.pods == 168
     error_message = "Pod count must not depend on shard size, got ${output.matcher.pods}."
-  }
-
-  # And with the graph small, CPU is what binds — the graph is free.
-  assert {
-    condition     = length(regexall("CPU-bound", output.shard_memory_note)) > 0
-    error_message = "With a small graph the pool should be CPU-bound: ${output.shard_memory_note}"
   }
 }
 

--- a/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
+++ b/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
@@ -573,6 +573,102 @@ run "the_memory_model_reproduces_the_large_shard" {
   }
 }
 
+# Both directions of the shard-to-pod mapping are throughput statements, so one
+# expression covers them and the crossover needs no special case. Below the
+# knee a pod's capacity exceeds a shard's load and should absorb more
+# geography; above it a shard's load exceeds a pod and replicas split it.
+run "arity_collapses_the_low_end_pod_floor" {
+  command = plan
+
+  variables {
+    shards                 = run.shards.shards
+    throughput_target_eps  = 1000
+    max_shards_per_matcher = 8
+  }
+
+  # 1250 evt/s over 256 shards is 5 evt/s each, so a 6000 evt/s pod could hold
+  # over a thousand of them — the cap is what binds, not the arithmetic.
+  assert {
+    condition     = output.matcher.shards_per_pod == 8
+    error_message = "Expected the arity cap to bind at 8, got ${output.matcher.shards_per_pod}."
+  }
+
+  assert {
+    condition     = output.matcher.groups == 32
+    error_message = "256 shards at 8 per pod is 32 Deployments, got ${output.matcher.groups}."
+  }
+
+  # Where the old model needed 256 pods for 1250 evt/s, purely because a shard
+  # could not share a pod.
+  assert {
+    condition     = output.matcher.pods == 32
+    error_message = "Expected 32 pods, got ${output.matcher.pods}."
+  }
+
+  # A group only exists because its load fits one pod, so replicas stay at one.
+  assert {
+    condition     = output.matcher.replicas == 1
+    error_message = "A grouped shard set must not also need replicas, got ${output.matcher.replicas}."
+  }
+}
+
+# Arity has to disappear on its own as load rises, or it would cap throughput.
+# Once one shard fills a pod the relationship inverts back to replicas, which is
+# exactly what ships today.
+run "arity_self_disables_above_the_knee" {
+  command = plan
+
+  variables {
+    shards                 = run.shards.shards
+    throughput_target_eps  = 800000
+    max_shards_per_matcher = 8
+  }
+
+  # 1M over 256 shards is 3906 each, under one pod's 6000 — so grouping two
+  # would exceed it and the arity collapses to one.
+  assert {
+    condition     = output.matcher.shards_per_pod == 1
+    error_message = "At 3906 evt/s per shard the arity must be 1, got ${output.matcher.shards_per_pod}."
+  }
+
+  # Identical to the figures the model produced before arity existed.
+  assert {
+    condition     = output.matcher.pods == 256
+    error_message = "Above the knee the pod count must be unchanged by arity, got ${output.matcher.pods}."
+  }
+
+  assert {
+    condition     = output.matcher.groups == output.shard_count
+    error_message = "At arity 1 a group is a shard."
+  }
+}
+
+# A pod holding several shards holds several graphs, so arity trades pods for
+# per-pod memory. It is still a large net win, because the pod count falls
+# faster than the graph grows.
+run "arity_trades_pods_for_per_pod_memory" {
+  command = plan
+
+  variables {
+    shards                 = run.shards.shards
+    throughput_target_eps  = 1000
+    max_shards_per_matcher = 8
+    largest_shard_file_mib = 20.2
+  }
+
+  # Eight graphs and, conservatively, eight fixed terms.
+  assert {
+    condition     = output.matcher.memory_mib > 1263
+    error_message = "Eight shards in a pod must cost more memory than one, got ${output.matcher.memory_mib}."
+  }
+
+  # Fleet-wide it still falls: 32 pods of 8 graphs against 256 pods of one.
+  assert {
+    condition     = output.matcher.graph_mib_total < 256 * 1263
+    error_message = "Arity must reduce fleet-wide graph memory, got ${output.matcher.graph_mib_total}."
+  }
+}
+
 # The infra pool must never be packed to the point where losing one node costs
 # JetStream its quorum. Bin packing alone would happily do exactly that, since
 # a big node fits several brokers.

--- a/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
+++ b/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
@@ -97,16 +97,103 @@ run "the_two_halves_scale_independently" {
     error_message = "Expected an HPA ceiling of 4 replicas, got ${output.matcher.replicas_max}."
   }
 
-  # 1M / 8000 per pod = 125, snapped up to 128 so every pod takes exactly 8
+  # 1M / 40000 per pod = 25, snapped up to 32 so every pod takes exactly 32
   # partitions. The fleet is independent of the shard count entirely.
   assert {
-    condition     = output.fleet.size == 128
-    error_message = "Expected a fleet of 128, got ${output.fleet.size}."
+    condition     = output.fleet.size == 32
+    error_message = "Expected a fleet of 32, got ${output.fleet.size}."
   }
 
   assert {
-    condition     = output.fleet.partitions_per_pod == 8
-    error_message = "Expected 8 partitions per pod, got ${output.fleet.partitions_per_pod}."
+    condition     = output.fleet.partitions_per_pod == 32
+    error_message = "Expected 32 partitions per pod, got ${output.fleet.partitions_per_pod}."
+  }
+}
+
+# The orchestrator is an I/O scheduler with a compute cost, and the two bind
+# separately. Fusing them into one rate hid a concurrency shortfall as a
+# hardware requirement — the shipped 64 workers reach 8k evt/s against cores
+# worth 40k, so a pod sized for the cores could never use them.
+run "the_orchestrator_reports_which_ceiling_binds" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 800000
+  }
+
+  # 512 workers over an 8 ms round trip.
+  assert {
+    condition     = output.fleet.io_eps == 64000
+    error_message = "Expected 64000 evt/s of concurrency, got ${output.fleet.io_eps}."
+  }
+
+  # 2000 millicores at 50 microseconds an event.
+  assert {
+    condition     = output.fleet.cpu_eps == 40000
+    error_message = "Expected 40000 evt/s of compute, got ${output.fleet.cpu_eps}."
+  }
+
+  # The lower of the two is the pod's rate, and the profile is deliberately
+  # sized so compute is what binds: concurrency is cheap, cores are not.
+  assert {
+    condition     = output.fleet.eps_per_pod == 40000
+    error_message = "The pod's rate must be the lower bound, got ${output.fleet.eps_per_pod}."
+  }
+
+  assert {
+    condition     = output.fleet.bound == "compute"
+    error_message = "Expected the profile to be compute-bound, got ${output.fleet.bound}."
+  }
+
+  # Nothing stranded when compute binds: every core bought is reachable.
+  assert {
+    condition     = output.orchestrator_efficiency_note == ""
+    error_message = output.orchestrator_efficiency_note
+  }
+}
+
+# A profile with the chart's shipped worker count against these cores, to show
+# the failure the split exists to catch.
+run "a_concurrency_starved_profile_is_called_out" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 800000
+
+    profiles = {
+      starved = {
+        matcher_workers    = 10
+        matcher_cpu_millis = 2000
+        matcher_memory_mib = 3072
+        matcher_eps        = 6000
+
+        # The chart default, against a pod sized for far more.
+        orchestrator_workers              = 64
+        orchestrator_round_trip_ms        = 8
+        orchestrator_cpu_micros_per_event = 50
+        orchestrator_cpu_millis           = 2000
+        orchestrator_memory_mib           = 4096
+      }
+    }
+    vertical_profile = "starved"
+  }
+
+  assert {
+    condition     = output.fleet.bound == "concurrency"
+    error_message = "64 workers over an 8ms round trip must bind on concurrency, got ${output.fleet.bound}."
+  }
+
+  # 8k of 40k reachable, so four fifths of every pod's cores are unusable.
+  assert {
+    condition     = output.fleet.stranded_cpu_millis == 1600
+    error_message = "Expected 1600m stranded per pod, got ${output.fleet.stranded_cpu_millis}."
+  }
+
+  assert {
+    condition     = length(output.orchestrator_efficiency_note) > 0
+    error_message = "A concurrency-bound fleet must say so, and say that workers are the fix."
   }
 }
 

--- a/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
+++ b/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
@@ -682,6 +682,111 @@ run "cost_follows_the_fleet_that_would_be_built" {
   }
 }
 
+# A test environment is all floors and no throughput: one matcher per shard
+# whatever the load, an availability floor on the brokers, and a fixed
+# observability allowance. Under the dedicated layout each of those is a node
+# of its own, so the deployment costs six nodes to run seven pods.
+run "the_shared_layout_collapses_the_per_shape_node_floor" {
+  command = plan
+
+  variables {
+    machines              = { shared = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 30 } }
+    pool_layout           = "shared"
+    observability_enabled = false
+
+    shards                 = ["r1", "r3", "r6"]
+    shard_precision        = 2
+    binary_shard_precision = 2
+    throughput_target_eps  = 1000
+    design_target_eps      = 1000
+    vertical_profile       = "small"
+    largest_shard_file_mib = 413
+    pricing_commitment     = "spot"
+
+    nats_min_replicas           = 1
+    nats_cpu_millis             = 1000
+    nats_memory_mib             = 4096
+    valkey_replicas_per_primary = 0
+    valkey_cpu_millis           = 1000
+    valkey_memory_mib           = 2048
+    provisioned_iops            = 3000
+    provisioned_throughput_mib  = 140
+    collector_cpu_millis        = 500
+    collector_memory_mib        = 1024
+    matcher_working_set_mib     = 256
+  }
+
+  assert {
+    condition     = length(keys(output.pools)) == 1
+    error_message = "The shared layout must produce one pool, got ${join(", ", keys(output.pools))}."
+  }
+
+  # Three matchers, an orchestrator, a broker, a keyspace and a collector.
+  assert {
+    condition     = output.totals.pods == 7
+    error_message = "Expected 7 pods, got ${output.totals.pods}."
+  }
+
+  assert {
+    condition     = output.totals.nodes == 1
+    error_message = "The whole test deployment should fit one node, got ${output.totals.nodes}."
+  }
+
+  # Tight but real: 6000m of requests against 7310m allocatable. If a profile
+  # change pushes this over, the deployment silently needs a second node and
+  # doubles.
+  assert {
+    condition     = output.pools["shared"].cpu_utilisation < 1
+    error_message = "The shared pool is over-committed at ${output.pools["shared"].cpu_utilisation}."
+  }
+
+  # The budget this layout exists to hit. The cluster fee is nearly a third of
+  # it, which is why a test environment wants a zonal cluster.
+  assert {
+    condition     = output.cost.total < 250
+    error_message = "Expected the test tier under $250/month, got ${output.cost.total}."
+  }
+
+  assert {
+    condition     = output.cost.cluster_fee > output.cost.storage.total
+    error_message = "At this size the cluster fee outweighs all storage, which is worth knowing before optimising disks."
+  }
+}
+
+# The brokers' spread floor has to follow them into whichever pool holds them,
+# or the shared layout would quietly drop the guarantee.
+run "the_broker_spread_floor_follows_the_layout" {
+  command = plan
+
+  variables {
+    machines              = { shared = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 60 } }
+    pool_layout           = "shared"
+    observability_enabled = false
+
+    shards                 = ["r1", "r3", "r6"]
+    shard_precision        = 2
+    binary_shard_precision = 2
+    throughput_target_eps  = 1000
+    design_target_eps      = 1000
+    vertical_profile       = "small"
+    largest_shard_file_mib = 413
+
+    # Three brokers on one pool: the spread floor must still force three nodes,
+    # even though every pod would otherwise fit on one.
+    nats_min_replicas = 3
+  }
+
+  assert {
+    condition     = output.nats.spread_nodes == 2
+    error_message = "A 3-server cluster needs 2 nodes to survive a loss, got ${output.nats.spread_nodes}."
+  }
+
+  assert {
+    condition     = output.totals.nodes >= output.nats.spread_nodes
+    error_message = "The shared pool must still honour the broker spread floor."
+  }
+}
+
 # Coverage is how a shard list generated over the wrong extent is caught before
 # it becomes a fleet of idle matchers.
 run "coverage_catches_shards_outside_the_service_region" {

--- a/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
+++ b/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
@@ -505,6 +505,76 @@ run "finer_geography_costs_pods_rather_than_saving_them" {
   }
 }
 
+# A matcher's memory is its shard's graph, measured rather than assumed: `r1`
+# is 413 MiB on disk and 3.31 GB resident. The file understates the pod by
+# 7.6x, which is why sizing a matcher from its shard file would OOM it.
+run "matcher_memory_is_derived_from_the_measured_shard" {
+  command = plan
+
+  variables {
+    shards                 = ["r3gq", "r3gr", "r3gw", "r3gx", "r652", "r658"]
+    throughput_target_eps  = 800000
+    largest_shard_file_mib = 413
+  }
+
+  # 413 MiB at 7.6x.
+  assert {
+    condition     = output.matcher.graph_mib == 3139
+    error_message = "Expected a 3139 MiB resident graph, got ${output.matcher.graph_mib}."
+  }
+
+  # The graph plus the working set, and above the 3072 MiB the chart used to
+  # hardcode — which the graph alone would already have exceeded.
+  assert {
+    condition     = output.matcher.memory_mib == 4163
+    error_message = "Expected 4163 MiB per matcher, got ${output.matcher.memory_mib}."
+  }
+
+  assert {
+    condition     = output.matcher.memory_mib > 3072
+    error_message = "A shard this size no longer fits the chart's old flat 3072 MiB limit, and the model must say so."
+  }
+
+  # Every replica loads its shard's whole graph, so the fleet holds the same
+  # geography many times over. This is the cost coarse shards actually carry.
+  assert {
+    condition     = output.matcher.graph_mib_total == output.matcher.pods * output.matcher.graph_mib
+    error_message = "Fleet-wide graph memory must be the pod count times the graph."
+  }
+}
+
+# A bigger shard cannot be offset by having fewer of them, because throughput
+# fixes the pod count. Coarsening therefore multiplies memory without reducing
+# pods, and tips the pool from CPU-bound to memory-bound.
+run "a_coarser_grid_costs_memory_without_saving_pods" {
+  command = plan
+
+  variables {
+    shards                 = ["r3gq", "r3gr", "r3gw", "r3gx", "r652", "r658"]
+    throughput_target_eps  = 800000
+    largest_shard_file_mib = 6.5
+  }
+
+  # A precision-4 shard is ~1/64 of a precision-2 one, so the pod shrinks to
+  # roughly its working set.
+  assert {
+    condition     = output.matcher.memory_mib < 1200
+    error_message = "A fine-grained shard should leave the working set dominant, got ${output.matcher.memory_mib}."
+  }
+
+  # The pod count is identical to the coarse case: geography never moved it.
+  assert {
+    condition     = output.matcher.pods == 168
+    error_message = "Pod count must not depend on shard size, got ${output.matcher.pods}."
+  }
+
+  # And with the graph small, CPU is what binds — the graph is free.
+  assert {
+    condition     = length(regexall("CPU-bound", output.shard_memory_note)) > 0
+    error_message = "With a small graph the pool should be CPU-bound: ${output.shard_memory_note}"
+  }
+}
+
 # The infra pool must never be packed to the point where losing one node costs
 # JetStream its quorum. Bin packing alone would happily do exactly that, since
 # a big node fits several brokers.

--- a/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
+++ b/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
@@ -354,6 +354,70 @@ run "a_shard_that_cannot_be_scaled_recommends_a_finer_precision" {
   }
 }
 
+# Shards divide the pod count rather than multiplying it, so the two cancel and
+# the fleet size is set by throughput alone. What survives the cancellation is
+# the per-shard rounding, which finer geography pays more often — the opposite
+# of the intuition that fewer, bigger shards mean fewer pods.
+run "the_matcher_count_follows_throughput_not_geography" {
+  command = plan
+
+  variables {
+    shards                = ["r3gq", "r3gr", "r3gw", "r3gx", "r652", "r658"]
+    throughput_target_eps = 800000
+  }
+
+  # 1M evt/s over 6000 per pod.
+  assert {
+    condition     = output.matcher.pods_floor == 167
+    error_message = "Expected a 167-pod throughput floor, got ${output.matcher.pods_floor}."
+  }
+
+  # Six shards land within one pod of it: 28 replicas each is 168.
+  assert {
+    condition     = output.matcher.pods == 168
+    error_message = "Expected 168 pods at 6 shards, got ${output.matcher.pods}."
+  }
+
+  assert {
+    condition     = output.matcher.rounding_overhead < 1.02
+    error_message = "Coarse geography should sit within 2% of the floor, got ${output.matcher.rounding_overhead}x."
+  }
+}
+
+# The same target over a finer grid costs more pods, not fewer: every shard
+# rounds its replicas up to a whole pod, and there are more shards to round.
+run "finer_geography_costs_pods_rather_than_saving_them" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 800000
+  }
+
+  # 256 shards at 3906 evt/s each: one replica apiece, well under a pod's
+  # 6000, so more than half of every pod is bought and idle.
+  assert {
+    condition     = output.matcher.replicas == 1
+    error_message = "Expected the one-replica minimum at 256 shards, got ${output.matcher.replicas}."
+  }
+
+  assert {
+    condition     = output.matcher.pods == 256
+    error_message = "Expected 256 pods, got ${output.matcher.pods}."
+  }
+
+  assert {
+    condition     = output.matcher.pods > output.matcher.pods_floor
+    error_message = "A grid finer than the throughput floor must cost pods over it."
+  }
+
+  # Past the floor in shard count, the pod count simply follows the shards.
+  assert {
+    condition     = output.shard_count > output.matcher.pods_floor
+    error_message = "This fixture is meant to sit past the throughput floor in shard count."
+  }
+}
+
 # The infra pool must never be packed to the point where losing one node costs
 # JetStream its quorum. Bin packing alone would happily do exactly that, since
 # a big node fits several brokers.

--- a/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
+++ b/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
@@ -8,8 +8,8 @@
 variables {
   machines = {
     matcher  = { machine_type = "c4-highcpu-32", vcpu = 32, memory_gib = 64 }
-    pipeline = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
-    infra    = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+    pipeline = { machine_type = "c4-highcpu-16", vcpu = 16, memory_gib = 32 }
+    infra    = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
     system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
   }
 
@@ -351,6 +351,66 @@ run "a_shard_that_cannot_be_scaled_recommends_a_finer_precision" {
   assert {
     condition     = output.recommended_precision > 4
     error_message = "A shard deficit must recommend a finer precision, got ${output.recommended_precision}."
+  }
+}
+
+# The infra pool must never be packed to the point where losing one node costs
+# JetStream its quorum. Bin packing alone would happily do exactly that, since
+# a big node fits several brokers.
+run "the_infra_pool_keeps_the_brokers_spread" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 800000
+  }
+
+  # A node may hold at most half the cluster short of one.
+  assert {
+    condition     = output.nats.spread_nodes >= ceil(output.nats.replicas_total / 2)
+    error_message = "A ${output.nats.replicas_total}-server cluster needs at least ${ceil(output.nats.replicas_total / 2)} nodes, got ${output.nats.spread_nodes}."
+  }
+
+  assert {
+    condition     = output.pools["infra"].min_node_count >= output.nats.spread_nodes
+    error_message = "The infra pool floors at ${output.pools["infra"].min_node_count} nodes but the brokers need ${output.nats.spread_nodes} to spread across."
+  }
+
+  # Losing the most loaded node must leave a majority behind.
+  assert {
+    condition     = (output.nats.replicas_total - ceil(output.nats.replicas_total / output.nats.spread_nodes)) > (output.nats.replicas_total / 2)
+    error_message = "Losing one infra node would take ${ceil(output.nats.replicas_total / output.nats.spread_nodes)} of ${output.nats.replicas_total} servers, costing quorum."
+  }
+}
+
+# Capacity and performance are separate constraints on the file store. Sizing
+# the volume for the retention window says nothing about whether it can absorb
+# the write rate, which is why both are derived.
+run "the_file_store_is_sized_for_rate_as_well_as_volume" {
+  command = plan
+
+  variables {
+    shards                = run.shards.shards
+    throughput_target_eps = 800000
+  }
+
+  # 1M evt/s of raw at 256B plus 1M emissions at 2KiB, over 5 servers.
+  assert {
+    condition     = output.jetstream_disk.write_mib_per_server == 440
+    error_message = "Expected 440 MiB/s per server, got ${output.jetstream_disk.write_mib_per_server}."
+  }
+
+  assert {
+    condition     = output.jetstream_disk.iops_per_server == 25000
+    error_message = "Expected 25000 IOPS per server, got ${output.jetstream_disk.iops_per_server}."
+  }
+
+  # The matched stream is most of the bytes, because an emission carries the
+  # whole cut trip rather than a delta. If this ever inverts, the retention
+  # policy is no longer what dominates the disk.
+  assert {
+    condition     = var.matched_event_bytes > var.raw_event_bytes * 4
+    error_message = "The disk model assumes emissions dominate ingest by volume."
   }
 }
 

--- a/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
+++ b/infrastructure/terraform/modules/capacity/tests/capacity.tftest.hcl
@@ -9,8 +9,8 @@ variables {
   machines = {
     matcher  = { machine_type = "c4-highcpu-32", vcpu = 32, memory_gib = 64 }
     pipeline = { machine_type = "c4-highcpu-16", vcpu = 16, memory_gib = 32 }
-    infra    = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 64 }
-    system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 32 }
+    infra    = { machine_type = "c4-standard-16", vcpu = 16, memory_gib = 60 }
+    system   = { machine_type = "c4-standard-8", vcpu = 8, memory_gib = 30 }
   }
 
   shard_precision = 4
@@ -475,6 +475,55 @@ run "the_file_store_is_sized_for_rate_as_well_as_volume" {
   assert {
     condition     = var.matched_event_bytes > var.raw_event_bytes * 4
     error_message = "The disk model assumes emissions dominate ingest by volume."
+  }
+}
+
+# Cost is derived from the same pod shapes as the node counts, so it cannot
+# describe a fleet other than the one that would be built. These pin the
+# arithmetic, not the rates — a price change moves the totals and should.
+run "cost_follows_the_fleet_that_would_be_built" {
+  command = plan
+
+  variables {
+    shards                = ["r3gq", "r3gr", "r3gw", "r3gx", "r652", "r658"]
+    throughput_target_eps = 800000
+  }
+
+  # Nodes are bought whole, so the pool total is count times rate.
+  assert {
+    condition = (
+      output.cost.by_pool["matcher"]
+      == output.pools["matcher"].min_node_count * var.prices.machines["c4-highcpu-32"].on_demand
+    )
+    error_message = "The matcher pool's cost must be its node count at its machine's rate."
+  }
+
+  # Attribution splits the pools without inventing or losing money.
+  assert {
+    condition     = abs(sum(values(output.cost.by_service)) - output.cost.compute) < 1
+    error_message = "Per-service attribution (${sum(values(output.cost.by_service))}) must reconcile with compute (${output.cost.compute})."
+  }
+
+  assert {
+    condition = abs(
+      output.cost.total - (output.cost.compute + output.cost.storage.total + output.cost.cluster_fee)
+    ) < 1
+    error_message = "The total must be compute plus storage plus the cluster fee."
+  }
+
+  # Only what exceeds the class baseline is billable, and the brokers are well
+  # past it — so most of the file store's cost is performance, not capacity.
+  assert {
+    condition     = output.cost.storage.jetstream_performance > output.cost.storage.jetstream_capacity
+    error_message = "Provisioned performance should dominate the file store's cost at this write rate."
+  }
+
+  # Committing buys nothing on disk or the cluster fee, so the saving is
+  # bounded by the compute share and a three-year term cannot halve the bill
+  # without also being most of it.
+  assert {
+    condition     = output.cost.compute / output.cost.total > 0.9
+    error_message = "Compute should dominate; if it does not, the storage model has drifted."
   }
 }
 

--- a/infrastructure/terraform/modules/capacity/tests/setup/main.tf
+++ b/infrastructure/terraform/modules/capacity/tests/setup/main.tf
@@ -1,0 +1,34 @@
+# Generates the synthetic shard list the tests run against.
+#
+# It lives in a module because a `tofu test` variables block cannot call
+# functions, and a few hundred shards is not something to write out by hand.
+# Run it with `command = apply` — a plan leaves the outputs unknown.
+
+variable "prefixes" {
+  description = "Leading geohash characters to fan out from, each of length precision - 2."
+  type        = list(string)
+}
+
+variable "shards_per_prefix" {
+  description = "Shards generated under each prefix. Capped at 32 so the last two characters stay a valid geohash pair."
+  type        = number
+  default     = 32
+
+  validation {
+    condition     = var.shards_per_prefix >= 1 && var.shards_per_prefix <= 32
+    error_message = "shards_per_prefix must be in 1..32; the geohash alphabet has 32 symbols."
+  }
+}
+
+locals {
+  # The geohash alphabet: base32 without a, i, l or o.
+  alphabet = split("", "0123456789bcdefghjkmnpqrstuvwxyz")
+}
+
+output "shards" {
+  value = flatten([
+    for prefix in var.prefixes : [
+      for i in range(var.shards_per_prefix) : "${prefix}${local.alphabet[i]}"
+    ]
+  ])
+}

--- a/infrastructure/terraform/modules/capacity/variables.tf
+++ b/infrastructure/terraform/modules/capacity/variables.tf
@@ -214,6 +214,61 @@ variable "matcher_working_set_mib" {
   default     = 1024
 }
 
+variable "max_shards_per_matcher" {
+  description = <<-EOT
+    How many shards one matcher instance may serve — the arity of the
+    shard-to-pod mapping, in the direction the current code cannot express.
+
+    Both directions of that mapping are throughput statements, and only one
+    applies at a time:
+
+      many pods per shard   a shard's load exceeds one pod, so replicas split
+                            it through the queue group. This is what happens
+                            above the knee, and it is what ships today.
+      many shards per pod   a pod's capacity exceeds a shard's load, so the
+                            spare is filled with more geography. This is what
+                            the low end needs, and 1 forbids it.
+
+    At 1 the model reproduces today's behaviour: one Deployment per shard, and
+    a floor of one pod per shard however little traffic there is. That floor is
+    the entire bill below the knee.
+
+    Above 1 this needs a matcher change. `ShardLoader::load` already returns a
+    separate network per shard from a cache map, and the request subject's last
+    token says which shard a request belongs to, so a pod can hold several
+    networks and pick per request — the per-shard solver is unchanged, there
+    are just several of it in one process. Nothing on the wire moves: the
+    orchestrator still addresses `events.match.<shard>` and does not care which
+    pod answers.
+  EOT
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.max_shards_per_matcher >= 1 && floor(var.max_shards_per_matcher) == var.max_shards_per_matcher
+    error_message = "max_shards_per_matcher must be a whole number of at least 1."
+  }
+}
+
+variable "shard_memory_fixed_is_per_process" {
+  description = <<-EOT
+    Whether `shard_memory_fixed_mib` is paid once per pod or once per shard.
+
+    Unresolved, and it decides whether arity saves memory as well as pods. Both
+    measurements come from a process holding exactly one network, so they
+    cannot separate a per-process cost (runtime, allocator arenas) from a
+    per-network one (index structures that do not scale with the graph).
+
+    Defaulted to per-shard, which is the conservative direction: it assumes
+    arity saves nothing on memory and wins only on pod count. Loading two
+    shards into one matcher and reading its RSS would settle it, and if the
+    cost is per-process then arity 6 also saves five times the fixed term per
+    pod.
+  EOT
+  type        = bool
+  default     = false
+}
+
 variable "hot_shard_replica_factor" {
   description = <<-EOT
     Ceiling multiplier for a shard's matcher HPA, over the replica count the

--- a/infrastructure/terraform/modules/capacity/variables.tf
+++ b/infrastructure/terraform/modules/capacity/variables.tf
@@ -414,6 +414,25 @@ variable "jetstream_stream_replicas" {
   default     = 1
 }
 
+variable "jetstream_messages_per_write" {
+  description = <<-EOT
+    Messages a stream commits per disk write.
+
+    JetStream appends and fsyncs in batches rather than once per message, so
+    the volume's operation count is well under the message rate. The softest
+    number in the disk model, and it only sets IOPS — throughput is derived
+    from bytes and is usually what binds first, since the appends are
+    sequential.
+  EOT
+  type        = number
+  default     = 16
+
+  validation {
+    condition     = var.jetstream_messages_per_write >= 1
+    error_message = "jetstream_messages_per_write must be at least 1."
+  }
+}
+
 variable "raw_event_bytes" {
   description = "Wire size of one postcard-encoded raw event, including its JetStream framing and subject. Sizes the work-queue backlog on disk."
   type        = number

--- a/infrastructure/terraform/modules/capacity/variables.tf
+++ b/infrastructure/terraform/modules/capacity/variables.tf
@@ -117,11 +117,16 @@ variable "shard_fanout_per_precision" {
 
     Geohash grows 32x per level, but populated cells grow far slower: a road
     network is close to one-dimensional inside a two-dimensional cell, so
-    subdividing mostly yields empty children. Recalibrate by generating shards
-    at two adjacent precisions and taking the ratio.
+    subdividing mostly yields empty children.
+
+    Calibrated from the shard files rather than guessed. The same network split
+    two levels apart gives `r1` at 433 MB and `r3gr` at 21.2 MB — a factor of
+    20 across two levels, so about 4.5 per level. Total network size is fixed,
+    so a shard shrinking 4.5x per level is the same statement as the shard
+    count growing 4.5x.
   EOT
   type        = number
-  default     = 8
+  default     = 4.5
 
   validation {
     condition     = var.shard_fanout_per_precision > 1
@@ -135,15 +140,19 @@ variable "largest_shard_file_mib" {
 
     The largest and not the mean, because the chart gives every matcher
     Deployment the same limit, so it has to fit the worst shard rather than the
-    typical one. Measured, not estimated: `r1` — the largest in Australia, at
-    precision 2 — is 433 MB, which is 413 MiB.
+    typical one.
 
-    Re-measure it when the precision changes. A shard's size is roughly the
-    network divided by the shard count, so a level of precision cuts it by
-    about the same factor it multiplies the shard count by.
+    Measured, not estimated. At the deployed precision 4, `r3gr` over Sydney is
+    21.2 MB — 20.2 MiB — and is the densest cell in the shipped set. For
+    comparison, `r1` at precision 2 is 433 MB (413 MiB), which is the figure to
+    use if the grid is ever coarsened.
+
+    Re-measure when the precision changes rather than scaling it: the two
+    measurements put the real fan-out at about 4.5x per level, not the 32x the
+    geohash grid suggests.
   EOT
   type        = number
-  default     = 413
+  default     = 20.2
 
   validation {
     condition     = var.largest_shard_file_mib > 0
@@ -151,23 +160,45 @@ variable "largest_shard_file_mib" {
   }
 }
 
-variable "shard_memory_expansion" {
+variable "shard_memory_slope" {
   description = <<-EOT
-    Resident bytes per byte of `.shard.rt` once loaded.
+    Resident MiB per MiB of `.shard.rt`, for the part that scales with the
+    graph.
 
-    Measured at 7.6: `r1` is 413 MiB on disk and 3.31 GB resident before any
-    other cache is populated. The graph is deserialised into nodes, edges and
-    their indices, so the on-disk form is far more compact than the working
-    one — which is why sizing a matcher from its file size understates it by
-    almost an order of magnitude.
+    A single expansion ratio does not describe this. Two measurements:
+
+      r1    413 MiB on disk -> 3.31 GB resident   7.6x
+      r3gr   20 MiB on disk ->  250 MB resident  11.8x
+
+    The smaller shard expands further, which is the signature of a fixed cost
+    rather than a varying ratio. Fitting a line through both gives 7.43x on the
+    graph itself plus `shard_memory_fixed_mib` of overhead, and that recovers
+    each measurement to within a percent.
+
+    Using either ratio as a constant would be wrong in one direction or the
+    other: 7.6x understates a small shard's pod by a third, and 11.8x
+    over-provisions a large one by 1.8 GB.
   EOT
   type        = number
-  default     = 7.6
+  default     = 7.43
 
   validation {
-    condition     = var.shard_memory_expansion >= 1
-    error_message = "shard_memory_expansion must be at least 1; a loaded graph cannot be smaller than its file."
+    condition     = var.shard_memory_slope >= 1
+    error_message = "shard_memory_slope must be at least 1; a loaded graph cannot be smaller than its file."
   }
+}
+
+variable "shard_memory_fixed_mib" {
+  description = <<-EOT
+    Resident memory a matcher holds regardless of its shard's size: the
+    runtime, the allocator's arenas, and the parts of the index that do not
+    scale with the network.
+
+    The intercept of the fit through the two measurements. It is what makes a
+    small shard look like a worse deal per byte than a large one.
+  EOT
+  type        = number
+  default     = 88
 }
 
 variable "matcher_working_set_mib" {

--- a/infrastructure/terraform/modules/capacity/variables.tf
+++ b/infrastructure/terraform/modules/capacity/variables.tf
@@ -129,6 +129,60 @@ variable "shard_fanout_per_precision" {
   }
 }
 
+variable "largest_shard_file_mib" {
+  description = <<-EOT
+    The biggest `<shard>.shard.rt` in the deployed set, on disk.
+
+    The largest and not the mean, because the chart gives every matcher
+    Deployment the same limit, so it has to fit the worst shard rather than the
+    typical one. Measured, not estimated: `r1` — the largest in Australia, at
+    precision 2 — is 433 MB, which is 413 MiB.
+
+    Re-measure it when the precision changes. A shard's size is roughly the
+    network divided by the shard count, so a level of precision cuts it by
+    about the same factor it multiplies the shard count by.
+  EOT
+  type        = number
+  default     = 413
+
+  validation {
+    condition     = var.largest_shard_file_mib > 0
+    error_message = "largest_shard_file_mib must be positive."
+  }
+}
+
+variable "shard_memory_expansion" {
+  description = <<-EOT
+    Resident bytes per byte of `.shard.rt` once loaded.
+
+    Measured at 7.6: `r1` is 413 MiB on disk and 3.31 GB resident before any
+    other cache is populated. The graph is deserialised into nodes, edges and
+    their indices, so the on-disk form is far more compact than the working
+    one — which is why sizing a matcher from its file size understates it by
+    almost an order of magnitude.
+  EOT
+  type        = number
+  default     = 7.6
+
+  validation {
+    condition     = var.shard_memory_expansion >= 1
+    error_message = "shard_memory_expansion must be at least 1; a loaded graph cannot be smaller than its file."
+  }
+}
+
+variable "matcher_working_set_mib" {
+  description = <<-EOT
+    Memory a matcher needs above its graph: the candidate caches and one
+    trellis per concurrent solve, plus allocator headroom.
+
+    Sized alongside the graph rather than inside the profile because it scales
+    with `matcher_workers`, and the graph does not scale with anything the
+    profile controls.
+  EOT
+  type        = number
+  default     = 1024
+}
+
 variable "hot_shard_replica_factor" {
   description = <<-EOT
     Ceiling multiplier for a shard's matcher HPA, over the replica count the
@@ -259,7 +313,6 @@ variable "profiles" {
   type = map(object({
     matcher_workers    = number
     matcher_cpu_millis = number
-    matcher_memory_mib = number
     matcher_eps        = number
 
     orchestrator_workers              = number
@@ -273,7 +326,6 @@ variable "profiles" {
     small = {
       matcher_workers    = 5
       matcher_cpu_millis = 1000
-      matcher_memory_mib = 3072
       matcher_eps        = 1500
 
       orchestrator_workers              = 64
@@ -294,7 +346,6 @@ variable "profiles" {
     standard = {
       matcher_workers    = 10
       matcher_cpu_millis = 2000
-      matcher_memory_mib = 3072
       matcher_eps        = 6000
 
       orchestrator_workers              = 512
@@ -310,7 +361,6 @@ variable "profiles" {
     large = {
       matcher_workers    = 24
       matcher_cpu_millis = 6000
-      matcher_memory_mib = 6144
       matcher_eps        = 16000
 
       orchestrator_workers              = 2048

--- a/infrastructure/terraform/modules/capacity/variables.tf
+++ b/infrastructure/terraform/modules/capacity/variables.tf
@@ -614,6 +614,109 @@ variable "collector_memory_mib" {
   default     = 2048
 }
 
+# --- Cost -------------------------------------------------------------------
+
+variable "pricing_commitment" {
+  description = <<-EOT
+    Which rate to cost the compute at.
+
+    Commitments apply to the nodes only; disk and the cluster fee are charged
+    the same either way. Spot is priced here for comparison and is not a
+    configuration this deployment should adopt wholesale — an orchestrator's
+    partitions have no other owner while it reschedules.
+  EOT
+  type        = string
+  default     = "on_demand"
+
+  validation {
+    condition     = contains(["on_demand", "cud_1y", "cud_3y", "spot"], var.pricing_commitment)
+    error_message = "pricing_commitment must be on_demand, cud_1y, cud_3y or spot."
+  }
+}
+
+variable "boot_disk_gib" {
+  description = "Boot disk per node, matching the platform module's `node_disk_size_gb`. Image layers under streaming, so it holds little and is priced at the class baseline."
+  type        = number
+  default     = 100
+}
+
+variable "provisioned_iops" {
+  description = "IOPS provisioned per file store volume, matching the devstack. Only what exceeds the class baseline is billable."
+  type        = number
+  default     = 30000
+}
+
+variable "provisioned_throughput_mib" {
+  description = "MiB/s provisioned per file store volume, matching the devstack. Only what exceeds the class baseline is billable."
+  type        = number
+  default     = 750
+}
+
+variable "prices" {
+  description = <<-EOT
+    Monthly rates, in USD.
+
+    Read for australia-southeast1 (Sydney) on 2026-08-05. Sydney is well above
+    the US regions — roughly 1.35x — so these do not transfer to another
+    region by inspection.
+
+    The machine rates are per node per month at 730 hours, taken from the
+    published per-region tables. The Hyperdisk figures are the weaker set: the
+    per-GiB Sydney rate was not published in a form that could be read
+    directly and is extrapolated from the Sydney/US ratio on pd-balanced,
+    while the IOPS and throughput rates are the published US figures and are
+    probably understated for Sydney. Treat the storage lines as an estimate
+    and the compute lines as quotes.
+
+    Confirm against the billing account before anything depends on the total.
+  EOT
+
+  type = object({
+    machines = map(object({
+      on_demand = number
+      cud_1y    = number
+      cud_3y    = number
+      spot      = number
+    }))
+
+    hyperdisk_balanced_gib = number
+    hyperdisk_iops         = number
+    hyperdisk_mib          = number
+    hyperdisk_free_iops    = number
+    hyperdisk_free_mib     = number
+
+    gke_cluster_hour = number
+  })
+
+  default = {
+    # Per node per month at 730 hours. Spot is the hourly rate scaled the same
+    # way, for comparison rather than for use.
+    machines = {
+      "c4-highcpu-32"  = { on_demand = 1241.76, cud_1y = 782.33, cud_3y = 558.80, spot = 548.52 }
+      "c4-highcpu-16"  = { on_demand = 620.88, cud_1y = 391.16, cud_3y = 279.40, spot = 274.26 }
+      "c4-standard-16" = { on_demand = 721.50, cud_1y = 454.55, cud_3y = 324.67, spot = 318.72 }
+      "c4-standard-8"  = { on_demand = 360.75, cud_1y = 227.28, cud_3y = 162.34, spot = 159.36 }
+    }
+
+    # Estimated from the Sydney/US ratio on pd-balanced, which is published at
+    # $0.135/GB there against $0.10 in the US.
+    hyperdisk_balanced_gib = 0.147
+
+    # Published US rates for provisioning above the baseline. Sydney is
+    # probably higher, so these understate the storage line.
+    hyperdisk_iops = 0.005
+    hyperdisk_mib  = 0.040
+
+    # The baseline every Hyperdisk Balanced volume includes at no charge.
+    hyperdisk_free_iops = 3000
+    hyperdisk_free_mib  = 140
+
+    # One regional cluster. A billing account gets one zonal cluster free,
+    # which a regional cluster is not.
+    gke_cluster_hour = 0.10
+  }
+}
+
 # --- Nodes ------------------------------------------------------------------
 
 variable "machines" {

--- a/infrastructure/terraform/modules/capacity/variables.tf
+++ b/infrastructure/terraform/modules/capacity/variables.tf
@@ -832,12 +832,58 @@ variable "prices" {
 # --- Nodes ------------------------------------------------------------------
 
 variable "machines" {
-  description = "Machine shape per node pool. `vcpu` and `memory_gib` must match `machine_type`; the model derives allocatable capacity from them."
+  description = <<-EOT
+    Machine shape per node pool. `vcpu` and `memory_gib` must match
+    `machine_type`; the model derives allocatable capacity from them.
+
+    Keys are the pool names: `matcher`, `pipeline`, `infra` and `system` under
+    the default layout, or just `shared` when `pool_layout` is `shared`.
+  EOT
   type = map(object({
     machine_type = string
     vcpu         = number
     memory_gib   = number
   }))
+}
+
+variable "pool_layout" {
+  description = <<-EOT
+    How workloads are distributed over node pools.
+
+    `dedicated` gives each tier its own tainted pool, which is what a real
+    deployment wants: matchers get a compute-optimised shape, the brokers are
+    kept off it, and one tier's autoscaling cannot evict another's pods. It
+    also sets a floor of one node per pod shape — six shapes, so six nodes —
+    which is irrelevant at scale and dominant at nothing.
+
+    `shared` puts everything in one untainted pool. It exists for a test
+    environment, where the whole deployment is a handful of pods and the floor
+    is the entire bill. Do not use it for anything carrying load: a matcher
+    scaling up would then compete with the broker holding its stream.
+  EOT
+  type        = string
+  default     = "dedicated"
+
+  validation {
+    condition     = contains(["dedicated", "shared"], var.pool_layout)
+    error_message = "pool_layout must be 'dedicated' or 'shared'."
+  }
+}
+
+variable "observability_enabled" {
+  description = <<-EOT
+    Whether kube-prometheus-stack is installed, mirroring the devstack flag of
+    the same name.
+
+    Its allowance is 6 pods, 4 cores and 16 GiB, which is a rounding error
+    against a production fleet and the largest single shape in a test one — it
+    alone forces a node. The collector is not covered by this and is always
+    counted: the services have no metrics endpoint, so spans are the only
+    telemetry they emit and dropping it makes the pipeline blind rather than
+    unmonitored.
+  EOT
+  type        = bool
+  default     = true
 }
 
 variable "max_pods_per_node" {

--- a/infrastructure/terraform/modules/capacity/variables.tf
+++ b/infrastructure/terraform/modules/capacity/variables.tf
@@ -229,64 +229,95 @@ variable "profiles" {
   description = <<-EOT
     Vertical scaling steps.
 
-    `matcher_eps` is the sustained request rate one matcher replica serves, and
-    `orchestrator_eps` the sustained rate one orchestrator pod drives. The two
-    are independent now: a matcher is a pure request/reply solver behind a
-    queue group, and an orchestrator owns vehicle partitions rather than
-    geography, so neither is pinned to the other's count.
+    `matcher_eps` is the sustained request rate one matcher replica serves. It
+    is CPU-bound work — a Viterbi solve fanned across rayon — so one number
+    describes it.
 
-    Both are estimates from the shipped worker defaults, not measurements. The
-    orchestrator figure is the softer of the two: a worker holds its vehicle's
-    lane across the whole round trip — solve, broker-confirmed publish, batched
-    archive flush — so the pod's ceiling is `workers / mean_round_trip`, and
-    the round trip is dominated by parts this model cannot see.
+    The orchestrator is not, and a single number hid that. It is mostly an I/O
+    scheduler: a worker holds its vehicle's lane across the whole round trip —
+    solve, broker-confirmed publish, batched archive flush — and spends almost
+    all of that awaiting rather than computing. So its ceiling is whichever of
+    two independent bounds binds first:
+
+      concurrency   `workers / round_trip`. Workers are tokio tasks, so this
+                    bound is cheap to raise and has nothing to do with cores.
+
+      compute       the real per-event CPU: decode, context assembly,
+                    reconcile, encode. This is what the CPU request buys.
+
+    Holding them apart matters because they are measured differently and fixed
+    differently. A pod short on concurrency is one config change away from
+    twice the throughput on the same cores; a pod short on CPU is not. Fusing
+    them into one `orchestrator_eps` made a concurrency shortfall look like a
+    hardware requirement, and bought cores that could not be used.
+
+    Every figure here is an estimate from the shipped defaults rather than a
+    measurement. `orchestrator_round_trip_ms` and
+    `orchestrator_cpu_micros_per_event` are the two worth measuring first,
+    because between them they set the whole pipeline pool.
   EOT
   type = map(object({
-    matcher_workers         = number
-    matcher_cpu_millis      = number
-    matcher_memory_mib      = number
-    matcher_eps             = number
-    orchestrator_workers    = number
-    orchestrator_cpu_millis = number
-    orchestrator_memory_mib = number
-    orchestrator_eps        = number
+    matcher_workers    = number
+    matcher_cpu_millis = number
+    matcher_memory_mib = number
+    matcher_eps        = number
+
+    orchestrator_workers              = number
+    orchestrator_round_trip_ms        = number
+    orchestrator_cpu_micros_per_event = number
+    orchestrator_cpu_millis           = number
+    orchestrator_memory_mib           = number
   }))
 
   default = {
     small = {
-      matcher_workers         = 5
-      matcher_cpu_millis      = 1000
-      matcher_memory_mib      = 3072
-      matcher_eps             = 1500
-      orchestrator_workers    = 16
-      orchestrator_cpu_millis = 500
-      orchestrator_memory_mib = 1024
-      orchestrator_eps        = 2000
+      matcher_workers    = 5
+      matcher_cpu_millis = 1000
+      matcher_memory_mib = 3072
+      matcher_eps        = 1500
+
+      orchestrator_workers              = 64
+      orchestrator_round_trip_ms        = 8
+      orchestrator_cpu_micros_per_event = 50
+      orchestrator_cpu_millis           = 500
+      orchestrator_memory_mib           = 1024
     }
 
-    # The calibration anchor: the chart's shipped worker counts.
+    # The calibration anchor. Concurrency is sized so neither bound wastes the
+    # other: 512 workers at an 8 ms round trip is 64k evt/s of scheduling
+    # against 40k evt/s of CPU, so the pod is compute-bound with the
+    # concurrency to keep those cores fed through a latency spike.
+    #
+    # The chart's shipped 64 workers is 8k evt/s — a fifth of what the same
+    # cores can do — so a pod sized this way and left at that count would buy
+    # CPU it could never reach.
     standard = {
-      matcher_workers         = 10
-      matcher_cpu_millis      = 2000
-      matcher_memory_mib      = 3072
-      matcher_eps             = 6000
-      orchestrator_workers    = 64
-      orchestrator_cpu_millis = 1000
-      orchestrator_memory_mib = 1024
-      orchestrator_eps        = 8000
+      matcher_workers    = 10
+      matcher_cpu_millis = 2000
+      matcher_memory_mib = 3072
+      matcher_eps        = 6000
+
+      orchestrator_workers              = 512
+      orchestrator_round_trip_ms        = 8
+      orchestrator_cpu_micros_per_event = 50
+      orchestrator_cpu_millis           = 2000
+      orchestrator_memory_mib           = 4096
     }
 
     # Fewer, fatter pods. Fewer objects is its own win: a fleet of thousands
-    # of Deployments makes a rollout an API-server problem.
+    # of Deployments makes a rollout an API-server problem. It is not a cost
+    # win — see the summary's per-event line.
     large = {
-      matcher_workers         = 24
-      matcher_cpu_millis      = 6000
-      matcher_memory_mib      = 6144
-      matcher_eps             = 16000
-      orchestrator_workers    = 256
-      orchestrator_cpu_millis = 4000
-      orchestrator_memory_mib = 4096
-      orchestrator_eps        = 30000
+      matcher_workers    = 24
+      matcher_cpu_millis = 6000
+      matcher_memory_mib = 6144
+      matcher_eps        = 16000
+
+      orchestrator_workers              = 2048
+      orchestrator_round_trip_ms        = 8
+      orchestrator_cpu_micros_per_event = 50
+      orchestrator_cpu_millis           = 8000
+      orchestrator_memory_mib           = 16384
     }
   }
 }

--- a/infrastructure/terraform/modules/capacity/variables.tf
+++ b/infrastructure/terraform/modules/capacity/variables.tf
@@ -1,0 +1,636 @@
+# Sizing inputs. Every number is measurable, not a preference — change a
+# calibration only with a benchmark behind it. Numbers this model cannot
+# justify from a published figure or a measurement say so in their
+# description, so an unmeasured default is never mistaken for a known one.
+
+variable "throughput_target_eps" {
+  description = "Raw events per second to absorb."
+  type        = number
+
+  validation {
+    condition     = var.throughput_target_eps > 0
+    error_message = "throughput_target_eps must be positive."
+  }
+}
+
+variable "design_target_eps" {
+  description = <<-EOT
+    The rate the deployment is designed to reach, as opposed to the one it
+    carries today.
+
+    Only the wire-law quantities need to be right for it now: `partitions`,
+    because producers hash into it, and `streams`, because revisions are
+    stream sequences. Everything else — shards, replicas, fleet size, Valkey
+    primaries — is a variable change away, so it is sized for
+    `throughput_target_eps` and reported against this.
+  EOT
+  type        = number
+  default     = 5000000
+
+  validation {
+    condition     = var.design_target_eps > 0
+    error_message = "design_target_eps must be positive."
+  }
+}
+
+variable "headroom_ratio" {
+  description = "Spare capacity above the target. Absorbs diurnal peaks and the Restart burst after a matcher or orchestrator restart."
+  type        = number
+  default     = 0.25
+
+  validation {
+    condition     = var.headroom_ratio >= 0 && var.headroom_ratio < 5
+    error_message = "headroom_ratio must be in [0, 5)."
+  }
+}
+
+# --- Geography: the matcher half -------------------------------------------
+
+variable "shards" {
+  description = <<-EOT
+    Road-bearing geohash shards to deploy, at `shard_precision`, as emitted by
+    `cargo run -p routers_shard --bin generate-shards`.
+
+    Never compute this as 32^precision. Precision 6 is 1.07e9 cells globally
+    and almost all are empty; each shard listed costs at least one matcher
+    whether or not it sees traffic.
+  EOT
+  type        = list(string)
+
+  validation {
+    condition     = length(var.shards) > 0
+    error_message = "At least one shard is required."
+  }
+
+  validation {
+    condition     = length(var.shards) == length(distinct(var.shards))
+    error_message = "shards must not contain duplicates; each shard owns exactly one matcher Deployment."
+  }
+}
+
+variable "shard_precision" {
+  description = <<-EOT
+    Geohash precision of `shards`, passed to the matcher's PRECISION.
+
+    Must equal `binary_shard_precision`. The orchestrator picks a request
+    subject with the precision compiled into it, so a mismatch sends every
+    request to a subject no matcher serves.
+  EOT
+  type        = number
+
+  validation {
+    condition     = var.shard_precision >= 1 && var.shard_precision <= 12 && floor(var.shard_precision) == var.shard_precision
+    error_message = "shard_precision must be a whole number in 1..12."
+  }
+
+  validation {
+    condition     = alltrue([for s in var.shards : length(s) == var.shard_precision])
+    error_message = "Every shard must be exactly shard_precision characters long, or a matcher loads a different extent from the one its subject covers."
+  }
+}
+
+variable "binary_shard_precision" {
+  description = <<-EOT
+    The `event::SHARD_PRECISION` constant compiled into the binaries.
+
+    The orchestrator is geography-blind except for one line: it routes each
+    request to `events.match.<shard_of(point)>`, and derives that shard with
+    this constant rather than from configuration, because every pod must agree
+    on it whether or not it holds chart values. Raising deployed precision is
+    therefore a code change, not a variable change — this exists so the plan
+    says that instead of the cluster discovering it at runtime.
+  EOT
+  type        = number
+  default     = 4
+}
+
+variable "coverage_cells" {
+  description = "Optional allowlist of geohash prefixes for the service region. Catches a shard list generated over the wrong extent before it becomes a fleet of idle matchers."
+  type        = list(string)
+  default     = []
+}
+
+variable "shard_fanout_per_precision" {
+  description = <<-EOT
+    Growth in road-bearing shard count per precision level, used only to
+    recommend a precision.
+
+    Geohash grows 32x per level, but populated cells grow far slower: a road
+    network is close to one-dimensional inside a two-dimensional cell, so
+    subdividing mostly yields empty children. Recalibrate by generating shards
+    at two adjacent precisions and taking the ratio.
+  EOT
+  type        = number
+  default     = 8
+
+  validation {
+    condition     = var.shard_fanout_per_precision > 1
+    error_message = "shard_fanout_per_precision must exceed 1, or raising precision would add no capacity."
+  }
+}
+
+variable "hot_shard_replica_factor" {
+  description = <<-EOT
+    Ceiling multiplier for a shard's matcher HPA, over the replica count the
+    mean rate implies.
+
+    Load per shard is not uniform — shards are geographic, traffic is not — and
+    the mean is what this model can compute. The HPA absorbs the difference, so
+    this is how much skew a hot shard may take up before it queues: 4 means a
+    shard carrying four times the mean can still be served.
+  EOT
+  type        = number
+  default     = 4
+
+  validation {
+    condition     = var.hot_shard_replica_factor >= 1
+    error_message = "hot_shard_replica_factor must be at least 1."
+  }
+}
+
+# --- Vehicles: the orchestrator half ---------------------------------------
+
+variable "max_matcher_replicas_per_shard" {
+  description = <<-EOT
+    The point past which one shard's queue group stops being the right
+    structure, and the geography should be subdivided instead.
+
+    Every replica of a shard loads that shard's whole `.shard.rt` file, so
+    scaling one shard buys throughput at a fixed memory cost per pod, and a
+    single Deployment's rollout eventually becomes the slow part. When the mean
+    load needs more replicas than this, the model reports a shard deficit and a
+    finer precision rather than a taller Deployment.
+  EOT
+  type        = number
+  default     = 32
+
+  validation {
+    condition     = var.max_matcher_replicas_per_shard >= 1
+    error_message = "max_matcher_replicas_per_shard must be at least 1."
+  }
+}
+
+variable "partitions" {
+  description = <<-EOT
+    Vehicle partitions the space divides into: `partition::PARTITIONS`.
+
+    Wire law, not a tunable. Producers compute `splitmix64(vehicle_id) % this`
+    to pick a subject, so changing it re-addresses every event in flight. It
+    appears here only because the fleet size must divide it.
+  EOT
+  type        = number
+  default     = 1024
+}
+
+variable "streams" {
+  description = <<-EOT
+    Raw JetStream streams the partition space divides across, fleet-wide.
+
+    Wire law with a migration behind it, not a tuning knob: a revision is a
+    stream sequence, so moving a partition to another stream resets its
+    sequence domain and breaks every revision comparison across the boundary.
+    Pin it once, above what the design target needs.
+
+    One stream is one raft leader, which is what makes the count matter at all:
+    64 streams put the 5M design target at ~98k writes/s each, inside
+    `jetstream_writes_per_stream`. 32 would put it at ~195k, over that ceiling
+    — and discovering it later costs a migration rather than an edit.
+  EOT
+  type        = number
+  default     = 64
+
+  validation {
+    condition     = var.streams >= 1 && floor(var.streams) == var.streams
+    error_message = "streams must be a whole number of at least 1."
+  }
+}
+
+variable "matched_streams" {
+  description = <<-EOT
+    Streams the matched emissions divide across.
+
+    Fixed at 1 because `ingest::MATCHED_STREAM` is one stream in the binary.
+    Unlike the raw side this carries no sequence law — revisions are minted on
+    ingest — so splitting it is a small code change rather than a migration.
+    The model reports what the target needs so the gap is visible before an
+    apply, not after.
+  EOT
+  type        = number
+  default     = 1
+}
+
+variable "vertical_profile" {
+  description = "Which `profiles` entry to deploy."
+  type        = string
+  default     = "standard"
+}
+
+variable "profiles" {
+  description = <<-EOT
+    Vertical scaling steps.
+
+    `matcher_eps` is the sustained request rate one matcher replica serves, and
+    `orchestrator_eps` the sustained rate one orchestrator pod drives. The two
+    are independent now: a matcher is a pure request/reply solver behind a
+    queue group, and an orchestrator owns vehicle partitions rather than
+    geography, so neither is pinned to the other's count.
+
+    Both are estimates from the shipped worker defaults, not measurements. The
+    orchestrator figure is the softer of the two: a worker holds its vehicle's
+    lane across the whole round trip — solve, broker-confirmed publish, batched
+    archive flush — so the pod's ceiling is `workers / mean_round_trip`, and
+    the round trip is dominated by parts this model cannot see.
+  EOT
+  type = map(object({
+    matcher_workers         = number
+    matcher_cpu_millis      = number
+    matcher_memory_mib      = number
+    matcher_eps             = number
+    orchestrator_workers    = number
+    orchestrator_cpu_millis = number
+    orchestrator_memory_mib = number
+    orchestrator_eps        = number
+  }))
+
+  default = {
+    small = {
+      matcher_workers         = 5
+      matcher_cpu_millis      = 1000
+      matcher_memory_mib      = 3072
+      matcher_eps             = 1500
+      orchestrator_workers    = 16
+      orchestrator_cpu_millis = 500
+      orchestrator_memory_mib = 1024
+      orchestrator_eps        = 2000
+    }
+
+    # The calibration anchor: the chart's shipped worker counts.
+    standard = {
+      matcher_workers         = 10
+      matcher_cpu_millis      = 2000
+      matcher_memory_mib      = 3072
+      matcher_eps             = 6000
+      orchestrator_workers    = 64
+      orchestrator_cpu_millis = 1000
+      orchestrator_memory_mib = 1024
+      orchestrator_eps        = 8000
+    }
+
+    # Fewer, fatter pods. Fewer objects is its own win: a fleet of thousands
+    # of Deployments makes a rollout an API-server problem.
+    large = {
+      matcher_workers         = 24
+      matcher_cpu_millis      = 6000
+      matcher_memory_mib      = 6144
+      matcher_eps             = 16000
+      orchestrator_workers    = 256
+      orchestrator_cpu_millis = 4000
+      orchestrator_memory_mib = 4096
+      orchestrator_eps        = 30000
+    }
+  }
+}
+
+variable "max_shards_per_release" {
+  description = <<-EOT
+    Guard on Helm release size. Every shard renders a Deployment and an HPA
+    into one release, whose manifests live in a single Kubernetes Secret, and a
+    Secret holds 1 MiB.
+
+    The whole deployment is one release: the orchestrator fleet is a single
+    StatefulSet over the vehicle partition space, so it must be rendered
+    exactly once, and splitting matchers into their own releases would put the
+    two halves of one system behind two apply paths.
+  EOT
+  type        = number
+  default     = 512
+}
+
+# --- NATS -------------------------------------------------------------------
+
+variable "nats_min_replicas" {
+  description = <<-EOT
+    Availability floor for the cluster.
+
+    Three, and now for a reason core NATS did not have: JetStream elects a raft
+    leader per stream, so a cluster meant to survive a node loss needs an odd
+    membership of at least three. At one replica a lost server takes its
+    streams' backlogs with it.
+  EOT
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.nats_min_replicas >= 1
+    error_message = "nats_min_replicas must be at least 1."
+  }
+}
+
+variable "nats_msgs_per_server" {
+  description = <<-EOT
+    Core deliveries per second one NATS server sustains, for postcard payloads
+    of 100B-10KiB. Applies to the request/reply half of the pipeline, which
+    does not touch a stream.
+
+    The least trustworthy number in this model. Every official NATS figure is a
+    single server over loopback on a laptop — the project publishes no
+    clustered benchmarks — and real networked hardware runs well under them.
+    This default is the published 4M aggregate for 1 publisher to 4 subscribers
+    at 128B, with a 4x haircut.
+
+    Measure it with `nats bench` on the real node shape before trusting the
+    server count it produces.
+    https://docs.nats.io/using-nats/nats-tools/nats_cli/natsbench
+  EOT
+  type        = number
+  default     = 1000000
+
+  validation {
+    condition     = var.nats_msgs_per_server > 0
+    error_message = "nats_msgs_per_server must be positive."
+  }
+}
+
+variable "nats_core_hops" {
+  description = <<-EOT
+    Deliveries per input event that never touch a stream.
+
+    Four: the raw event's delivery from its partition's consumer and the ack
+    back, then the solve request and its reply. The two stream *writes* — raw
+    ingest and the matched emission — are counted separately, because a
+    persisted write and a routed delivery cost different orders of magnitude.
+  EOT
+  type        = number
+  default     = 4
+}
+
+variable "jetstream_writes_per_stream" {
+  description = <<-EOT
+    Persisted messages per second one stream sustains, at file storage and one
+    replica.
+
+    Per *stream*, not per server, because a stream has one raft leader and that
+    leader is where its writes serialise. This is the number the stream count
+    exists to divide, and the reason the count cannot be small.
+
+    Unmeasured. Published JetStream figures put a single stream between 2.5x
+    and 24x under core NATS on the same hardware; this default sits an order of
+    magnitude under core, which is the conservative end of that range for
+    cloud-attached SSD. Measure with `nats bench --js` on the real node shape
+    and disk class before trusting it, because the stream count it justifies
+    cannot be changed afterwards without a migration.
+  EOT
+  type        = number
+  default     = 150000
+
+  validation {
+    condition     = var.jetstream_writes_per_stream > 0
+    error_message = "jetstream_writes_per_stream must be positive."
+  }
+}
+
+variable "jetstream_writes_per_server" {
+  description = "Persisted messages per second one server sustains across every stream it leads. Bounds how many stream leaders a server can hold, which is what decides cluster size once the per-stream ceiling is satisfied."
+  type        = number
+  default     = 400000
+
+  validation {
+    condition     = var.jetstream_writes_per_server > 0
+    error_message = "jetstream_writes_per_server must be positive."
+  }
+}
+
+variable "jetstream_stream_replicas" {
+  description = <<-EOT
+    Replicas per stream, and so the write amplification into the cluster.
+
+    One, because `ingest.rs` does not set `num_replicas` and JetStream
+    defaults to one. That is a deliberate gap to know about rather than a
+    setting: at R1 a lost server loses its streams' unprocessed backlog, since
+    a work queue holds the only copy of an event until it is acked. Raising it
+    is a change to the stream config in `ingest.rs`, not to this variable.
+  EOT
+  type        = number
+  default     = 1
+}
+
+variable "raw_event_bytes" {
+  description = "Wire size of one postcard-encoded raw event, including its JetStream framing and subject. Sizes the work-queue backlog on disk."
+  type        = number
+  default     = 256
+}
+
+variable "matched_event_bytes" {
+  description = <<-EOT
+    Wire size of one matched emission.
+
+    Far above a raw event, and deliberately: a matcher emits the entire cut
+    trip on every solve, so an emission carries every layer since the
+    convergence point rather than a delta. That is what makes competing solves
+    resolvable by revision, and it is also why the matched stream's byte rate
+    is a multiple of the raw one.
+  EOT
+  type        = number
+  default     = 2048
+}
+
+variable "raw_backlog_seconds" {
+  description = <<-EOT
+    Seconds of raw events the work queues must hold on disk.
+
+    A work queue deletes a message on ack, so steady-state disk is near zero
+    and this sizes the abnormal case: how long the orchestrator fleet may be
+    down, or wedged behind a sick matcher shard, before ingest has nowhere to
+    put events.
+  EOT
+  type        = number
+  default     = 900
+}
+
+variable "matched_retention_seconds" {
+  description = "How long the matched stream retains emissions. Nothing consumes it destructively, so this is the reconciler's worst tolerable lag, and it sizes that stream's disk outright."
+  type        = number
+  default     = 900
+}
+
+variable "nats_cpu_millis" {
+  description = "CPU request per NATS server. Core routing is a network loop, but JetStream adds raft and file I/O on top, so this buys both."
+  type        = number
+  default     = 4000
+}
+
+variable "nats_memory_mib" {
+  description = "Memory request per NATS server: connection buffers, slow-consumer queues, and JetStream's per-stream and per-consumer state. One durable consumer per partition means this scales with the partition count, not just with traffic."
+  type        = number
+  default     = 8192
+}
+
+# --- Valkey -----------------------------------------------------------------
+
+variable "valkey_ops_per_primary" {
+  description = <<-EOT
+    Commands per second one Valkey primary sustains.
+
+    The figure measured in Valkey's 1-billion-RPS cluster run: 2000 primaries
+    on r7g.2xlarge (8 vCPU) with 6 io-threads, ~500k ops/s each, growing almost
+    linearly with primary count. https://valkey.io/blog/1-billion-rps/
+
+    Single-node benchmarks reach ~1.19M ops/s, but with no replication and no
+    cluster bus, so that number does not describe a fleet member.
+  EOT
+  type        = number
+  default     = 500000
+
+  validation {
+    condition     = var.valkey_ops_per_primary > 0
+    error_message = "valkey_ops_per_primary must be positive."
+  }
+}
+
+variable "valkey_ops_per_event" {
+  description = <<-EOT
+    Commands per input event: one `XADD ... MAXLEN ~` appending the vehicle's
+    raw tail, trimmed in the same command.
+
+    One, where the previous topology needed two. The orchestrator absorbed the
+    historian's batched write, and its per-event read is gone: a vehicle's
+    history lane is warmed once per ownership and held in the pod, so the
+    `XREVRANGE` amortises to near zero over the vehicle's stay. Raise it only
+    if lane eviction becomes common, which means `vehicle_cache` is too small.
+  EOT
+  type        = number
+  default     = 1
+}
+
+variable "valkey_io_threads" {
+  description = "Valkey `io-threads`, the vertical lever. The 1B RPS run used 6 on an 8-core node; sizing them to every core starves the interrupt handlers and throughput drops."
+  type        = number
+  default     = 6
+
+  validation {
+    condition     = var.valkey_io_threads >= 1
+    error_message = "valkey_io_threads must be at least 1."
+  }
+}
+
+variable "valkey_replicas_per_primary" {
+  description = "Read replicas per primary, for failover only. The pipeline never reads a replica: a warming lane must see the tail its own pod wrote."
+  type        = number
+  default     = 1
+}
+
+variable "valkey_cpu_millis" {
+  description = "CPU request per Valkey pod. No CPU limit is set: a CFS cap would freeze the command loop in 100ms windows and queue every in-flight command behind it."
+  type        = number
+  default     = 2000
+}
+
+variable "valkey_memory_mib" {
+  description = "Memory request per Valkey pod. One stream per vehicle trimmed to HISTORY entries, so bounded by concurrent vehicles rather than by event rate."
+  type        = number
+  default     = 4096
+}
+
+variable "valkey_client_mode" {
+  description = <<-EOT
+    How clients address the fleet.
+
+    `pooled-hash` holds one multiplexed connection per primary and places a
+    vehicle by rendezvous hash over the URLs. No Redis Cluster protocol is
+    involved: no slot map, no `MOVED`, no cluster bus.
+
+    `single` reaches one primary only, and caps the deployment at its
+    throughput.
+  EOT
+  type        = string
+  default     = "pooled-hash"
+
+  validation {
+    condition     = contains(["single", "pooled-hash"], var.valkey_client_mode)
+    error_message = "valkey_client_mode must be 'single' or 'pooled-hash'."
+  }
+}
+
+# --- Telemetry --------------------------------------------------------------
+
+variable "spans_per_event" {
+  description = "Spans emitted per input event across both services: the queue waits, the solve round trip, the publish, the archive flush and the commit."
+  type        = number
+  default     = 8
+}
+
+variable "telemetry_sample_ratio" {
+  description = <<-EOT
+    Fraction of traces to export.
+
+    Unsampled telemetry does not survive this pipeline: the BatchSpanProcessor
+    drops the excess silently from a 16k queue, so metrics derived from it
+    under-report by an unknown factor. Sampling turns that loss into a known
+    constant. Use 1.0 only in development.
+  EOT
+  type        = number
+  default     = 0.001
+
+  validation {
+    condition     = var.telemetry_sample_ratio > 0 && var.telemetry_sample_ratio <= 1
+    error_message = "telemetry_sample_ratio must be in (0, 1]."
+  }
+}
+
+variable "collector_spans_per_replica" {
+  description = "Spans per second one otel-collector replica converts to spanmetrics. CPU-bound: the connector hashes every span into a histogram keyed by the promoted dimensions."
+  type        = number
+  default     = 50000
+}
+
+variable "collector_cpu_millis" {
+  description = "CPU request per otel-collector replica."
+  type        = number
+  default     = 2000
+}
+
+variable "collector_memory_mib" {
+  description = "Memory request per otel-collector replica. Holds spanmetrics cardinality between flushes."
+  type        = number
+  default     = 2048
+}
+
+# --- Nodes ------------------------------------------------------------------
+
+variable "machines" {
+  description = "Machine shape per node pool. `vcpu` and `memory_gib` must match `machine_type`; the model derives allocatable capacity from them."
+  type = map(object({
+    machine_type = string
+    vcpu         = number
+    memory_gib   = number
+  }))
+}
+
+variable "max_pods_per_node" {
+  description = "Pods per node. The node's pod CIDR is sized from this at pool creation, so raising it later needs a new pool."
+  type        = number
+  default     = 110
+
+  validation {
+    condition     = var.max_pods_per_node >= 8 && var.max_pods_per_node <= 256
+    error_message = "max_pods_per_node must be in 8..256; GKE Standard allows at most 110."
+  }
+}
+
+variable "daemonset_cpu_millis" {
+  description = "Per-node CPU claimed by DaemonSets before any workload: kube-proxy, gke-metadata-server, netd, the logging and metrics agents, the GCS FUSE CSI node driver."
+  type        = number
+  default     = 600
+}
+
+variable "daemonset_memory_mib" {
+  description = "Per-node memory claimed by the same DaemonSets."
+  type        = number
+  default     = 1200
+}
+
+variable "daemonset_pods_per_node" {
+  description = "DaemonSet pods per node, deducted from the schedulable pod budget."
+  type        = number
+  default     = 10
+}

--- a/infrastructure/terraform/modules/capacity/versions.tf
+++ b/infrastructure/terraform/modules/capacity/versions.tf
@@ -1,0 +1,6 @@
+terraform {
+  # 1.9 for validation blocks that reference another variable: shard_precision
+  # is checked against both `shards` and the precision compiled into the
+  # binaries, and `streams` against the partition count.
+  required_version = ">= 1.9"
+}

--- a/infrastructure/terraform/modules/devstack/.terraform.lock.hcl
+++ b/infrastructure/terraform/modules/devstack/.terraform.lock.hcl
@@ -1,0 +1,64 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version     = "3.2.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:/TdLShnQEtyQRij46dZJobeA8clDnuncSdc2KRkc0B0=",
+    "h1:8j4dgSY+8Y9tukMTo0WuKPyJx0JKUeZsYx9ltTUmEuo=",
+    "h1:AOxR+hQy92GqWcp4rnD3ZBrDlip7M7fOB4zL4aw8AU4=",
+    "h1:IytRFhZXOMPVB36GainacnNoBtiibAdVMdezG2DPVag=",
+    "h1:XpXkXaOaDyICkDLyrRNBzxqUc8zrKp6Y7sw17FGD+Xg=",
+    "h1:c1NQPYp6/iIg0PG/HFodq0oyDVI/FAYZF32eEOliWaw=",
+    "h1:dBAYwgWCv9/ulFx7uxbkNzPYL9TI1aqUF8E7EBJbIRk=",
+    "h1:h05ap1OKMOtgqspVfdc1GmkX9vJJHquxn5g26Ik7+t4=",
+    "h1:h21YEXSmcV7Xe64kptnt0WQYEh6m99jVR8sec2o9stk=",
+    "h1:ikX+6kgc+kYNDAiNghhOhhY15T1Jt6omoWoHlh8CEsY=",
+    "h1:jvnisz9lHFn+5sjbuZwGCqqCvbddTeqWvrYtK4Wcbxw=",
+    "h1:nK2+CnIIaNh3zl4nRRhpxrA5Z7sAMrB3Jmzjcm9hw/4=",
+    "h1:r8rm1wyokhuaFvRDptDm2G1BsvrV6ukGiPoZRGaVmbc=",
+    "h1:thNSoWm4pdgTEO1XBi1n5V2nwsdSA6EVEXP3qPZiFcA=",
+    "h1:zVNhod3npW/4gn5QTcQzmlTSdAP7Ttjs59KW6VVyaoo=",
+    "zh:1a214581dee54ec4e9afa4050e54f6c187aed4b51b2d2ac929c58706b65e1159",
+    "zh:2f8ba94af93011768ed1fffd4d25b980cd764f2d49c9f13475512ec48464da0b",
+    "zh:36373bca4f374e95f654def79e0b12df0c8f2e01c634db80ff2737ded29062e3",
+    "zh:3a26b5c3e47b2bbc01faa0fa9fe816ea4f74f1f8f4555dfad7f62ee38266aaff",
+    "zh:51bc637700f13cfc1f7c6a8c03a4b5b5755338419912d945dbfe5ccb0ddbf614",
+    "zh:53f32f91afcb682209de124d8a994e591687023ae7c0dfed6184c5511778b16b",
+    "zh:6f4434327ed466b2b5be0d5f4aa537bca71ebd7f7fe05468065aeda52dfc8896",
+    "zh:7394e8c6f5027fa21699e46c9a45bee1ce87fd8dd98f2e89e8d414ec70c8e4e1",
+    "zh:d90b855a0990e3aa6445afe66de730c2f4651f39699c6b6345ca02f9af2a1a08",
+    "zh:d9b7246e6af0f75155ed532855014f888e9e5613242c89e321b4e0f9b54f5726",
+    "zh:dabd399ca36172c15d176a24cf199ac886ef191f7131e806d76a8dc209e5beb8",
+    "zh:e57987397be46dc123365f16c3bec4dd0615453c8bfdcfc1b7c9f3202a09c516",
+    "zh:ec88430b833b943b38d02f70b33250c72bb6ffa3b3d22360990a41390161a2b2",
+    "zh:f8ea01b57982e9ed9ad3a750b1caba261a478f5b0ddcac78a4502d886fd2fc74",
+    "zh:fb63819037158205ebf42b649c3a8ec308234ffe987a5dbd4444e1e0683f1170",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.38"
+  hashes = [
+    "h1:3VVgWmwdwXFT54fjrplnq+N4+4LZ3ZeLHAlr/0jhPiA=",
+    "h1:9LfHMXiMOboc6PhcEEelKjA3VL94l3MCj7RlbKO1PQM=",
+    "h1:AkW6iAcMGHS+P2BIc2nvQe3PZCHtDL4m6+80tEDLge0=",
+    "h1:HGkB9bCmUqMRcR5/bAUOSqPBsx6DAIEnbT1fZ8vzI78=",
+    "h1:eCV78xGlh9eay+62U4gAgCEMohuiBJXN9XTIZNn+rX4=",
+    "h1:ems+O2dA7atxMWpbtqIrsH7Oa+u+ERWSfpMaFnZPbh0=",
+    "h1:iEDf790HE0h3kz58zfj5IhTVODCDqWF1hISPHz210Uw=",
+    "h1:nY7J9jFXcsRINog0KYagiWZw1GVYF9D2JmtIB7Wnrao=",
+    "h1:yw6JHRONXmiTumaQfJBxl1ierFnNNT/Qio8+ttfMcG4=",
+    "zh:1096b41c4e5b2ee6c1980916fb9a8579bc1892071396f7a9432be058aabf3cbc",
+    "zh:2959fde9ae3d1deb5e317df0d7b02ea4977951ee6b9c4beb083c148ca8f3681c",
+    "zh:5082f98fcb3389c73339365f7df39fc6912bf2bd1a46d5f97778f441a67fd337",
+    "zh:620fd5d0fbc2d7a24ac6b420a4922e6093020358162a62fa8cbd37b2bac1d22e",
+    "zh:7f47c2de179bba35d759147c53082cad6c3449d19b0ec0c5a4ca8db5b06393e1",
+    "zh:89c3aa2a87e29febf100fd21cead34f9a4c0e6e7ae5f383b5cef815c677eb52a",
+    "zh:96eecc9f94938a0bc35b8a63d2c4a5f972395e44206620db06760b730d0471fc",
+    "zh:e15567c1095f898af173c281b66bffdc4f3068afdd9f84bb5b5b5521d9f29584",
+    "zh:ecc6b912629734a9a41a7cf1c4c73fb13b4b510afc9e7b2e0011d290bcd6d77f",
+  ]
+}

--- a/infrastructure/terraform/modules/devstack/nats.tf
+++ b/infrastructure/terraform/modules/devstack/nats.tf
@@ -1,0 +1,130 @@
+# One NATS cluster for the whole deployment, carrying both halves of the
+# pipeline: core request/reply for the solves, and JetStream for durable
+# ingest.
+#
+# A server forwards a core message only to routes that have registered matching
+# subscription interest, and never more than one hop, so a cluster already
+# partitions by subject. An earlier revision gave each geographic cell its own
+# cluster and paid a three-server availability floor per cell for locality that
+# interest routing was giving away.
+#
+# JetStream is no longer optional, and not merely for at-least-once delivery:
+# the orchestrator's ingest is a work-queue stream per block of vehicle
+# partitions with one filtered durable consumer per partition, and a revision —
+# the total order competing solves resolve by — is a stream sequence. Nothing
+# in the pipeline functions without it, which is also why the server floor is
+# now three: JetStream elects a leader per stream, and at one replica a lost
+# server takes its streams' unacked backlog with it.
+
+locals {
+  nats_resources = {
+    requests = {
+      cpu    = "${var.nats_cpu_millis}m"
+      memory = "${var.nats_memory_mib}Mi"
+    }
+    # No CPU limit. A CFS cap would throttle the routing loop in 100ms windows
+    # and stall every in-flight message behind the freeze — now including the
+    # raft heartbeats that keep stream leadership stable.
+    limits = {
+      memory = "${var.nats_memory_mib}Mi"
+    }
+  }
+
+  nats_pod_spec = merge(
+    length(var.node_selector) > 0 ? { nodeSelector = var.node_selector } : {},
+    length(var.tolerations) > 0 ? { tolerations = var.tolerations } : {},
+  )
+}
+
+resource "helm_release" "nats" {
+  name       = "nats"
+  repository = "https://nats-io.github.io/k8s/helm/charts/"
+  chart      = "nats"
+  version    = var.chart_versions.nats
+
+  namespace        = var.namespace
+  create_namespace = var.create_namespace
+
+  wait    = var.wait_for_rollout
+  timeout = var.release_timeout
+
+  values = [yamlencode({
+    # Fixes the Service name, so the client URL is derivable rather than
+    # dependent on the release name the chart happens to build.
+    fullnameOverride = "nats"
+
+    config = {
+      cluster = {
+        enabled  = true
+        replicas = var.nats_replicas
+      }
+
+      jetstream = {
+        enabled = true
+
+        # File, not memory. A work queue holds the only copy of an event until
+        # it is acked, so the store is the ingest buffer itself rather than a
+        # cache: memory storage would discard the backlog on restart, which is
+        # exactly the case the durability exists for.
+        #
+        # Sized per server by the capacity model from the retained backlog and
+        # the matched stream's retention. The matched stream dominates it —
+        # emissions carry the whole cut trip, so its byte rate is a multiple of
+        # ingest — and it is a PVC per pod, so this is the number to watch when
+        # the target moves.
+        fileStore = {
+          enabled = true
+          pvc = merge(
+            {
+              enabled = true
+              size    = "${var.jetstream_file_store_gib}Gi"
+            },
+            # Left to the cluster default when unset, which is pd-balanced on
+            # GKE. Worth setting to an SSD class if the write ceiling turns out
+            # to be disk rather than CPU.
+            var.jetstream_storage_class == "" ? {} : { storageClassName = var.jetstream_storage_class },
+          )
+        }
+      }
+    }
+
+    container = {
+      resources = local.nats_resources
+    }
+
+    podTemplate = merge(
+      {
+        # Spread servers across nodes, or the availability floor buys nothing.
+        topologySpreadConstraints = {
+          "kubernetes.io/hostname" = {
+            maxSkew           = 1
+            whenUnsatisfiable = "ScheduleAnyway"
+          }
+        }
+      },
+      length(local.nats_pod_spec) > 0 ? { merge = { spec = local.nats_pod_spec } } : {},
+    )
+
+    # The pipeline has no metrics of its own, so NATS' own series are the only
+    # direct view of queue depth and slow consumers.
+    promExporter = {
+      enabled = true
+      port    = 7777
+      podMonitor = {
+        enabled = true
+        merge = {
+          spec = {
+            podMetricsEndpoints = [{
+              port     = "prom-metrics"
+              interval = "10s"
+            }]
+          }
+        }
+      }
+    }
+
+    natsBox = {
+      enabled = false
+    }
+  })]
+}

--- a/infrastructure/terraform/modules/devstack/nats.tf
+++ b/infrastructure/terraform/modules/devstack/nats.tf
@@ -74,16 +74,15 @@ resource "helm_release" "nats" {
         # the target moves.
         fileStore = {
           enabled = true
-          pvc = merge(
-            {
-              enabled = true
-              size    = "${var.jetstream_file_store_gib}Gi"
-            },
-            # Left to the cluster default when unset, which is pd-balanced on
-            # GKE. Worth setting to an SSD class if the write ceiling turns out
-            # to be disk rather than CPU.
-            var.jetstream_storage_class == "" ? {} : { storageClassName = var.jetstream_storage_class },
-          )
+          pvc = {
+            enabled = true
+            size    = "${var.jetstream_file_store_gib}Gi"
+
+            # Never the cluster default: see storage.tf. The class provisions
+            # throughput independently of this size, so retention and write
+            # ceiling stop being the same dial.
+            storageClassName = local.jetstream_storage_class
+          }
         }
       }
     }
@@ -94,11 +93,20 @@ resource "helm_release" "nats" {
 
     podTemplate = merge(
       {
-        # Spread servers across nodes, or the availability floor buys nothing.
+        # Hard, not best-effort. Every stream elects a raft leader, so the
+        # cluster's fault tolerance is a property of how the servers are
+        # spread, not of how many there are: five servers on two nodes lose
+        # quorum to a single node failure.
+        #
+        # `ScheduleAnyway` would let exactly that happen the first time the
+        # scheduler found the infra pool tight, and it would look like a
+        # healthy five-server cluster right up until a node drained. The
+        # capacity model keeps the pool's node floor high enough for this to be
+        # satisfiable — see `nats_spread_nodes`.
         topologySpreadConstraints = {
           "kubernetes.io/hostname" = {
             maxSkew           = 1
-            whenUnsatisfiable = "ScheduleAnyway"
+            whenUnsatisfiable = "DoNotSchedule"
           }
         }
       },

--- a/infrastructure/terraform/modules/devstack/observability.tf
+++ b/infrastructure/terraform/modules/devstack/observability.tf
@@ -1,0 +1,205 @@
+# The span-to-metric bridge, and Prometheus to scrape it.
+#
+# The routers binaries hold no metric registry and expose no HTTP endpoint, so
+# a span is their only telemetry primitive. The spanmetrics connector turns
+# spans into duration histograms and call counters, scraped from :8889. Break
+# this and the pipeline goes blind, not just unmonitored. Traces are
+# aggregated, not stored; add a Tempo exporter for browsing.
+
+locals {
+  collector_scheduling = merge(
+    length(var.observability_node_selector) > 0 ? { nodeSelector = var.observability_node_selector } : {},
+    length(var.observability_tolerations) > 0 ? { tolerations = var.observability_tolerations } : {},
+  )
+}
+
+resource "helm_release" "collector" {
+  name       = "otel-collector"
+  repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
+  chart      = "opentelemetry-collector"
+  version    = var.chart_versions.collector
+
+  namespace        = var.namespace
+  create_namespace = var.create_namespace
+
+  wait    = var.wait_for_rollout
+  timeout = var.release_timeout
+
+  values = [yamlencode(merge({
+    mode         = "deployment"
+    replicaCount = var.collector_replicas
+
+    # spanmetrics lives in the contrib distribution only.
+    image = {
+      repository = "otel/opentelemetry-collector-contrib"
+    }
+    command = {
+      name = "otelcol-contrib"
+    }
+
+    resources = {
+      requests = {
+        cpu    = "${var.collector_cpu_millis}m"
+        memory = "${var.collector_memory_mib}Mi"
+      }
+      # No CPU limit: the work arrives in bursts that follow the pipeline's
+      # own, and throttling here drops spans when they matter most.
+      limits = {
+        memory = "${var.collector_memory_mib}Mi"
+      }
+    }
+
+    ports = {
+      spanmetrics = {
+        enabled       = true
+        containerPort = 8889
+        servicePort   = 8889
+        protocol      = "TCP"
+      }
+      # accepted/refused/dropped: the meta-signal for when the routers series
+      # go quiet.
+      metrics = {
+        enabled = true
+      }
+      # Only OTLP is spoken here.
+      jaeger-compact = { enabled = false }
+      jaeger-thrift  = { enabled = false }
+      jaeger-grpc    = { enabled = false }
+      zipkin         = { enabled = false }
+    }
+
+    serviceMonitor = {
+      enabled = var.observability_enabled
+      metricsEndpoints = [
+        { port = "metrics" },
+        { port = "spanmetrics", interval = var.metrics_flush_interval },
+      ]
+    }
+
+    config = {
+      receivers = {
+        otlp = {
+          protocols = {
+            grpc = { endpoint = "0.0.0.0:4317" }
+            http = { endpoint = "0.0.0.0:4318" }
+          }
+        }
+      }
+
+      connectors = {
+        spanmetrics = {
+          namespace              = "routers"
+          metrics_flush_interval = var.metrics_flush_interval
+          histogram = {
+            unit = "ms"
+            explicit = {
+              # Sub-second buckets resolve the compute spans. The tail to 120s
+              # is for the wait spans: a backlogged run parks messages for tens
+              # of seconds, and a 5s cap would censor that.
+              buckets = [
+                "1ms", "2ms", "5ms", "10ms", "25ms", "50ms", "100ms", "250ms",
+                "500ms", "1s", "2500ms", "5s", "10s", "30s", "60s", "120s",
+              ]
+            }
+          }
+          dimensions = [for d in var.span_metrics_dimensions : { name = d }]
+        }
+      }
+
+      exporters = {
+        prometheus = {
+          endpoint = "0.0.0.0:8889"
+        }
+      }
+
+      service = {
+        pipelines = {
+          traces = {
+            receivers = ["otlp"]
+            exporters = ["spanmetrics"]
+          }
+          metrics = {
+            receivers = ["spanmetrics"]
+            exporters = ["prometheus"]
+          }
+          logs = null
+        }
+      }
+    }
+  }, local.collector_scheduling))]
+}
+
+resource "helm_release" "prometheus" {
+  count = var.observability_enabled ? 1 : 0
+
+  name       = "kube-prometheus-stack"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-prometheus-stack"
+  version    = var.chart_versions.prometheus
+
+  namespace        = var.namespace
+  create_namespace = var.create_namespace
+
+  wait    = var.wait_for_rollout
+  timeout = var.release_timeout
+
+  values = [yamlencode({
+    grafana = merge(
+      {
+        fullnameOverride = "grafana"
+
+        # Discover dashboard ConfigMaps in every namespace, so the routers
+        # chart ships its own.
+        sidecar = {
+          dashboards = {
+            searchNamespace = "ALL"
+          }
+        }
+
+        "grafana.ini" = merge(
+          {
+            users = { allow_sign_up = false }
+            dashboards = {
+              # The sidecar writes dashboards into /tmp/dashboards, keyed by
+              # their ConfigMap data key.
+              default_home_dashboard_path = "/tmp/dashboards/routers-realtime.json"
+            }
+          },
+          # Developer machines only: anyone who reaches the service becomes an
+          # administrator.
+          var.grafana_anonymous_admin ? {
+            "auth.anonymous" = {
+              enabled  = true
+              org_role = "Admin"
+            }
+            auth = {
+              disable_login_form = true
+            }
+          } : {},
+        )
+      },
+      local.collector_scheduling,
+    )
+
+    prometheus = {
+      prometheusSpec = merge(
+        {
+          # Discover ServiceMonitors and PodMonitors from any namespace with
+          # any labels, so routers releases need not match this release's
+          # Helm labels.
+          serviceMonitorSelectorNilUsesHelmValues = false
+          serviceMonitorSelector                  = {}
+          serviceMonitorNamespaceSelector         = {}
+          podMonitorSelectorNilUsesHelmValues     = false
+          podMonitorSelector                      = {}
+          podMonitorNamespaceSelector             = {}
+        },
+        local.collector_scheduling,
+      )
+    }
+
+    alertmanager = {
+      alertmanagerSpec = local.collector_scheduling
+    }
+  })]
+}

--- a/infrastructure/terraform/modules/devstack/outputs.tf
+++ b/infrastructure/terraform/modules/devstack/outputs.tf
@@ -1,0 +1,75 @@
+# Service names are fixed with fullnameOverride, so these URLs are derived
+# rather than read back from the releases. That keeps them known at plan time,
+# which matters because the realtime module feeds them into Helm values.
+
+locals {
+  dns_suffix = "${var.namespace}.svc.cluster.local"
+}
+
+output "namespace" {
+  description = "Namespace the dependencies were installed into."
+  value       = var.namespace
+}
+
+output "nats_url" {
+  description = "Client URL for the cluster. Every workload uses it: one cluster carries the core solve traffic and the JetStream ingest alike."
+  value       = "nats://nats.${local.dns_suffix}:4222"
+}
+
+output "valkey_urls" {
+  description = <<-EOT
+    The Valkey fleet. Every workload gets the whole list and places a vehicle by
+    rendezvous hash over the URLs.
+
+    Order carries no meaning: a primary's identity is its URL, so reordering
+    this list moves nothing. Adding or removing one moves about 1/N of vehicles,
+    which is the minimum any placement can achieve.
+  EOT
+  value = [
+    for key in sort(keys(local.valkey_indices)) :
+    "redis://valkey-${key}-primary.${local.dns_suffix}:6379"
+  ]
+}
+
+output "valkey_primaries" {
+  description = "Primaries in the fleet, and the modulus clients hash against."
+  value       = var.valkey_primaries
+}
+
+output "otlp_url" {
+  description = "OTLP http/protobuf endpoint. One collector deployment serves the whole pipeline."
+  value       = "http://otel-collector-opentelemetry-collector.${local.dns_suffix}:4318"
+}
+
+output "valkey_client_mode" {
+  description = "How clients are expected to address the fleet."
+  value       = var.valkey_client_mode
+}
+
+output "valkey_client_prerequisite" {
+  description = "Non-empty when the fleet is larger than the client can address."
+  value = (var.valkey_client_mode == "single" && var.valkey_primaries > 1) ? join(" ", [
+    "valkey_client_mode is 'single' with ${var.valkey_primaries} primaries, so",
+    "only the first URL would be used and the rest would sit idle.",
+  ]) : ""
+}
+
+output "release_names" {
+  description = "Every Helm release this module manages."
+  value = concat(
+    [helm_release.nats.name],
+    [for r in helm_release.valkey : r.name],
+    [helm_release.collector.name],
+    [for r in helm_release.prometheus : r.name],
+  )
+}
+
+output "totals" {
+  description = "Dependency pod counts, for comparison against the capacity model."
+  value = {
+    nats_servers     = var.nats_replicas
+    valkey_primaries = var.valkey_primaries
+    valkey_pods      = var.valkey_primaries * (1 + var.valkey_replicas_per_primary)
+    collectors       = var.collector_replicas
+  }
+}

--- a/infrastructure/terraform/modules/devstack/storage.tf
+++ b/infrastructure/terraform/modules/devstack/storage.tf
@@ -67,3 +67,18 @@ check "the_file_store_can_absorb_the_write_rate" {
     error_message = "The JetStream file store is provisioned for ${var.jetstream_provisioned_iops} IOPS per server but the streams need ${var.jetstream_required_iops}."
   }
 }
+
+# Provisioning past what the node can deliver is the quieter failure: the
+# volume runs at the instance ceiling, nothing reports a shortfall, and the
+# bill reflects the provisioning rather than the delivery.
+check "the_node_can_deliver_what_the_volume_provisions" {
+  assert {
+    condition     = var.jetstream_provisioned_throughput_mib <= var.jetstream_instance_throughput_limit_mib
+    error_message = "The file store provisions ${var.jetstream_provisioned_throughput_mib} MiB/s but the node tops out at ${var.jetstream_instance_throughput_limit_mib} MiB/s across every disk attached to it, boot disk included. The volume would run at the node's ceiling and the difference would be paid for and not delivered; use a larger machine type for the infra pool, or provision less."
+  }
+
+  assert {
+    condition     = var.jetstream_provisioned_iops <= var.jetstream_instance_iops_limit
+    error_message = "The file store provisions ${var.jetstream_provisioned_iops} IOPS but the node tops out at ${var.jetstream_instance_iops_limit}."
+  }
+}

--- a/infrastructure/terraform/modules/devstack/storage.tf
+++ b/infrastructure/terraform/modules/devstack/storage.tf
@@ -1,0 +1,69 @@
+# The StorageClass behind the JetStream file store.
+#
+# This exists because the cluster default does not serve the workload. GKE
+# defaults to pd-balanced, whose throughput and IOPS scale with capacity — so
+# the disk's speed becomes a side effect of how much retention happens to be
+# configured, which is exactly the wrong coupling for a broker whose write rate
+# is set by traffic.
+#
+# Hyperdisk provisions both independently of size, so the numbers below come
+# from the capacity model's measured demand rather than from the volume being
+# large enough to accidentally be fast.
+#
+# What drives that demand is worth stating: the raw work queues are small
+# messages that delete on ack, while the matched stream retains whole cut trips
+# for its whole retention window. The matched stream is most of the bytes.
+
+resource "kubernetes_storage_class" "jetstream" {
+  count = var.jetstream_storage_class == "" ? 1 : 0
+
+  metadata {
+    name = var.jetstream_storage_class_name
+  }
+
+  storage_provisioner = "pd.csi.storage.gke.io"
+
+  # The file store is the ingest buffer, not a cache: a work queue holds the
+  # only copy of an event until it is acked. Retaining it through a pod's
+  # rescheduling is the whole point, so the volume outlives the pod.
+  reclaim_policy         = "Retain"
+  allow_volume_expansion = true
+
+  # The volume is provisioned in the zone its consumer landed in. With
+  # immediate binding a PVC can be created in a zone the NATS pod cannot be
+  # scheduled to, and the pod stays Pending against a disk it cannot reach.
+  volume_binding_mode = "WaitForFirstConsumer"
+
+  parameters = {
+    type = var.jetstream_disk_type
+
+    # Provisioned rather than derived from capacity. Both are per volume, and
+    # a NATS server holds one.
+    "provisioned-iops-on-create"       = tostring(var.jetstream_provisioned_iops)
+    "provisioned-throughput-on-create" = "${var.jetstream_provisioned_throughput_mib}Mi"
+  }
+}
+
+locals {
+  # The class the file store PVCs bind to: the one created here, or an existing
+  # class named by the caller.
+  jetstream_storage_class = (
+    var.jetstream_storage_class != ""
+    ? var.jetstream_storage_class
+    : kubernetes_storage_class.jetstream[0].metadata[0].name
+  )
+}
+
+# Provisioning below what the brokers will actually write is the failure this
+# module exists to prevent, so it is checked rather than left to a dashboard.
+check "the_file_store_can_absorb_the_write_rate" {
+  assert {
+    condition     = var.jetstream_provisioned_throughput_mib >= var.jetstream_required_throughput_mib
+    error_message = "The JetStream file store is provisioned for ${var.jetstream_provisioned_throughput_mib} MiB/s per server but the streams will write ${var.jetstream_required_throughput_mib} MiB/s. Writes will queue behind the disk, the stream's raft leader will fall behind its followers, and ingest will throttle at max_ack_pending while looking like a broker problem."
+  }
+
+  assert {
+    condition     = var.jetstream_provisioned_iops >= var.jetstream_required_iops
+    error_message = "The JetStream file store is provisioned for ${var.jetstream_provisioned_iops} IOPS per server but the streams need ${var.jetstream_required_iops}."
+  }
+}

--- a/infrastructure/terraform/modules/devstack/valkey.tf
+++ b/infrastructure/terraform/modules/devstack/valkey.tf
@@ -1,0 +1,122 @@
+# The Valkey fleet: N independent primaries, each its own release.
+#
+# Not a Valkey Cluster, and not partitioned geographically. Clients place a
+# vehicle by rendezvous hash over the URL list this module outputs, so there is
+# no slot map, no MOVED handling and no `cluster-async` feature. A primary's
+# identity is its URL, not its index, so `valkey_urls` order does not matter
+# and a resize moves about 1/N of vehicles.
+
+locals {
+  # Zero-padded so both the release names and the URL list sort in index order.
+  valkey_indices = { for i in range(var.valkey_primaries) : format("%03d", i) => i }
+
+  valkey_resources = {
+    requests = {
+      cpu    = "${var.valkey_cpu_millis}m"
+      memory = "${var.valkey_memory_mib}Mi"
+    }
+    # No CPU limit, deliberately. Command execution is single-threaded, so a
+    # CFS cap freezes the loop in ~100ms windows and every in-flight command
+    # queues behind it: measured as a 50-100ms stall tail on reads while
+    # execution itself stayed at ~7us per call.
+    limits = {
+      memory = "${var.valkey_memory_mib}Mi"
+    }
+  }
+
+  valkey_image = {
+    for k, v in {
+      registry   = var.valkey_image.registry
+      repository = var.valkey_image.repository
+      tag        = var.valkey_image.tag
+    } : k => v if v != ""
+  }
+
+  valkey_scheduling = merge(
+    length(var.node_selector) > 0 ? { nodeSelector = var.node_selector } : {},
+    length(var.tolerations) > 0 ? { tolerations = var.tolerations } : {},
+  )
+
+  # Replication is for failover only, so zero replicas is legitimate.
+  valkey_architecture = var.valkey_replicas_per_primary > 0 ? "replication" : "standalone"
+
+  # io-threads is the vertical lever: threads parse and write while command
+  # execution stays on the main thread. Passed as a flag, not through
+  # `configuration`, which replaces the chart's whole config file rather than
+  # adding to it and would silently drop every default the chart sets.
+  valkey_flags = ["--io-threads", tostring(var.valkey_io_threads)]
+}
+
+resource "helm_release" "valkey" {
+  for_each = local.valkey_indices
+
+  name    = "valkey-${each.key}"
+  chart   = "oci://registry-1.docker.io/bitnamicharts/valkey"
+  version = var.chart_versions.valkey
+
+  namespace        = var.namespace
+  create_namespace = var.create_namespace
+
+  wait    = var.wait_for_rollout
+  timeout = var.release_timeout
+
+  values = [yamlencode(merge(
+    {
+      fullnameOverride = "valkey-${each.key}"
+
+      # No auth. The keyspace is reachable only from inside the cluster, and a
+      # password costs a handshake per reconnect on the hot path for no
+      # boundary the network does not already enforce.
+      auth = {
+        enabled = false
+      }
+
+      architecture = local.valkey_architecture
+
+      primary = merge({
+        resources   = local.valkey_resources
+        extraFlags  = local.valkey_flags
+        persistence = { enabled = var.valkey_persistence }
+      }, local.valkey_scheduling)
+
+      replica = merge({
+        replicaCount = var.valkey_replicas_per_primary
+        resources    = local.valkey_resources
+        extraFlags   = local.valkey_flags
+        persistence  = { enabled = var.valkey_persistence }
+      }, local.valkey_scheduling)
+
+      metrics = {
+        enabled = true
+        serviceMonitor = {
+          enabled = true
+        }
+      }
+    },
+    length(local.valkey_image) > 0 ? { image = local.valkey_image } : {},
+  ))]
+}
+
+check "valkey_client_can_address_the_fleet" {
+  assert {
+    condition = var.valkey_client_mode == "pooled-hash" || var.valkey_primaries == 1
+    error_message = join(" ", [
+      "valkey_client_mode is 'single' but the fleet has ${var.valkey_primaries} primaries,",
+      "so clients would reach only the first URL and the rest would sit idle.",
+      "Set 'pooled-hash', or set valkey_primaries to 1.",
+    ])
+  }
+}
+
+check "valkey_image_is_pinned" {
+  assert {
+    condition = var.valkey_image.tag != ""
+    error_message = join(" ", [
+      "valkey_image.tag is unset, so the Bitnami chart default applies.",
+      "That default is `registry-1.docker.io/bitnami/valkey:latest`, and its metrics",
+      "sidecar is `bitnami/redis-exporter:latest`: floating tags, from a catalogue",
+      "Bitnami moved to `bitnamilegacy/*` during 2025.",
+      "Mirror a pinned digest into Artifact Registry and set valkey_image.",
+    ])
+  }
+}

--- a/infrastructure/terraform/modules/devstack/variables.tf
+++ b/infrastructure/terraform/modules/devstack/variables.tf
@@ -47,9 +47,66 @@ variable "jetstream_file_store_gib" {
 }
 
 variable "jetstream_storage_class" {
-  description = "StorageClass for the file store PVCs. Empty uses the cluster default, which is pd-balanced on GKE. Worth setting to an SSD class if measurement shows the per-stream write ceiling is disk-bound rather than CPU-bound."
+  description = <<-EOT
+    An existing StorageClass to bind the file store PVCs to. Empty — the
+    default — makes this module create one instead, sized from the demand
+    variables below.
+
+    Do not point this at the cluster default. GKE's is pd-balanced, whose
+    throughput and IOPS scale with capacity, so the broker's disk speed becomes
+    a side effect of how much retention was configured.
+  EOT
   type        = string
   default     = ""
+}
+
+variable "jetstream_storage_class_name" {
+  description = "Name of the StorageClass this module creates when `jetstream_storage_class` is empty."
+  type        = string
+  default     = "routers-jetstream"
+}
+
+variable "jetstream_disk_type" {
+  description = <<-EOT
+    Disk type behind the file store.
+
+    Hyperdisk, because it provisions IOPS and throughput independently of
+    capacity — a pd-* class would tie the broker's write ceiling to its
+    retention window. `hyperdisk-balanced` covers this workload;
+    `hyperdisk-extreme` exists for a measured IOPS wall that balanced cannot
+    reach.
+  EOT
+  type        = string
+  default     = "hyperdisk-balanced"
+
+  validation {
+    condition     = startswith(var.jetstream_disk_type, "hyperdisk-")
+    error_message = "jetstream_disk_type must be a hyperdisk type: a pd-* volume's performance scales with its size, which makes the write ceiling depend on the retention window rather than on the traffic."
+  }
+}
+
+variable "jetstream_provisioned_iops" {
+  description = "IOPS provisioned per file store volume. One volume per NATS server, so this is per server."
+  type        = number
+  default     = 30000
+}
+
+variable "jetstream_provisioned_throughput_mib" {
+  description = "Throughput in MiB/s provisioned per file store volume. This is usually the binding one rather than IOPS: JetStream appends sequentially, so the bytes matter more than the operation count."
+  type        = number
+  default     = 750
+}
+
+variable "jetstream_required_iops" {
+  description = "IOPS the streams will actually need per server, from the capacity model. Checked against the provisioned figure."
+  type        = number
+  default     = 0
+}
+
+variable "jetstream_required_throughput_mib" {
+  description = "MiB/s the streams will actually write per server, from the capacity model. Checked against the provisioned figure."
+  type        = number
+  default     = 0
 }
 
 variable "valkey_primaries" {

--- a/infrastructure/terraform/modules/devstack/variables.tf
+++ b/infrastructure/terraform/modules/devstack/variables.tf
@@ -70,11 +70,23 @@ variable "jetstream_disk_type" {
   description = <<-EOT
     Disk type behind the file store.
 
-    Hyperdisk, because it provisions IOPS and throughput independently of
-    capacity — a pd-* class would tie the broker's write ceiling to its
-    retention window. `hyperdisk-balanced` covers this workload;
-    `hyperdisk-extreme` exists for a measured IOPS wall that balanced cannot
-    reach.
+    Hyperdisk, because it provisions performance independently of capacity — a
+    pd-* class would tie the broker's write ceiling to its retention window,
+    and C4 does not offer Persistent Disk in any case.
+
+    Balanced rather than Extreme, for two independent reasons:
+
+      Extreme is unavailable at this node size. C4 requires at least 96 vCPUs
+      to attach a Hyperdisk Extreme volume, and the infra pool is nowhere near
+      that. Reaching it would mean sizing the pool for the disk rather than for
+      the brokers.
+
+      Extreme is also the wrong shape. It provisions IOPS only: throughput
+      comes as 250 MiB/s per 1,000 IOPS, capped at 5,000. This workload is
+      throughput-bound — JetStream appends sequentially — so Balanced, which
+      provisions both, targets the constraint that actually binds. Balanced
+      reaches 160,000 IOPS and 2,400 MiB/s per volume, well past what the
+      streams need.
   EOT
   type        = string
   default     = "hyperdisk-balanced"
@@ -83,6 +95,25 @@ variable "jetstream_disk_type" {
     condition     = startswith(var.jetstream_disk_type, "hyperdisk-")
     error_message = "jetstream_disk_type must be a hyperdisk type: a pd-* volume's performance scales with its size, which makes the write ceiling depend on the retention window rather than on the traffic."
   }
+}
+
+variable "jetstream_instance_iops_limit" {
+  description = <<-EOT
+    IOPS the NATS pod's *node* can sustain across every disk attached to it,
+    from the machine series' Hyperdisk performance limits.
+
+    A volume cannot reach its provisioned performance on an instance that does
+    not support that level, and nothing reports the shortfall: the disk simply
+    runs at the instance's ceiling while the bill reflects the provisioning.
+  EOT
+  type        = number
+  default     = 100000
+}
+
+variable "jetstream_instance_throughput_limit_mib" {
+  description = "MiB/s the NATS pod's node can sustain across every attached disk, including its boot disk. The same silent-shortfall applies as for IOPS."
+  type        = number
+  default     = 1600
 }
 
 variable "jetstream_provisioned_iops" {

--- a/infrastructure/terraform/modules/devstack/variables.tf
+++ b/infrastructure/terraform/modules/devstack/variables.tf
@@ -1,0 +1,239 @@
+variable "namespace" {
+  description = "Namespace for the dependencies. Kept apart from the routers workloads so a teardown of one does not touch the other."
+  type        = string
+  default     = "routers-dev"
+}
+
+variable "create_namespace" {
+  description = "Whether Helm creates the namespace."
+  type        = bool
+  default     = true
+}
+
+# --- Topology ---------------------------------------------------------------
+
+variable "nats_replicas" {
+  description = <<-EOT
+    Servers in the single NATS cluster, from the capacity module's
+    `nats.replicas_total`. Sized by whichever binds first — routed core
+    deliveries or persisted JetStream writes — and rounded up to odd, because a
+    stream's leader is elected.
+  EOT
+  type        = number
+
+  validation {
+    condition     = var.nats_replicas >= 1
+    error_message = "nats_replicas must be at least 1."
+  }
+}
+
+variable "jetstream_file_store_gib" {
+  description = <<-EOT
+    File store PVC per NATS server, from the capacity module's
+    `nats.file_store_gib`.
+
+    Holds the raw work queues — which are the ingest buffer, since a work queue
+    deletes on ack and so holds only the backlog — plus the matched stream for
+    its whole retention. The matched stream dominates: emissions carry the
+    entire cut trip rather than a delta, so its byte rate is a multiple of
+    ingest's.
+  EOT
+  type        = number
+
+  validation {
+    condition     = var.jetstream_file_store_gib >= 1
+    error_message = "jetstream_file_store_gib must be at least 1."
+  }
+}
+
+variable "jetstream_storage_class" {
+  description = "StorageClass for the file store PVCs. Empty uses the cluster default, which is pd-balanced on GKE. Worth setting to an SSD class if measurement shows the per-stream write ceiling is disk-bound rather than CPU-bound."
+  type        = string
+  default     = ""
+}
+
+variable "valkey_primaries" {
+  description = "Primaries in the Valkey fleet, from the capacity module. Each is an independent release. Clients place a vehicle by rendezvous hash over the primary URLs."
+  type        = number
+
+  validation {
+    condition     = var.valkey_primaries >= 1
+    error_message = "valkey_primaries must be at least 1."
+  }
+}
+
+variable "valkey_client_mode" {
+  description = <<-EOT
+    `pooled-hash` is what the code does: one multiplexed connection per
+    primary, and a vehicle placed by rendezvous hash over the URLs. Order does
+    not matter, and a resize moves about 1/N of vehicles.
+
+    `single` uses one connection, so only the first URL is reached. Valid only
+    with one primary.
+  EOT
+  type        = string
+  default     = "pooled-hash"
+
+  validation {
+    condition     = contains(["single", "pooled-hash"], var.valkey_client_mode)
+    error_message = "valkey_client_mode must be 'single' or 'pooled-hash'."
+  }
+}
+
+variable "valkey_io_threads" {
+  description = "Valkey `io-threads`. The 1B RPS run used 6 on an 8-core node, leaving 2 cores for network interrupt affinity."
+  type        = number
+  default     = 6
+}
+
+variable "valkey_persistence" {
+  description = "Whether primaries keep a PVC. Off by default: the keyspace is a rolling window trimmed to HISTORY entries per vehicle, and the orchestrator rebuilds a vehicle's tail as it re-warms that lane."
+  type        = bool
+  default     = false
+}
+
+# --- Resources --------------------------------------------------------------
+
+variable "nats_cpu_millis" {
+  description = "CPU request per NATS server."
+  type        = number
+  default     = 4000
+}
+
+variable "nats_memory_mib" {
+  description = "Memory request and limit per NATS server."
+  type        = number
+  default     = 8192
+}
+
+variable "valkey_cpu_millis" {
+  description = "CPU request per Valkey pod."
+  type        = number
+  default     = 2000
+}
+
+variable "valkey_memory_mib" {
+  description = "Memory request and limit per Valkey pod."
+  type        = number
+  default     = 4096
+}
+
+variable "valkey_replicas_per_primary" {
+  description = "Replicas per primary, for failover only. The pipeline never reads a replica: a warming lane must see the tail its own pod wrote. Zero installs a standalone primary."
+  type        = number
+  default     = 1
+}
+
+variable "collector_replicas" {
+  description = "otel-collector replicas, sized from the sampled span rate."
+  type        = number
+  default     = 1
+}
+
+variable "collector_cpu_millis" {
+  description = "CPU request per collector replica."
+  type        = number
+  default     = 2000
+}
+
+variable "collector_memory_mib" {
+  description = "Memory request and limit per collector replica."
+  type        = number
+  default     = 2048
+}
+
+# --- Images -----------------------------------------------------------------
+
+variable "valkey_image" {
+  description = <<-EOT
+    Overrides the Valkey image. Worth setting: the chart defaults to
+    `registry-1.docker.io/bitnami/valkey:latest` and its metrics sidecar to
+    `bitnami/redis-exporter:latest`. Floating tags make a deploy
+    unreproducible, and Bitnami moved its free public catalogue to
+    `bitnamilegacy/*` during 2025, so the default may not resolve. Mirror a
+    pinned digest into Artifact Registry. Empty fields take the chart default.
+  EOT
+  type = object({
+    registry   = optional(string, "")
+    repository = optional(string, "")
+    tag        = optional(string, "")
+  })
+  default = {}
+}
+
+# --- Observability ----------------------------------------------------------
+
+variable "observability_enabled" {
+  description = "Whether to install kube-prometheus-stack. The collector is installed regardless, because it is the services' only telemetry path."
+  type        = bool
+  default     = true
+}
+
+variable "grafana_anonymous_admin" {
+  description = "Logs every visitor in as Admin with no password. Developer machines only: anyone who reaches the service is an administrator."
+  type        = bool
+  default     = false
+}
+
+variable "metrics_flush_interval" {
+  description = "How often the spanmetrics connector flushes. The collector's own default is a leisurely 60s, which makes a dashboard useless during an incident."
+  type        = string
+  default     = "5s"
+}
+
+variable "span_metrics_dimensions" {
+  description = "Span attributes promoted to metric labels. Everything else stays out of Prometheus, so the services can attribute spans freely."
+  type        = list(string)
+  default     = ["outcome", "severity", "reason", "continuation", "subject"]
+}
+
+# --- Scheduling -------------------------------------------------------------
+
+variable "node_selector" {
+  description = "Node labels pinning the dependencies to their pool."
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = "Tolerations for the dependency pool's taint."
+  type        = list(any)
+  default     = []
+}
+
+variable "observability_node_selector" {
+  description = "Node labels for Prometheus, Grafana and the collector, which normally sit on a different pool from NATS and Valkey."
+  type        = map(string)
+  default     = {}
+}
+
+variable "observability_tolerations" {
+  description = "Tolerations for the observability pool's taint."
+  type        = list(any)
+  default     = []
+}
+
+# --- Chart versions ---------------------------------------------------------
+
+variable "chart_versions" {
+  description = "Pinned chart versions. Floating versions turn an unrelated `tofu apply` into an unplanned dependency upgrade. Confirmed upstream on 2026-07-31."
+  type = object({
+    nats       = optional(string, "2.14.2")
+    valkey     = optional(string, "6.2.4")
+    prometheus = optional(string, "88.0.1")
+    collector  = optional(string, "0.165.0")
+  })
+  default = {}
+}
+
+variable "release_timeout" {
+  description = "Per-release timeout in seconds."
+  type        = number
+  default     = 900
+}
+
+variable "wait_for_rollout" {
+  description = "Whether Helm waits for pods to become Ready. False keeps a large apply from serialising behind the slowest StatefulSet."
+  type        = bool
+  default     = false
+}

--- a/infrastructure/terraform/modules/devstack/versions.tf
+++ b/infrastructure/terraform/modules/devstack/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.8"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+  }
+}

--- a/infrastructure/terraform/modules/platform/.terraform.lock.hcl
+++ b/infrastructure/terraform/modules/platform/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.50"
+  hashes = [
+    "h1:ULGxKibTy8Z9F3roMLNFiPgw+MDs7FYuOdiy+Oispi8=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}

--- a/infrastructure/terraform/modules/platform/cluster.tf
+++ b/infrastructure/terraform/modules/platform/cluster.tf
@@ -1,0 +1,163 @@
+# The GKE cluster. Standard, not Autopilot: the pipeline needs custom node
+# pools, local NVMe on the matcher pool, and pods with no CPU limit. Autopilot
+# rejects all three — it forces a CPU limit equal to the request, and a CFS cap
+# on a matcher freezes its rayon pool in 100ms throttle windows.
+
+resource "google_container_cluster" "cluster" {
+  project  = var.project_id
+  name     = var.cluster_name
+  location = var.region
+
+  deletion_protection = var.deletion_protection
+
+  network    = google_compute_network.vpc.id
+  subnetwork = google_compute_subnetwork.nodes.id
+
+  # A regional cluster replicates the control plane across the region's zones
+  # and spreads nodes across them, so a zonal outage costs a fraction of the
+  # matchers and a fraction of the orchestrator fleet rather than either
+  # outright. Upgrades and API calls are slower.
+  #
+  # The default pool is created and then removed, because its node config
+  # cannot be controlled. initial_node_count is required even so.
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  # VPC-native. Pod IPs are real VPC addresses out of the secondary range, so
+  # they are routable and the pod range arithmetic in main.tf applies.
+  ip_allocation_policy {
+    cluster_secondary_range_name  = local.pods_range_name
+    services_secondary_range_name = local.services_range_name
+  }
+
+  default_max_pods_per_node = var.max_pods_per_node
+
+  # Dataplane V2 is eBPF-based (Cilium). The iptables dataplane degrades as
+  # service and endpoint counts grow, and this cluster carries a Deployment per
+  # shard plus the orchestrator fleet. It cannot be turned off without
+  # rebuilding.
+  datapath_provider = "ADVANCED_DATAPATH"
+
+  private_cluster_config {
+    # No public IPs on nodes. Egress goes through Cloud NAT.
+    enable_private_nodes = true
+
+    # The endpoint stays public so CI and operators reach it without a bastion
+    # or a VPN. Only master_authorized_cidrs can connect. A private endpoint is
+    # tighter, but then every deploy must run from inside the VPC.
+    enable_private_endpoint = false
+    master_ipv4_cidr_block  = var.master_ipv4_cidr_block
+  }
+
+  master_authorized_networks_config {
+    # An empty list is a closed door, not an open one: an environment that has
+    # not declared its operators is unreachable from outside Google Cloud.
+    dynamic "cidr_blocks" {
+      for_each = var.master_authorized_cidrs
+      content {
+        cidr_block   = cidr_blocks.value.cidr_block
+        display_name = cidr_blocks.value.display_name
+      }
+    }
+  }
+
+  # Workload Identity replaces service account keys: the shard cache account
+  # binds to a Kubernetes one, so there is no JSON key to leak.
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  addons_config {
+    # Matcher pods mount the shard cache bucket read-only through this driver,
+    # so shard files need no image baking or hostPath sync.
+    gcs_fuse_csi_driver_config {
+      enabled = true
+    }
+
+    # Nothing is served over HTTP, so there is no Ingress to run it for.
+    http_load_balancing {
+      disabled = true
+    }
+
+    # Node pools declare their own bounds, sized by the capacity module.
+    # Vertical pod autoscaling would fight those numbers.
+    horizontal_pod_autoscaling {
+      disabled = false
+    }
+  }
+
+  # Node pool autoscaling only. Node auto-provisioning stays off: a machine
+  # type chosen at runtime is a machine type nobody sized.
+  #
+  # OPTIMIZE_UTILIZATION removes underused nodes sooner than BALANCED. That was
+  # safe when every pod was pinned to a shard for its lifetime; matchers now
+  # carry an HPA, so scale-down does follow traffic. It stays because the
+  # eviction it risks is a matcher replica — one member of a shard's queue
+  # group, whose requests the others take — and never an orchestrator, which
+  # has no autoscaler and owns its partitions alone.
+  cluster_autoscaling {
+    enabled             = false
+    autoscaling_profile = "OPTIMIZE_UTILIZATION"
+  }
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+  logging_config {
+    # System components and the control plane only. The services already export
+    # logs and spans through the collector, and Cloud Logging bills per GiB.
+    enable_components = [
+      "SYSTEM_COMPONENTS",
+      "APISERVER",
+      "CONTROLLER_MANAGER",
+      "SCHEDULER",
+    ]
+  }
+
+  monitoring_config {
+    enable_components = [
+      "SYSTEM_COMPONENTS",
+      "APISERVER",
+      "CONTROLLER_MANAGER",
+      "SCHEDULER",
+      # Per-container CPU and memory: how to tell a saturated matcher from a
+      # starved one.
+      "KUBELET",
+      "CADVISOR",
+    ]
+
+    # Managed Prometheus scrapes the cluster with no server to operate. It is
+    # the managed equivalent of kube-prometheus-stack in infrastructure/dev.
+    managed_prometheus {
+      enabled = true
+    }
+  }
+
+  master_auth {
+    # Legacy client certificate auth issues a credential that cannot be revoked
+    # and does not expire. Workload Identity and IAM cover every access path.
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  resource_labels = merge(var.labels, {
+    env       = var.env
+    component = "routers-platform"
+  })
+
+  lifecycle {
+    ignore_changes = [
+      # GKE and other controllers write their own labels onto the cluster.
+      # Without this, every plan after an addon update shows a label diff.
+      resource_labels["goog-composer-environment"],
+    ]
+  }
+
+  depends_on = [
+    # Nodes that boot before NAT exists cannot pull images, and pool creation
+    # then times out.
+    google_compute_router_nat.nat,
+  ]
+}

--- a/infrastructure/terraform/modules/platform/main.tf
+++ b/infrastructure/terraform/modules/platform/main.tf
@@ -27,6 +27,16 @@ locals {
   # fleet, so widening the range is cheap and getting it wrong is not.
   pod_range_node_capacity = pow(2, local.node_pod_slice_prefix - local.pods_prefix)
 
+  # Machine series that support Hyperdisk only. A pd-* boot disk on one of
+  # these does not run slower, it fails instance creation — and it fails
+  # during apply, after the cluster exists and while its pools are building.
+  hyperdisk_only_series = ["c4", "c4a", "c4d", "n4", "z3"]
+
+  pools_requiring_hyperdisk = [
+    for name, pool in var.node_pools : "${name} (${pool.machine_type})"
+    if contains(local.hyperdisk_only_series, split("-", pool.machine_type)[0])
+  ]
+
   # Kubernetes node labels, keyed by pool. Deliberately only the pool
   # identity: these become nodeSelectors in the realtime chart, and mixing
   # billing labels into a selector makes a pod's placement depend on a

--- a/infrastructure/terraform/modules/platform/main.tf
+++ b/infrastructure/terraform/modules/platform/main.tf
@@ -1,0 +1,59 @@
+# Derived values shared by the network, cluster and node pool files. Nothing
+# here talks to GCP; it is the arithmetic that decides whether the addressing
+# plan can hold the fleet the capacity module asked for.
+
+locals {
+  name_prefix = "${var.env}-${var.cluster_name}"
+
+  subnet_name         = "${var.network_name}-nodes"
+  pods_range_name     = "${var.network_name}-pods"
+  services_range_name = "${var.network_name}-services"
+
+  # The autoscaler ceiling across every pool. This, not the steady state, is
+  # what the pod range has to survive: the range is exhausted at the peak.
+  max_nodes = sum([for name, pool in var.node_pools : pool.max_node_count])
+
+  # GKE reserves a fixed pod slice per node. The slice holds twice
+  # max_pods_per_node addresses, rounded up to a power of two, which gives the
+  # slice's prefix length. At 110 pods: 2 * 110 = 220, rounded up to 256, so
+  # 32 - log2(256) = /24 per node.
+  node_pod_slice_prefix = 32 - ceil(log(var.max_pods_per_node * 2, 2))
+
+  pods_prefix = tonumber(split("/", var.pods_secondary_cidr)[1])
+
+  # How many of those slices the pod range contains, and so the hard ceiling
+  # on node count. A /16 split into /24s yields 2^(24-16) = 256 nodes. A /15
+  # yields 512. Note the doubling: one extra bit of pod range doubles the
+  # fleet, so widening the range is cheap and getting it wrong is not.
+  pod_range_node_capacity = pow(2, local.node_pod_slice_prefix - local.pods_prefix)
+
+  # Kubernetes node labels, keyed by pool. Deliberately only the pool
+  # identity: these become nodeSelectors in the realtime chart, and mixing
+  # billing labels into a selector makes a pod's placement depend on a
+  # billing change.
+  pool_node_labels = {
+    for name, pool in var.node_pools : name => {
+      "routers.dev/pool" = name
+    }
+  }
+
+  # The GKE API spells effects NO_SCHEDULE; a Kubernetes toleration spells the
+  # same thing NoSchedule. Translate once here so consumers of the
+  # `pool_tolerations` output can paste it straight into a pod spec.
+  taint_effect_to_kubernetes = {
+    NO_SCHEDULE        = "NoSchedule"
+    PREFER_NO_SCHEDULE = "PreferNoSchedule"
+    NO_EXECUTE         = "NoExecute"
+  }
+
+  pool_tolerations = {
+    for name, pool in var.node_pools : name => [
+      for t in pool.taints : {
+        key      = t.key
+        operator = "Equal"
+        value    = t.value
+        effect   = local.taint_effect_to_kubernetes[t.effect]
+      }
+    ]
+  }
+}

--- a/infrastructure/terraform/modules/platform/network.tf
+++ b/infrastructure/terraform/modules/platform/network.tf
@@ -1,0 +1,85 @@
+# VPC, node subnet and egress. Nodes are private, so the only route off the
+# cluster is Cloud NAT.
+
+resource "google_compute_network" "vpc" {
+  project = var.project_id
+  name    = var.network_name
+
+  # Auto mode creates a subnet in every region with ranges we do not control,
+  # and those ranges tend to collide with the pod range later.
+  auto_create_subnetworks = false
+
+  # Traffic is pod-to-pod within the region; global routing only adds cost.
+  routing_mode = "REGIONAL"
+}
+
+resource "google_compute_subnetwork" "nodes" {
+  project = var.project_id
+  name    = local.subnet_name
+  region  = var.region
+  network = google_compute_network.vpc.id
+
+  # Only nodes draw from the primary range. That is what VPC-native means.
+  ip_cidr_range = var.subnet_cidr
+
+  # Nodes have no external IPs, so they reach Google APIs (Artifact Registry,
+  # GCS, the metadata server) over the internal path rather than NAT.
+  private_ip_google_access = true
+
+  secondary_ip_range {
+    range_name    = local.pods_range_name
+    ip_cidr_range = var.pods_secondary_cidr
+  }
+
+  secondary_ip_range {
+    range_name    = local.services_range_name
+    ip_cidr_range = var.services_secondary_cidr
+  }
+
+  lifecycle {
+    # The pod range is fixed for the life of the cluster: enlarging it means
+    # rebuilding. Fail at plan time, not at 3am when the autoscaler stops
+    # adding nodes because it cannot allocate a pod range.
+    precondition {
+      condition     = local.pod_range_node_capacity >= local.max_nodes
+      error_message = "pods_secondary_cidr (${var.pods_secondary_cidr}) holds ${local.pod_range_node_capacity} nodes at ${var.max_pods_per_node} pods per node, but the pools scale to ${local.max_nodes}. Widen the range by one bit to double the capacity."
+    }
+
+    # Overlap is accepted by the API in some orders and then breaks routing.
+    precondition {
+      condition = !(
+        cidrhost(var.subnet_cidr, 0) == cidrhost(var.pods_secondary_cidr, 0) ||
+        cidrhost(var.subnet_cidr, 0) == cidrhost(var.services_secondary_cidr, 0) ||
+        cidrhost(var.pods_secondary_cidr, 0) == cidrhost(var.services_secondary_cidr, 0)
+      )
+      error_message = "subnet_cidr, pods_secondary_cidr and services_secondary_cidr must be distinct ranges."
+    }
+  }
+}
+
+resource "google_compute_router" "router" {
+  project = var.project_id
+  name    = "${local.name_prefix}-router"
+  region  = var.region
+  network = google_compute_network.vpc.id
+}
+
+resource "google_compute_router_nat" "nat" {
+  project = var.project_id
+  name    = "${local.name_prefix}-nat"
+  region  = var.region
+  router  = google_compute_router.router.name
+
+  # Private nodes still need the public internet: image layers not in Artifact
+  # Registry, GKE addons, OS updates during repair. Without NAT a new node
+  # boots and then fails to pull.
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    # Successful translations are high volume and tell us nothing. Failures
+    # mean port exhaustion, seen as image pulls timing out on new nodes.
+    filter = "ERRORS_ONLY"
+  }
+}

--- a/infrastructure/terraform/modules/platform/node_pools.tf
+++ b/infrastructure/terraform/modules/platform/node_pools.tf
@@ -124,6 +124,14 @@ resource "google_container_node_pool" "pool" {
     ignore_changes = [initial_node_count]
 
     precondition {
+      condition = (
+        length(local.pools_requiring_hyperdisk) == 0
+        || startswith(var.node_disk_type, "hyperdisk-")
+      )
+      error_message = "node_disk_type is ${var.node_disk_type}, but these pools use a machine series that supports Hyperdisk only: ${join(", ", local.pools_requiring_hyperdisk)}. Persistent Disk is not slower there, it is unavailable, so the pool would fail to create nodes. Use hyperdisk-balanced."
+    }
+
+    precondition {
       condition     = !(each.value.spot && length(each.value.taints) == 0)
       error_message = "Pool ${each.key} is spot with no taint, so anything may land on preemptible nodes. That is survivable for a shard's matchers, which are a queue group, and not for the orchestrator fleet, whose pods each own vehicle partitions outright. Make the placement deliberate: add a taint and select for it in the chart."
     }

--- a/infrastructure/terraform/modules/platform/node_pools.tf
+++ b/infrastructure/terraform/modules/platform/node_pools.tf
@@ -1,0 +1,131 @@
+# Node pools, one per entry in `node_pools`. Shapes come from the capacity
+# module; this file only turns them into infrastructure.
+
+resource "google_service_account" "nodes" {
+  project      = var.project_id
+  account_id   = "${var.env}-gke-nodes"
+  display_name = "GKE nodes (${var.cluster_name})"
+}
+
+# The default compute service account is Editor on the project. Nodes get their
+# own instead, with only what a kubelet needs to report in.
+resource "google_project_iam_member" "nodes" {
+  for_each = toset([
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/monitoring.viewer",
+    "roles/stackdriver.resourceMetadata.writer",
+  ])
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.nodes.email}"
+}
+
+resource "google_container_node_pool" "pool" {
+  for_each = var.node_pools
+
+  project  = var.project_id
+  name     = each.key
+  location = var.region
+  cluster  = google_container_cluster.cluster.name
+
+  # Per zone, unlike the totals below. The autoscaler corrects it immediately,
+  # so it only decides how many nodes exist before the first scale event.
+  initial_node_count = 1
+
+  autoscaling {
+    # `total_` prefixed, deliberately. The unprefixed pair is per zone, so on a
+    # three-zone regional cluster it would treble every number the capacity
+    # module produced.
+    total_min_node_count = each.value.min_node_count
+    total_max_node_count = each.value.max_node_count
+
+    # Spread nodes over the region's zones rather than filling the cheapest, so
+    # a zone loss costs a fraction of each tier rather than all of one. It
+    # matters most to the orchestrator fleet: a lost pod's vehicle partitions
+    # have no other owner until it reschedules, where a shard's matchers form a
+    # queue group whose surviving members absorb the requests.
+    location_policy = "BALANCED"
+  }
+
+  max_pods_per_node = var.max_pods_per_node
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  upgrade_settings {
+    # Add a node before taking one away. max_unavailable > 0 would drain
+    # orchestrator pods whose partitions have no other owner, and each
+    # replacement re-warms from Valkey every history lane it inherits.
+    strategy        = "SURGE"
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
+  node_config {
+    machine_type = each.value.machine_type
+    spot         = each.value.spot
+
+    disk_size_gb = var.node_disk_size_gb
+    disk_type    = var.node_disk_type
+
+    service_account = google_service_account.nodes.email
+    # Scopes are the legacy access-control layer and cannot be narrowed usefully
+    # once IAM is doing the work; the node's own IAM roles are the real bound.
+    oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    labels = local.pool_node_labels[each.key]
+
+    dynamic "taint" {
+      for_each = each.value.taints
+      content {
+        key    = taint.value.key
+        value  = taint.value.value
+        effect = taint.value.effect
+      }
+    }
+
+    dynamic "ephemeral_storage_local_ssd_config" {
+      for_each = each.value.local_ssd_count > 0 ? [each.value.local_ssd_count] : []
+      content {
+        local_ssd_count = ephemeral_storage_local_ssd_config.value
+      }
+    }
+
+    # Required for Workload Identity. Without it pods reach the legacy metadata
+    # server and inherit the node service account.
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    # Lazily pull image layers, so a matcher starts before its whole image has
+    # landed. These images are large and every scale-up event pays for them.
+    gcfs_config {
+      enabled = true
+    }
+
+    shielded_instance_config {
+      enable_secure_boot          = true
+      enable_integrity_monitoring = true
+    }
+
+    resource_labels = merge(var.labels, {
+      env       = var.env
+      component = "routers-platform"
+      pool      = each.key
+    })
+  }
+
+  lifecycle {
+    # The autoscaler owns this after creation.
+    ignore_changes = [initial_node_count]
+
+    precondition {
+      condition     = !(each.value.spot && length(each.value.taints) == 0)
+      error_message = "Pool ${each.key} is spot with no taint, so anything may land on preemptible nodes. That is survivable for a shard's matchers, which are a queue group, and not for the orchestrator fleet, whose pods each own vehicle partitions outright. Make the placement deliberate: add a taint and select for it in the chart."
+    }
+  }
+}

--- a/infrastructure/terraform/modules/platform/outputs.tf
+++ b/infrastructure/terraform/modules/platform/outputs.tf
@@ -1,0 +1,68 @@
+output "cluster_name" {
+  value = google_container_cluster.cluster.name
+}
+
+output "cluster_endpoint" {
+  description = "Control plane address, for the kubernetes and helm providers."
+  value       = google_container_cluster.cluster.endpoint
+  sensitive   = true
+}
+
+output "cluster_ca_certificate" {
+  description = "Base64 cluster CA, for the kubernetes and helm providers."
+  value       = google_container_cluster.cluster.master_auth[0].cluster_ca_certificate
+  sensitive   = true
+}
+
+output "cluster_location" {
+  value = google_container_cluster.cluster.location
+}
+
+output "network" {
+  value = {
+    vpc_id    = google_compute_network.vpc.id
+    subnet_id = google_compute_subnetwork.nodes.id
+  }
+}
+
+output "pool_names" {
+  value = [for name, pool in google_container_node_pool.pool : pool.name]
+}
+
+output "pool_node_selectors" {
+  description = "nodeSelector per pool, to pass to the realtime module's *_node_selector inputs."
+  value       = local.pool_node_labels
+}
+
+output "pool_tolerations" {
+  description = "Tolerations per pool, already in Kubernetes spelling."
+  value       = local.pool_tolerations
+}
+
+output "image_registry" {
+  description = "Registry prefix for the chart's image.registry."
+  value       = "${google_artifact_registry_repository.images.location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.images.repository_id}"
+}
+
+output "shard_bucket" {
+  value = google_storage_bucket.shards.name
+}
+
+output "shard_cache_service_account_email" {
+  description = "Google service account the matcher's Kubernetes service account impersonates. Becomes the chart's iam.gke.io/gcp-service-account annotation."
+  value       = google_service_account.shard_cache.email
+}
+
+output "node_service_account_email" {
+  value = google_service_account.nodes.email
+}
+
+output "addressing" {
+  description = "Pod range arithmetic, so a root can report how close the fleet is to exhausting it."
+  value = {
+    max_pods_per_node       = var.max_pods_per_node
+    node_pod_slice_prefix   = local.node_pod_slice_prefix
+    pod_range_node_capacity = local.pod_range_node_capacity
+    max_nodes               = local.max_nodes
+  }
+}

--- a/infrastructure/terraform/modules/platform/registry.tf
+++ b/infrastructure/terraform/modules/platform/registry.tf
@@ -1,0 +1,29 @@
+# Artifact Registry for the matcher and orchestrator images.
+
+resource "google_artifact_registry_repository" "images" {
+  project       = var.project_id
+  location      = var.region
+  repository_id = var.artifact_repository_id
+  format        = "DOCKER"
+  description   = "routers realtime pipeline images"
+
+  docker_config {
+    # A tag that can be moved is a tag that cannot be rolled back to. With one
+    # replica per shard there is no second pod to compare a bad image against.
+    immutable_tags = var.immutable_image_tags
+  }
+
+  labels = merge(var.labels, {
+    env       = var.env
+    component = "routers-platform"
+  })
+}
+
+# Repository-scoped, not project-wide: nodes pull these images and nothing else.
+resource "google_artifact_registry_repository_iam_member" "nodes_pull" {
+  project    = var.project_id
+  location   = google_artifact_registry_repository.images.location
+  repository = google_artifact_registry_repository.images.name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.nodes.email}"
+}

--- a/infrastructure/terraform/modules/platform/storage.tf
+++ b/infrastructure/terraform/modules/platform/storage.tf
@@ -1,0 +1,58 @@
+# Shard cache bucket. Matcher pods mount it read-only through the GCS FUSE CSI
+# driver, so the `<shard>.shard.rt` files are neither baked into the image nor
+# synced onto a hostPath.
+
+resource "google_storage_bucket" "shards" {
+  project  = var.project_id
+  name     = var.shard_bucket_name
+  location = var.region
+
+  # Same region as the cluster. A matcher reads its whole shard file at
+  # startup, so a cross-region read costs latency and egress on every restart.
+  storage_class = "STANDARD"
+
+  force_destroy               = !var.deletion_protection
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+
+  # A shard file is regenerated, not edited. Versioning is what makes a bad
+  # generation recoverable while matchers are already reading it.
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    condition {
+      num_newer_versions = var.shard_bucket_keep_versions
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  labels = merge(var.labels, {
+    env       = var.env
+    component = "routers-platform"
+  })
+}
+
+resource "google_service_account" "shard_cache" {
+  project      = var.project_id
+  account_id   = "${var.env}-shard-cache"
+  display_name = "Shard cache reader (${var.cluster_name})"
+}
+
+resource "google_storage_bucket_iam_member" "shard_cache_read" {
+  bucket = google_storage_bucket.shards.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.shard_cache.email}"
+}
+
+# Lets the named Kubernetes service account impersonate the Google one, which
+# is what removes the service account key. The binding is by name and holds
+# whether or not the chart has created that service account yet.
+resource "google_service_account_iam_member" "shard_cache_workload_identity" {
+  service_account_id = google_service_account.shard_cache.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.workload_identity_namespace}/${var.workload_identity_service_account}]"
+}

--- a/infrastructure/terraform/modules/platform/tests/platform.tftest.hcl
+++ b/infrastructure/terraform/modules/platform/tests/platform.tftest.hcl
@@ -143,6 +143,45 @@ run "rejects_the_kubernetes_spelling_of_a_taint_effect" {
   expect_failures = [var.node_pools]
 }
 
+# C4 supports Hyperdisk only. A pd-* boot disk there is not the slower choice,
+# it is an unavailable one, and it fails during apply — after the cluster
+# exists and while its pools are building.
+run "rejects_persistent_disk_on_a_hyperdisk_only_series" {
+  command = plan
+
+  variables {
+    node_disk_type = "pd-balanced"
+
+    node_pools = {
+      matcher = {
+        machine_type   = "c4-highcpu-32"
+        min_node_count = 1
+        max_node_count = 2
+      }
+    }
+  }
+
+  expect_failures = [google_container_node_pool.pool["matcher"]]
+}
+
+# The same pool is fine once the disk matches what the series offers, so the
+# guard is about compatibility rather than about C4 being unusable.
+run "accepts_hyperdisk_on_a_hyperdisk_only_series" {
+  command = plan
+
+  variables {
+    node_disk_type = "hyperdisk-balanced"
+
+    node_pools = {
+      matcher = {
+        machine_type   = "c4-highcpu-32"
+        min_node_count = 1
+        max_node_count = 2
+      }
+    }
+  }
+}
+
 # Preemption on an untainted pool is silent: pods land there because nothing
 # stopped them, and a matcher losing its node takes its shard offline.
 run "rejects_an_untainted_spot_pool" {

--- a/infrastructure/terraform/modules/platform/tests/platform.tftest.hcl
+++ b/infrastructure/terraform/modules/platform/tests/platform.tftest.hcl
@@ -1,0 +1,190 @@
+# Guards on the substrate itself, driven directly rather than through an env
+# root. Mock providers stand in for GCP, so this runs without credentials.
+
+mock_provider "google" {
+  mock_resource "google_service_account" {
+    defaults = {
+      name  = "projects/routers-test/serviceAccounts/dev-shard-cache@routers-test.iam.gserviceaccount.com"
+      email = "dev-shard-cache@routers-test.iam.gserviceaccount.com"
+    }
+  }
+
+  mock_resource "google_artifact_registry_repository" {
+    defaults = {
+      name = "routers"
+    }
+  }
+}
+
+variables {
+  project_id        = "routers-test"
+  region            = "australia-southeast1"
+  env               = "dev"
+  cluster_name      = "routers"
+  network_name      = "routers"
+  shard_bucket_name = "routers-test-shards"
+
+  subnet_cidr             = "10.0.0.0/20"
+  pods_secondary_cidr     = "10.16.0.0/16"
+  services_secondary_cidr = "10.32.0.0/20"
+
+  node_pools = {
+    matcher = { machine_type = "c4-highcpu-32", min_node_count = 4, max_node_count = 8 }
+  }
+}
+
+# GKE gives every node a fixed slice of the pod range, sized to twice
+# max_pods_per_node rounded up to a power of two. At 110 pods that is a /24, so
+# a /16 holds 256 nodes and no more.
+run "pod_range_arithmetic_follows_the_slice_size" {
+  command = plan
+
+  assert {
+    condition     = output.addressing.node_pod_slice_prefix == 24
+    error_message = "Expected a /24 slice per node at 110 pods, got /${output.addressing.node_pod_slice_prefix}."
+  }
+
+  assert {
+    condition     = output.addressing.pod_range_node_capacity == 256
+    error_message = "Expected a /16 to hold 256 nodes, got ${output.addressing.pod_range_node_capacity}."
+  }
+}
+
+# One extra bit of pod range doubles the fleet, which is why widening it early
+# is cheap and getting it wrong is not.
+run "one_more_bit_doubles_the_node_capacity" {
+  command = plan
+
+  variables {
+    pods_secondary_cidr = "10.16.0.0/15"
+  }
+
+  assert {
+    condition     = output.addressing.pod_range_node_capacity == 512
+    error_message = "Expected a /15 to hold 512 nodes, got ${output.addressing.pod_range_node_capacity}."
+  }
+}
+
+# The pod range is fixed for the life of the cluster: GKE cannot re-slice it
+# once nodes hold slices. The failure otherwise appears at 3am, when the
+# autoscaler stops adding nodes because it cannot allocate a pod range.
+run "rejects_a_pod_range_the_pools_can_outgrow" {
+  command = plan
+
+  variables {
+    node_pools = {
+      matcher = { machine_type = "c4-highcpu-32", min_node_count = 100, max_node_count = 300 }
+    }
+  }
+
+  expect_failures = [google_compute_subnetwork.nodes]
+}
+
+# Raising the pod ceiling enlarges every node's slice, so it lowers the node
+# count the same range supports. Easy to get backwards.
+run "more_pods_per_node_means_fewer_nodes" {
+  command = plan
+
+  variables {
+    max_pods_per_node = 256
+  }
+
+  assert {
+    condition     = output.addressing.pod_range_node_capacity == 128
+    error_message = "Expected 128 nodes at 256 pods each in a /16, got ${output.addressing.pod_range_node_capacity}."
+  }
+}
+
+# The GKE API spells taint effects in screaming snake case; a pod spec spells
+# them differently. The module translates so the chart can paste the output in.
+run "taints_are_translated_for_pod_specs" {
+  command = plan
+
+  variables {
+    node_pools = {
+      matcher = {
+        machine_type   = "c4-highcpu-32"
+        min_node_count = 1
+        max_node_count = 2
+        taints = [{
+          key    = "routers.dev/pool"
+          value  = "matcher"
+          effect = "NO_SCHEDULE"
+        }]
+      }
+    }
+  }
+
+  assert {
+    condition     = output.pool_tolerations["matcher"][0].effect == "NoSchedule"
+    error_message = "Expected NoSchedule, got ${output.pool_tolerations["matcher"][0].effect}."
+  }
+
+  assert {
+    condition     = output.pool_tolerations["matcher"][0].operator == "Equal"
+    error_message = "A toleration for a valued taint must use Equal."
+  }
+}
+
+run "rejects_the_kubernetes_spelling_of_a_taint_effect" {
+  command = plan
+
+  variables {
+    node_pools = {
+      matcher = {
+        machine_type   = "c4-highcpu-32"
+        min_node_count = 1
+        max_node_count = 2
+        taints         = [{ key = "k", value = "v", effect = "NoSchedule" }]
+      }
+    }
+  }
+
+  expect_failures = [var.node_pools]
+}
+
+# Preemption on an untainted pool is silent: pods land there because nothing
+# stopped them, and a matcher losing its node takes its shard offline.
+run "rejects_an_untainted_spot_pool" {
+  command = plan
+
+  variables {
+    node_pools = {
+      matcher = {
+        machine_type   = "c4-highcpu-32"
+        min_node_count = 1
+        max_node_count = 2
+        spot           = true
+      }
+    }
+  }
+
+  expect_failures = [google_container_node_pool.pool["matcher"]]
+}
+
+# Autoscaler bounds are cluster-wide totals. The unprefixed pair is per zone,
+# which on a three-zone regional cluster would treble every number the capacity
+# module produced.
+run "autoscaling_bounds_are_totals_not_per_zone" {
+  command = plan
+
+  assert {
+    condition     = google_container_node_pool.pool["matcher"].autoscaling[0].total_min_node_count == 4
+    error_message = "Expected a total floor of 4 nodes."
+  }
+
+  assert {
+    condition     = google_container_node_pool.pool["matcher"].autoscaling[0].max_node_count == null
+    error_message = "The per-zone bound must stay unset, or it fights the total."
+  }
+}
+
+run "rejects_a_pods_range_smaller_than_a_slash_16" {
+  command = plan
+
+  variables {
+    pods_secondary_cidr = "10.16.0.0/20"
+  }
+
+  expect_failures = [var.pods_secondary_cidr]
+}

--- a/infrastructure/terraform/modules/platform/variables.tf
+++ b/infrastructure/terraform/modules/platform/variables.tf
@@ -1,0 +1,265 @@
+# Inputs to the GCP substrate for the routers realtime pipeline. Sizing is not
+# chosen here: `node_pools` comes from the capacity module's `pools` output,
+# and this module only turns that shape into infrastructure.
+
+variable "project_id" {
+  description = "GCP project that owns the network, cluster, registry and bucket."
+  type        = string
+}
+
+variable "region" {
+  description = <<-EOT
+    Region for every regional resource. Keep the bucket and the cluster in the
+    same region: a matcher reads its shard cache through the GCS FUSE mount, so
+    a cross-region bucket adds latency and egress cost to every cache miss.
+  EOT
+  type        = string
+}
+
+variable "env" {
+  description = "Short environment name used in resource names. Short because a service account id is limited to 30 characters and this prefixes several of them."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{0,11}$", var.env))
+    error_message = "env must be 1-12 characters, lowercase letters, digits and dashes, starting with a letter."
+  }
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster."
+  type        = string
+}
+
+variable "network_name" {
+  description = "Name of the VPC. Subnets are created explicitly, so no default subnet appears."
+  type        = string
+}
+
+variable "subnet_cidr" {
+  description = "Primary range of the node subnet. Only node addresses come from here, so it stays small: pods and services use the secondary ranges below."
+  type        = string
+
+  validation {
+    condition     = can(cidrhost(var.subnet_cidr, 0))
+    error_message = "subnet_cidr must be a valid IPv4 CIDR block."
+  }
+}
+
+variable "pods_secondary_cidr" {
+  description = <<-EOT
+    Secondary range for pod IPs. It must be much larger than it first appears
+    necessary.
+
+    GKE gives every node a fixed slice of this range, sized to twice
+    `max_pods_per_node` rounded up to a power of two, so a node at 110 pods
+    consumes a /24 and never releases part of it. Usable node count is the
+    number of slices that fit, not the address count: at 110 pods per node a
+    /16 holds exactly 256 nodes. The failure appears late — the autoscaler
+    stops adding nodes because it cannot allocate a pod range — so size for the
+    ceiling. The precondition in network.tf checks this against the sum of
+    `max_node_count` over all pools.
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(cidrhost(var.pods_secondary_cidr, 0))
+    error_message = "pods_secondary_cidr must be a valid IPv4 CIDR block."
+  }
+
+  validation {
+    # /16 reaches only 256 nodes at 110 pods per node. Anything smaller cannot
+    # host a fleet of this shape, so reject it before a plan is drawn.
+    condition     = tonumber(split("/", var.pods_secondary_cidr)[1]) <= 16
+    error_message = "pods_secondary_cidr must be /16 or larger; smaller ranges cannot hold enough per-node pod slices."
+  }
+}
+
+variable "services_secondary_cidr" {
+  description = "Secondary range for ClusterIP services. The pipeline uses headless services and direct NATS subjects rather than a service per shard, so this range stays modest even at high shard counts."
+  type        = string
+
+  validation {
+    condition     = can(cidrhost(var.services_secondary_cidr, 0))
+    error_message = "services_secondary_cidr must be a valid IPv4 CIDR block."
+  }
+}
+
+variable "max_pods_per_node" {
+  description = "Pod ceiling per node, applied to every pool and to the cluster default. It also drives the pod range arithmetic: raising it enlarges every node's pod slice and so lowers the node count the range supports."
+  type        = number
+  default     = 110
+
+  validation {
+    condition     = var.max_pods_per_node >= 8 && var.max_pods_per_node <= 256
+    error_message = "max_pods_per_node must be between 8 and 256."
+  }
+}
+
+variable "release_channel" {
+  description = "GKE release channel. REGULAR is the usual choice. UNSPECIFIED pins the version by hand and also turns off node auto-upgrade, which then becomes a manual job."
+  type        = string
+  default     = "REGULAR"
+
+  validation {
+    condition     = contains(["RAPID", "REGULAR", "STABLE", "EXTENDED", "UNSPECIFIED"], var.release_channel)
+    error_message = "release_channel must be one of RAPID, REGULAR, STABLE, EXTENDED or UNSPECIFIED."
+  }
+}
+
+variable "master_authorized_cidrs" {
+  description = <<-EOT
+    Networks allowed to reach the control plane. The endpoint is public but
+    closed by default: an empty list means nothing outside Google Cloud reaches
+    the API server, including your laptop and CI.
+  EOT
+  type = list(object({
+    cidr_block   = string
+    display_name = string
+  }))
+  default = []
+}
+
+variable "master_ipv4_cidr_block" {
+  description = "Range for the control plane's own endpoints. It is peered into the VPC and must not overlap the subnet or either secondary range. A /28 is required."
+  type        = string
+  default     = "172.16.0.0/28"
+
+  validation {
+    condition     = can(cidrhost(var.master_ipv4_cidr_block, 0)) && tonumber(split("/", var.master_ipv4_cidr_block)[1]) == 28
+    error_message = "master_ipv4_cidr_block must be a valid IPv4 CIDR with a /28 prefix."
+  }
+}
+
+variable "node_pools" {
+  description = <<-EOT
+    Node pools to create, keyed by pool name. This shape is the capacity
+    module's `pools` output: pass it through rather than hand-writing it.
+    `max_node_count` is the ceiling covering headroom plus rollout surge. Set
+    `spot` only for work that can lose its node without consequence: a matcher
+    owns a shard, so preemption there rebuilds that shard's state.
+  EOT
+  type = map(object({
+    machine_type   = string
+    min_node_count = number
+    max_node_count = number
+
+    taints          = optional(list(object({ key = string, value = string, effect = string })), [])
+    local_ssd_count = optional(number, 0)
+    spot            = optional(bool, false)
+  }))
+
+  validation {
+    condition     = length(var.node_pools) > 0
+    error_message = "At least one node pool is required."
+  }
+
+  validation {
+    condition = alltrue([
+      for name, pool in var.node_pools : pool.min_node_count >= 1 && pool.max_node_count >= pool.min_node_count
+    ])
+    error_message = "Every pool needs min_node_count >= 1 and max_node_count >= min_node_count."
+  }
+
+  validation {
+    # The GKE API spells taint effects in screaming snake case, unlike the
+    # Kubernetes manifests that tolerate them. The module converts to the
+    # Kubernetes spelling in the `pool_tolerations` output.
+    condition = alltrue(flatten([
+      for name, pool in var.node_pools : [
+        for t in pool.taints : contains(["NO_SCHEDULE", "PREFER_NO_SCHEDULE", "NO_EXECUTE"], t.effect)
+      ]
+    ]))
+    error_message = "Taint effect must be NO_SCHEDULE, PREFER_NO_SCHEDULE or NO_EXECUTE."
+  }
+
+  validation {
+    condition = alltrue([
+      for name, pool in var.node_pools : pool.local_ssd_count >= 0 && pool.local_ssd_count <= 8
+    ])
+    error_message = "local_ssd_count must be between 0 and 8."
+  }
+}
+
+variable "node_disk_size_gb" {
+  description = "Boot disk per node. Holds the image layers, and image streaming keeps the working set small."
+  type        = number
+  default     = 100
+
+  validation {
+    condition     = var.node_disk_size_gb >= 50
+    error_message = "node_disk_size_gb must be at least 50; smaller disks throttle image pulls."
+  }
+}
+
+variable "node_disk_type" {
+  description = "Boot disk type. pd-balanced is the usual choice; nodes hold no state worth pd-ssd."
+  type        = string
+  default     = "pd-balanced"
+
+  validation {
+    condition     = contains(["pd-standard", "pd-balanced", "pd-ssd", "hyperdisk-balanced"], var.node_disk_type)
+    error_message = "node_disk_type must be pd-standard, pd-balanced, pd-ssd or hyperdisk-balanced."
+  }
+}
+
+variable "artifact_repository_id" {
+  description = "Name of the Docker repository that holds the matcher and orchestrator images."
+  type        = string
+  default     = "routers"
+}
+
+variable "immutable_image_tags" {
+  description = "Refuse to move a tag that already exists. Worth leaving on: with one replica per shard, a bad image takes that shard offline and a moved tag leaves nothing to roll back to."
+  type        = bool
+  default     = true
+}
+
+variable "shard_bucket_keep_versions" {
+  description = "Noncurrent shard file versions retained before deletion."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.shard_bucket_keep_versions >= 1
+    error_message = "shard_bucket_keep_versions must be at least 1."
+  }
+}
+
+variable "shard_bucket_name" {
+  description = "Bucket holding the `<shard>.shard.rt` files. Bucket names are global, so this needs a project or organisation prefix to be unique."
+  type        = string
+}
+
+variable "workload_identity_namespace" {
+  description = "Kubernetes namespace of the Helm release whose service account may read the shard bucket."
+  type        = string
+  default     = "routers"
+}
+
+variable "workload_identity_service_account" {
+  description = <<-EOT
+    Kubernetes service account that matcher pods run as, bound to the shard
+    cache Google service account so only pods using it in
+    `workload_identity_namespace` read the bucket. The binding is by name, so
+    it exists whether or not the chart has created the account yet.
+  EOT
+  type        = string
+  default     = "routers-matcher"
+}
+
+variable "deletion_protection" {
+  description = <<-EOT
+    Guards the cluster and the shard bucket against destroy. Leave it on
+    outside scratch environments: `tofu destroy` on a realtime cluster is not
+    recoverable from state. It also controls `force_destroy` on the bucket.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "labels" {
+  description = "GCP resource labels for billing and ownership, applied to every resource that accepts them. Not Kubernetes node labels, which the module derives from the pool name."
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/terraform/modules/platform/variables.tf
+++ b/infrastructure/terraform/modules/platform/variables.tf
@@ -193,13 +193,27 @@ variable "node_disk_size_gb" {
 }
 
 variable "node_disk_type" {
-  description = "Boot disk type. pd-balanced is the usual choice; nodes hold no state worth pd-ssd."
+  description = <<-EOT
+    Boot disk type.
+
+    `hyperdisk-balanced`, and on C4 there is no alternative: the series does
+    not support Persistent Disk at all, so a pd-* value fails at instance
+    creation rather than merely being a slower choice. For a series that
+    supports only Hyperdisk, the boot disk must itself be Hyperdisk Balanced.
+
+    Nodes still hold no state worth paying for — this is image layers under
+    streaming — so the capacity is small and the performance is left at the
+    class default.
+  EOT
   type        = string
-  default     = "pd-balanced"
+  default     = "hyperdisk-balanced"
 
   validation {
-    condition     = contains(["pd-standard", "pd-balanced", "pd-ssd", "hyperdisk-balanced"], var.node_disk_type)
-    error_message = "node_disk_type must be pd-standard, pd-balanced, pd-ssd or hyperdisk-balanced."
+    condition = contains([
+      "pd-standard", "pd-balanced", "pd-ssd",
+      "hyperdisk-balanced", "hyperdisk-balanced-high-availability",
+    ], var.node_disk_type)
+    error_message = "node_disk_type must be a pd-* or hyperdisk-balanced type."
   }
 }
 

--- a/infrastructure/terraform/modules/platform/versions.tf
+++ b/infrastructure/terraform/modules/platform/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.8"
+
+  required_providers {
+    # GA provider only. Every feature this module uses (Dataplane V2, the GCS
+    # FUSE CSI driver addon, Workload Identity, the autoscaling profile) is
+    # generally available in google 6.x, so there is no google-beta dependency
+    # to carry. Keep it that way: a beta provider forces a second provider
+    # block on every root module that consumes this one.
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.50"
+    }
+  }
+}

--- a/infrastructure/terraform/modules/realtime/.terraform.lock.hcl
+++ b/infrastructure/terraform/modules/realtime/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version     = "3.2.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:/TdLShnQEtyQRij46dZJobeA8clDnuncSdc2KRkc0B0=",
+    "h1:8j4dgSY+8Y9tukMTo0WuKPyJx0JKUeZsYx9ltTUmEuo=",
+    "h1:AOxR+hQy92GqWcp4rnD3ZBrDlip7M7fOB4zL4aw8AU4=",
+    "h1:IytRFhZXOMPVB36GainacnNoBtiibAdVMdezG2DPVag=",
+    "h1:XpXkXaOaDyICkDLyrRNBzxqUc8zrKp6Y7sw17FGD+Xg=",
+    "h1:c1NQPYp6/iIg0PG/HFodq0oyDVI/FAYZF32eEOliWaw=",
+    "h1:dBAYwgWCv9/ulFx7uxbkNzPYL9TI1aqUF8E7EBJbIRk=",
+    "h1:h05ap1OKMOtgqspVfdc1GmkX9vJJHquxn5g26Ik7+t4=",
+    "h1:h21YEXSmcV7Xe64kptnt0WQYEh6m99jVR8sec2o9stk=",
+    "h1:ikX+6kgc+kYNDAiNghhOhhY15T1Jt6omoWoHlh8CEsY=",
+    "h1:jvnisz9lHFn+5sjbuZwGCqqCvbddTeqWvrYtK4Wcbxw=",
+    "h1:nK2+CnIIaNh3zl4nRRhpxrA5Z7sAMrB3Jmzjcm9hw/4=",
+    "h1:r8rm1wyokhuaFvRDptDm2G1BsvrV6ukGiPoZRGaVmbc=",
+    "h1:thNSoWm4pdgTEO1XBi1n5V2nwsdSA6EVEXP3qPZiFcA=",
+    "h1:zVNhod3npW/4gn5QTcQzmlTSdAP7Ttjs59KW6VVyaoo=",
+    "zh:1a214581dee54ec4e9afa4050e54f6c187aed4b51b2d2ac929c58706b65e1159",
+    "zh:2f8ba94af93011768ed1fffd4d25b980cd764f2d49c9f13475512ec48464da0b",
+    "zh:36373bca4f374e95f654def79e0b12df0c8f2e01c634db80ff2737ded29062e3",
+    "zh:3a26b5c3e47b2bbc01faa0fa9fe816ea4f74f1f8f4555dfad7f62ee38266aaff",
+    "zh:51bc637700f13cfc1f7c6a8c03a4b5b5755338419912d945dbfe5ccb0ddbf614",
+    "zh:53f32f91afcb682209de124d8a994e591687023ae7c0dfed6184c5511778b16b",
+    "zh:6f4434327ed466b2b5be0d5f4aa537bca71ebd7f7fe05468065aeda52dfc8896",
+    "zh:7394e8c6f5027fa21699e46c9a45bee1ce87fd8dd98f2e89e8d414ec70c8e4e1",
+    "zh:d90b855a0990e3aa6445afe66de730c2f4651f39699c6b6345ca02f9af2a1a08",
+    "zh:d9b7246e6af0f75155ed532855014f888e9e5613242c89e321b4e0f9b54f5726",
+    "zh:dabd399ca36172c15d176a24cf199ac886ef191f7131e806d76a8dc209e5beb8",
+    "zh:e57987397be46dc123365f16c3bec4dd0615453c8bfdcfc1b7c9f3202a09c516",
+    "zh:ec88430b833b943b38d02f70b33250c72bb6ffa3b3d22360990a41390161a2b2",
+    "zh:f8ea01b57982e9ed9ad3a750b1caba261a478f5b0ddcac78a4502d886fd2fc74",
+    "zh:fb63819037158205ebf42b649c3a8ec308234ffe987a5dbd4444e1e0683f1170",
+  ]
+}

--- a/infrastructure/terraform/modules/realtime/main.tf
+++ b/infrastructure/terraform/modules/realtime/main.tf
@@ -96,10 +96,10 @@ locals {
         # scheduling; the memory limit still bounds the pod.
         requests = {
           cpu    = "${var.profile.matcher_cpu_millis}m"
-          memory = "${var.profile.matcher_memory_mib}Mi"
+          memory = "${var.matcher_memory_mib}Mi"
         }
         limits = {
-          memory = "${var.profile.matcher_memory_mib}Mi"
+          memory = "${var.matcher_memory_mib}Mi"
         }
       }
     }

--- a/infrastructure/terraform/modules/realtime/main.tf
+++ b/infrastructure/terraform/modules/realtime/main.tf
@@ -1,0 +1,233 @@
+# Installs the routers-realtime chart as a single release.
+#
+# One release, and it has to be one: the orchestrator fleet is a single
+# StatefulSet dividing the vehicle partition space between its ordinals, so
+# rendering it more than once would hand the same partitions to two owners.
+# The matchers could be split by geography, but putting the two halves of one
+# pipeline behind two apply paths buys nothing — they are deployed together and
+# versioned together.
+#
+# Everything geographic ends at the matcher: a shard is a subject
+# (`events.match.<shard>`) served by a queue group, and the orchestrator
+# reaches it by hashing the event's position with the precision compiled into
+# the binary. That is the whole coupling between the two halves.
+
+locals {
+  redis_value = join(",", var.valkey_client_mode == "pooled-hash" ? var.valkey_urls : [var.valkey_urls[0]])
+
+  # The standard OTel sampler pair, rendered through each service's `env` map
+  # rather than a chart field: the chart passes those maps verbatim into the
+  # container, so a knob that is only an environment variable needs no template
+  # support to become deployable.
+  sampler_env = var.telemetry_sample_ratio == "" ? {} : {
+    OTEL_TRACES_SAMPLER     = "parentbased_traceidratio"
+    OTEL_TRACES_SAMPLER_ARG = var.telemetry_sample_ratio
+  }
+
+  values = {
+    shards         = var.shards
+    shardPrecision = var.shard_precision
+    streams        = var.streams
+
+    infra = {
+      # One NATS cluster and one Valkey fleet, neither partitioned
+      # geographically: the keyspace is per vehicle, and vehicles cross shards.
+      nats   = { url = var.nats_url }
+      valkey = { url = local.redis_value }
+      otlp   = { url = var.otlp_url }
+    }
+
+    image = {
+      registry = var.image_registry
+    }
+
+    imagePullSecrets = var.image_pull_secrets
+
+    serviceAccount = {
+      create = var.service_account_create
+      name   = var.service_account_name
+      annotations = var.gcp_service_account_email == "" ? {} : {
+        "iam.gke.io/gcp-service-account" = var.gcp_service_account_email
+      }
+    }
+
+    shardCache = merge(
+      { mode = var.shard_cache_mode },
+      var.shard_cache_mode == "gcsfuse" ? {
+        gcs = {
+          bucket       = var.shard_cache_bucket
+          mountOptions = var.shard_cache_mount_options
+        }
+      } : {},
+      var.shard_cache_mode == "hostPath" ? { hostPath = var.shard_cache_host_path } : {},
+      var.shard_cache_mode == "pvc" ? { pvc = { claimName = var.shard_cache_pvc_name } } : {},
+    )
+
+    matcher = {
+      image = {
+        repository = "routers-matcher"
+        tag        = var.image_tag
+        pullPolicy = var.image_pull_policy
+      }
+      rustLog  = var.log_level
+      replicas = var.matcher_replicas
+
+      autoscaling = {
+        enabled                        = var.matcher_autoscaling
+        minReplicas                    = var.matcher_replicas
+        maxReplicas                    = var.matcher_replicas_max
+        targetCPUUtilizationPercentage = var.matcher_target_cpu_utilization
+      }
+
+      # The matcher fans each boundary weighing across rayon, so the worker
+      # count is what uses the node's cores.
+      env = merge(
+        { WORKERS = tostring(var.profile.matcher_workers) },
+        local.sampler_env,
+        var.matcher_env,
+      )
+
+      nodeSelector = var.matcher_node_selector
+      tolerations  = var.matcher_tolerations
+
+      resources = {
+        # No CPU limit. A CFS cap freezes every worker and the rayon pool
+        # together in 100ms throttle windows. The request still guarantees
+        # scheduling; the memory limit still bounds the pod.
+        requests = {
+          cpu    = "${var.profile.matcher_cpu_millis}m"
+          memory = "${var.profile.matcher_memory_mib}Mi"
+        }
+        limits = {
+          memory = "${var.profile.matcher_memory_mib}Mi"
+        }
+      }
+    }
+
+    orchestrator = {
+      image = {
+        repository = "routers-orchestrator"
+        tag        = var.image_tag
+        pullPolicy = var.image_pull_policy
+      }
+      rustLog = var.log_level
+
+      # Not a replica count in the usual sense: the chart feeds this to the
+      # binary as FLEET alongside the pod's ordinal, and the two derive which
+      # partitions this pod owns.
+      replicas = var.fleet_size
+
+      # A worker holds its vehicle's lane across a whole solve round trip, so
+      # this is the pod's in-flight solve bound.
+      env = merge(
+        { WORKERS = tostring(var.profile.orchestrator_workers) },
+        local.sampler_env,
+        var.orchestrator_env,
+      )
+
+      nodeSelector = var.pipeline_node_selector
+      tolerations  = var.pipeline_tolerations
+
+      resources = {
+        requests = {
+          cpu    = "${var.profile.orchestrator_cpu_millis}m"
+          memory = "${var.profile.orchestrator_memory_mib}Mi"
+        }
+        limits = {
+          # Headroom for the per-vehicle trip and history lanes, which grow
+          # over a run. A reclaim stall at the limit looks like latency.
+          memory = "${var.profile.orchestrator_memory_mib}Mi"
+        }
+      }
+    }
+
+    grafanaDashboard = { enabled = var.grafana_dashboard_enabled }
+  }
+}
+
+resource "helm_release" "realtime" {
+  name             = var.release_name
+  chart            = var.chart_path
+  namespace        = var.namespace
+  create_namespace = var.create_namespace
+
+  wait         = var.wait_for_rollout
+  timeout      = var.release_timeout
+  max_history  = var.max_history
+  atomic       = false
+  reset_values = true
+
+  values = [yamlencode(local.values)]
+}
+
+# Configuration that would otherwise fail at runtime, not at plan time.
+check "shard_cache_source_is_configured" {
+  assert {
+    condition = (
+      var.shard_cache_mode != "gcsfuse" || var.shard_cache_bucket != ""
+    )
+    error_message = "shard_cache_mode is 'gcsfuse' but shard_cache_bucket is empty; matchers would start with an empty /shards and match nothing."
+  }
+
+  assert {
+    condition = (
+      var.shard_cache_mode != "hostPath" || var.shard_cache_host_path != ""
+    )
+    error_message = "shard_cache_mode is 'hostPath' but shard_cache_host_path is empty."
+  }
+
+  assert {
+    condition = (
+      var.shard_cache_mode != "pvc" || var.shard_cache_pvc_name != ""
+    )
+    error_message = "shard_cache_mode is 'pvc' but shard_cache_pvc_name is empty."
+  }
+}
+
+check "gcsfuse_can_authenticate" {
+  assert {
+    condition = (
+      var.shard_cache_mode != "gcsfuse" ||
+      (var.service_account_name != "" && var.gcp_service_account_email != "")
+    )
+    error_message = "gcsfuse needs Workload Identity: set service_account_name and gcp_service_account_email, or the CSI driver cannot read the bucket."
+  }
+}
+
+check "shards_match_the_declared_precision" {
+  assert {
+    condition     = alltrue([for s in var.shards : length(s) == var.shard_precision])
+    error_message = "Every shard must be exactly shard_precision characters. A shorter or longer one makes the matcher load a different extent from the subject it serves, and the orchestrator's requests reach nothing."
+  }
+}
+
+check "the_release_fits_a_kubernetes_secret" {
+  assert {
+    condition     = length(var.shards) <= var.max_shards_per_release
+    error_message = "This release renders ${length(var.shards)} shards, past the ${var.max_shards_per_release} guard. Every manifest lives in one Secret and a Secret holds 1 MiB; raise shard_precision only with the shard cache regenerated to match, or raise the guard if the release still applies."
+  }
+}
+
+check "the_fleet_divides_the_partition_space" {
+  assert {
+    # 1024 is `partition::PARTITIONS`. Pods take contiguous ordinal blocks and
+    # the last takes the remainder, so a non-divisor leaves one pod owning more
+    # partitions — and so more vehicles — than the rest.
+    condition     = 1024 % var.fleet_size == 0
+    error_message = "fleet_size ${var.fleet_size} does not divide the 1024 vehicle partitions. The binary gives the last pod the remainder, making it the hot one; use a power of two."
+  }
+}
+
+check "matcher_autoscaling_has_room" {
+  assert {
+    condition     = !var.matcher_autoscaling || var.matcher_replicas_max >= var.matcher_replicas
+    error_message = "matcher_replicas_max (${var.matcher_replicas_max}) is below the floor of ${var.matcher_replicas}, so the HPA would scale a shard down out of its own capacity."
+  }
+}
+
+check "image_tag_is_reproducible" {
+  assert {
+    condition     = var.image_tag != "latest" || var.image_pull_policy == "Never"
+    error_message = "image_tag is 'latest' on a cluster that pulls images, so a rollout is not reproducible and a rollback has nothing to return to. Pin a digest or an immutable tag."
+  }
+}

--- a/infrastructure/terraform/modules/realtime/outputs.tf
+++ b/infrastructure/terraform/modules/realtime/outputs.tf
@@ -1,0 +1,51 @@
+output "namespace" {
+  description = "Namespace the workloads were installed into."
+  value       = var.namespace
+}
+
+output "release_names" {
+  description = "Every Helm release this module manages. One, deliberately: the orchestrator fleet must be rendered exactly once."
+  value       = [helm_release.realtime.name]
+}
+
+output "shard_count" {
+  description = "Shards deployed, and so matcher Deployments."
+  value       = length(var.shards)
+}
+
+output "subjects" {
+  description = <<-EOT
+    The subjects in use.
+
+    A shard is one token now, not two: the orchestrator routes a solve to
+    `events.match.<shard_of(point)>`, so nothing needs to address a group of
+    shards with a wildcard. Raw and matched events are keyed by vehicle
+    partition instead, which is why their subjects carry a number rather than a
+    geohash.
+  EOT
+  value = {
+    match   = { for shard in var.shards : shard => "events.match.${shard}" }
+    raw     = "events.raw.p.<partition>"
+    matched = "events.matched.p.<partition>"
+  }
+}
+
+output "redis_value" {
+  description = "The REDIS env value rendered into the workloads: the fleet as a comma-separated list. Order carries no meaning; placement is a rendezvous hash over the URLs."
+  value       = local.redis_value
+}
+
+output "expected_pod_count" {
+  description = <<-EOT
+    Pods this module creates at the HPA floor, for comparison against the
+    capacity model's totals. The matcher half can grow to
+    `shards * matcher_replicas_max`; the fleet cannot grow at all without
+    re-slicing the partition space.
+  EOT
+  value = {
+    matchers      = length(var.shards) * var.matcher_replicas
+    matchers_max  = length(var.shards) * var.matcher_replicas_max
+    orchestrators = var.fleet_size
+    total         = length(var.shards) * var.matcher_replicas + var.fleet_size
+  }
+}

--- a/infrastructure/terraform/modules/realtime/variables.tf
+++ b/infrastructure/terraform/modules/realtime/variables.tf
@@ -141,14 +141,16 @@ variable "otlp_url" {
 variable "profile" {
   description = "Per-service worker counts and resources, from the capacity module's `profile` output, so the sizing model and the deployment cannot drift apart."
   type = object({
-    matcher_workers         = number
-    matcher_cpu_millis      = number
-    matcher_memory_mib      = number
-    matcher_eps             = number
-    orchestrator_workers    = number
-    orchestrator_cpu_millis = number
-    orchestrator_memory_mib = number
-    orchestrator_eps        = number
+    matcher_workers    = number
+    matcher_cpu_millis = number
+    matcher_memory_mib = number
+    matcher_eps        = number
+
+    orchestrator_workers              = number
+    orchestrator_round_trip_ms        = number
+    orchestrator_cpu_micros_per_event = number
+    orchestrator_cpu_millis           = number
+    orchestrator_memory_mib           = number
   })
 }
 

--- a/infrastructure/terraform/modules/realtime/variables.tf
+++ b/infrastructure/terraform/modules/realtime/variables.tf
@@ -143,7 +143,6 @@ variable "profile" {
   type = object({
     matcher_workers    = number
     matcher_cpu_millis = number
-    matcher_memory_mib = number
     matcher_eps        = number
 
     orchestrator_workers              = number
@@ -152,6 +151,24 @@ variable "profile" {
     orchestrator_cpu_millis           = number
     orchestrator_memory_mib           = number
   })
+}
+
+variable "matcher_memory_mib" {
+  description = <<-EOT
+    Memory request and limit for every matcher, from the capacity module's
+    `matcher.memory_mib`.
+
+    Not part of the vertical profile, because it is not a property of how fast
+    a pod should solve — it is the size of the graph its shard makes it hold,
+    which the profile has no say in. A pod given less than its graph needs is
+    not slow, it is OOM-killed before it serves a request.
+  EOT
+  type        = number
+
+  validation {
+    condition     = var.matcher_memory_mib > 0
+    error_message = "matcher_memory_mib must be positive."
+  }
 }
 
 variable "orchestrator_env" {

--- a/infrastructure/terraform/modules/realtime/variables.tf
+++ b/infrastructure/terraform/modules/realtime/variables.tf
@@ -1,0 +1,368 @@
+variable "chart_path" {
+  description = "Path to the routers-realtime chart, normally ../../../chart relative to the env root."
+  type        = string
+}
+
+variable "release_name" {
+  description = "Helm release name. One release holds the whole deployment."
+  type        = string
+  default     = "routers-realtime"
+}
+
+variable "namespace" {
+  description = "Namespace for the routers workloads. Kept separate from the dependency namespace."
+  type        = string
+  default     = "routers"
+}
+
+variable "create_namespace" {
+  description = "Whether Helm creates the namespace."
+  type        = bool
+  default     = true
+}
+
+# --- Topology ---------------------------------------------------------------
+
+variable "shards" {
+  description = <<-EOT
+    Geohash shards to deploy, at `shard_precision`. Each renders one matcher
+    Deployment serving `events.match.<shard>` through a queue group.
+  EOT
+  type        = list(string)
+
+  validation {
+    condition     = length(var.shards) > 0
+    error_message = "At least one shard is required."
+  }
+}
+
+variable "shard_precision" {
+  description = "Geohash precision of `shards`, rendered as the matcher's PRECISION. Must equal the precision compiled into the binaries — see the capacity module's `precision_prerequisite`."
+  type        = number
+}
+
+variable "streams" {
+  description = <<-EOT
+    Raw JetStream streams the vehicle partition space divides across.
+
+    Wire law: a revision is a stream sequence, so remapping partitions to a
+    different stream count resets sequence domains. It is rendered into the
+    orchestrator as STREAMS and must match what the streams were created with.
+  EOT
+  type        = number
+}
+
+variable "fleet_size" {
+  description = <<-EOT
+    Orchestrator StatefulSet replicas, from the capacity module's `fleet.size`.
+
+    Each pod derives a disjoint slice of the partition space from its ordinal,
+    so this is the divisor of that space and not merely a replica count.
+    Changing it re-slices ownership across the whole fleet.
+  EOT
+  type        = number
+
+  validation {
+    condition     = var.fleet_size >= 1
+    error_message = "fleet_size must be at least 1."
+  }
+}
+
+variable "matcher_replicas" {
+  description = "Replicas per matcher Deployment, and the HPA floor. Members of a shard's queue group split its requests, so this divides load rather than duplicating it."
+  type        = number
+  default     = 1
+}
+
+variable "matcher_replicas_max" {
+  description = "HPA ceiling per shard. Above `matcher_replicas` this is the headroom a hot shard may take, which is what covers the gap between a modelled mean and a geographic distribution."
+  type        = number
+  default     = 4
+}
+
+variable "matcher_autoscaling" {
+  description = "Whether to render the per-shard HorizontalPodAutoscaler. Meaningful only because matchers queue-subscribe: without a queue group extra replicas would repeat work rather than share it."
+  type        = bool
+  default     = true
+}
+
+variable "matcher_target_cpu_utilization" {
+  description = "HPA target CPU. Solving is CPU-bound, so utilisation tracks queue depth closely enough to scale on."
+  type        = number
+  default     = 80
+}
+
+variable "max_shards_per_release" {
+  description = "Guard on release size. Every shard renders a Deployment and an HPA into one release, whose manifests live in a single 1 MiB Kubernetes Secret."
+  type        = number
+  default     = 512
+}
+
+# --- Dependencies -----------------------------------------------------------
+
+variable "nats_url" {
+  description = "Client URL for the NATS cluster. JetStream must be enabled: the orchestrator creates work-queue streams and filtered durable consumers, which needs server 2.10+."
+  type        = string
+}
+
+variable "valkey_urls" {
+  description = <<-EOT
+    The Valkey fleet, from the devstack module. Rendered as a comma-separated
+    REDIS value. Placement is a rendezvous hash over the URLs, so order does
+    not matter and a resize moves about 1/N of vehicles.
+  EOT
+  type        = list(string)
+
+  validation {
+    condition     = length(var.valkey_urls) > 0
+    error_message = "At least one Valkey URL is required."
+  }
+}
+
+variable "valkey_client_mode" {
+  description = "`pooled-hash` renders every URL; `single` renders only the first and caps the deployment at one primary's throughput."
+  type        = string
+  default     = "pooled-hash"
+
+  validation {
+    condition     = contains(["single", "pooled-hash"], var.valkey_client_mode)
+    error_message = "valkey_client_mode must be 'single' or 'pooled-hash'."
+  }
+}
+
+variable "otlp_url" {
+  description = "OTLP http/protobuf endpoint. Empty disables span export, and telemetry degrades to structured logs."
+  type        = string
+  default     = ""
+}
+
+# --- Workload sizing --------------------------------------------------------
+
+variable "profile" {
+  description = "Per-service worker counts and resources, from the capacity module's `profile` output, so the sizing model and the deployment cannot drift apart."
+  type = object({
+    matcher_workers         = number
+    matcher_cpu_millis      = number
+    matcher_memory_mib      = number
+    matcher_eps             = number
+    orchestrator_workers    = number
+    orchestrator_cpu_millis = number
+    orchestrator_memory_mib = number
+    orchestrator_eps        = number
+  })
+}
+
+variable "orchestrator_env" {
+  description = <<-EOT
+    Extra orchestrator env, merged over what this module derives (WORKERS,
+    STREAMS, and the sampler pair). Keys are the binary's clap-derived env
+    names, so a new knob needs no template change to become deployable.
+
+    CONTEXT_WINDOW is also the resume horizon: a vehicle going more than this
+    many events without a committed result loses its reconcile overlap and
+    restarts. VEHICLE_CACHE is per worker, so the pod-wide bound is this times
+    WORKERS — size it above the concurrent vehicles the pod's partitions carry,
+    or a live vehicle's eviction costs a Valkey re-warm and a trip restart.
+  EOT
+  type        = map(string)
+  default = {
+    CONTEXT_WINDOW = "25"
+    VEHICLE_CACHE  = "4096"
+
+    # The raw tail: the failover recovery source, and the only thing an ack
+    # waits on besides the emission's publish.
+    HISTORY       = "25"
+    BATCH_SIZE    = "128"
+    BATCH_TIMEOUT = "20ms"
+
+    # The backlog knob. Under saturation the stream buffers and delivery
+    # throttles here; nothing is dropped.
+    MAX_ACK_PENDING = "2048"
+    ACK_WAIT        = "60s"
+
+    SOLVE_TIMEOUT = "5s"
+    SOLVE_RETRIES = "3"
+
+    # How long emissions are retained for the reconciler. Also what sizes that
+    # stream's disk, since nothing consumes it destructively.
+    MATCHED_RETENTION = "15m"
+  }
+}
+
+variable "matcher_env" {
+  description = "Extra matcher env, merged over the worker count from `profile`."
+  type        = map(string)
+  default     = {}
+}
+
+variable "log_level" {
+  description = "RUST_LOG for both services. `debug` is a throughput tax at these rates: the export path itself logs several lines per batch."
+  type        = string
+  default     = "info"
+}
+
+variable "telemetry_sample_ratio" {
+  description = <<-EOT
+    Trace sample ratio, rendered as the standard OTEL_TRACES_SAMPLER env pair
+    through each service's `env` map — the chart passes those maps verbatim, so
+    this needs no chart support.
+
+    Unsampled telemetry does not survive this pipeline: the BatchSpanProcessor
+    drops the excess silently from a 16k queue, so anything derived from it
+    under-reports by an unknown factor. Empty leaves the binaries' own default
+    in place.
+  EOT
+  type        = string
+  default     = ""
+}
+
+# --- Shard cache ------------------------------------------------------------
+
+variable "shard_cache_mode" {
+  description = <<-EOT
+    Where matchers read their `<shard>.shard.rt` files. `gcsfuse` mounts one
+    bucket read-only per pod through the GCS FUSE CSI driver, so a new shard
+    needs no volume work. `hostPath` suits only a single-node local cluster.
+    `pvc` needs a ReadOnlyMany volume that GCE persistent disks cannot provide
+    across zones.
+  EOT
+  type        = string
+  default     = "gcsfuse"
+
+  validation {
+    condition     = contains(["gcsfuse", "hostPath", "pvc"], var.shard_cache_mode)
+    error_message = "shard_cache_mode must be 'gcsfuse', 'hostPath' or 'pvc'."
+  }
+}
+
+variable "shard_cache_bucket" {
+  description = "GCS bucket holding the shard files. Required when shard_cache_mode is 'gcsfuse'."
+  type        = string
+  default     = ""
+}
+
+variable "shard_cache_host_path" {
+  description = "Node directory holding the shard files. Required when shard_cache_mode is 'hostPath'."
+  type        = string
+  default     = ""
+}
+
+variable "shard_cache_pvc_name" {
+  description = "Claim name. Required when shard_cache_mode is 'pvc'."
+  type        = string
+  default     = ""
+}
+
+variable "shard_cache_mount_options" {
+  description = <<-EOT
+    GCS FUSE mount options. `implicit-dirs` lets the flat bucket present as a
+    directory. The file cache matters: a matcher reads its whole shard file at
+    startup, and a restart would otherwise re-read it over the network.
+  EOT
+  type        = string
+  default     = "implicit-dirs,file-cache:max-size-mb:-1,metadata-cache:ttl-secs:-1"
+}
+
+# --- Images -----------------------------------------------------------------
+
+variable "image_registry" {
+  description = "Registry/repository prefix, e.g. <region>-docker.pkg.dev/<project>/routers. Empty renders bare image names for a local cluster."
+  type        = string
+  default     = ""
+}
+
+variable "image_tag" {
+  description = "Tag for both images. Use an immutable tag or a digest."
+  type        = string
+  default     = "latest"
+}
+
+variable "image_pull_policy" {
+  description = "Pull policy. `Never` suits a local cluster with pre-built images; GKE needs `IfNotPresent` or `Always`."
+  type        = string
+  default     = "IfNotPresent"
+}
+
+variable "image_pull_secrets" {
+  description = "Pull secret names. Not needed for Artifact Registry, where the node service account authenticates."
+  type        = list(string)
+  default     = []
+}
+
+# --- Scheduling -------------------------------------------------------------
+
+variable "matcher_node_selector" {
+  description = "Node labels pinning matchers to their pool. Matching is CPU-bound, so it wants a compute-optimised shape of its own."
+  type        = map(string)
+  default     = {}
+}
+
+variable "matcher_tolerations" {
+  description = "Tolerations for the matcher pool's taint, which keeps other workloads off it."
+  type        = list(any)
+  default     = []
+}
+
+variable "pipeline_node_selector" {
+  description = "Node labels pinning the orchestrator fleet to the pipeline pool."
+  type        = map(string)
+  default     = {}
+}
+
+variable "pipeline_tolerations" {
+  description = "Tolerations for the pipeline pool's taint."
+  type        = list(any)
+  default     = []
+}
+
+# --- Service account --------------------------------------------------------
+
+variable "service_account_name" {
+  description = "Kubernetes service account for the workloads. Required for gcsfuse, which authenticates to GCS through Workload Identity."
+  type        = string
+  default     = ""
+}
+
+variable "service_account_create" {
+  description = "Whether the chart creates the service account."
+  type        = bool
+  default     = true
+}
+
+variable "gcp_service_account_email" {
+  description = "GCP service account to impersonate through Workload Identity. Rendered as the iam.gke.io/gcp-service-account annotation."
+  type        = string
+  default     = ""
+}
+
+variable "grafana_dashboard_enabled" {
+  description = "Whether to ship the dashboard ConfigMap."
+  type        = bool
+  default     = true
+}
+
+# --- Release behaviour ------------------------------------------------------
+
+variable "wait_for_rollout" {
+  description = <<-EOT
+    Whether Helm waits for pods to become Ready.
+
+    False by default: a few hundred shards is a few hundred Deployments,
+    waiting serialises the apply behind the slowest matcher's shard-file load,
+    and one unschedulable pod fails the whole release.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "release_timeout" {
+  description = "Release timeout in seconds."
+  type        = number
+  default     = 900
+}
+
+variable "max_history" {
+  description = "Helm revisions retained. Each is a Secret holding every rendered manifest, so an unbounded history is real cluster storage at this manifest count."
+  type        = number
+  default     = 5
+}

--- a/infrastructure/terraform/modules/realtime/versions.tf
+++ b/infrastructure/terraform/modules/realtime/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
Creates a terraform configuration for the deployment cluster (incl. helm chart). The orchestrator is to be vehicle-partitioned whilst the matcher is shard-partitioned for locality on the optimal heuristic lines, namely temporal locality for the orchestrator and spatial locality for the matcher.

This allows the node cluster to scale somewhat independently, with the limiting scaling factor falling onto NATS's JetStream component, due to disk IOPS.