### PR TITLE
feat: Infrastructure Tools in Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,15 @@
             vulkan-loader
             wayland
           ];
+
+        # `gcloud` supplies the credentials the google provider reads, through
+        # `gcloud auth application-default login`. The GKE component is for
+        # `kubectl` and `helm`, which call it as an exec credential plugin; the
+        # terraform roots do not need it, because they take a token from
+        # `google_client_config` instead.
+        gcloud = pkgs.google-cloud-sdk.withExtraComponents [
+          pkgs.google-cloud-sdk.components.gke-gcloud-auth-plugin
+        ];
       in
       {
         devShells.default = pkgs.mkShell {
@@ -62,6 +71,12 @@
 
             kubectl
             kubernetes-helm
+
+            # `infrastructure/terraform` runs on OpenTofu, not Terraform: the
+            # Justfile calls `tofu`, and the lock files record provider hashes
+            # from the OpenTofu registry.
+            opentofu
+            gcloud
 
             pkg-config
             cmake

--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,16 @@
+{
+  "worktree": {
+    "setup": [
+      "# Nix flake toolchain (go, gcc, golangci-lint, gstreamer) via direnv",
+      "direnv allow && eval \"$(direnv hook bash)\""
+    ]
+  },
+  "metadataGeneration": {
+    "branchName": {
+      "instructions": "prefix with feat- or fix- and use kebab case"
+    },
+    "commitMessage": {
+      "instructions": "Use conventional commits, in the form \"<fix/feat/..>(<scope>): <description>\", i.e. fix(camera-process): use shorter polling policy\"."
+    }
+  }
+}


### PR DESCRIPTION
Add OpenTofu and gcloud to the Nix development shell to support infrastructure-as-code workflows.