### PR TITLE
feat: Reuse Dijkstra Working Buffers

### DIFF
--- a/libs/routers_transition/src/primitives/algorithms/dijkstra.rs
+++ b/libs/routers_transition/src/primitives/algorithms/dijkstra.rs
@@ -1,10 +1,13 @@
 use alloc::collections::BinaryHeap;
 use core::cmp::Ordering;
 use core::hash::{BuildHasherDefault, Hash};
+use core::mem;
 use indexmap::IndexMap;
 use indexmap::map::Entry;
 use pathfinding::num_traits::Zero;
 use rustc_hash::{FxHashSet, FxHasher};
+use std::any::Any;
+use std::cell::RefCell;
 
 use crate::primitives::WeightAndDistance;
 
@@ -41,15 +44,88 @@ impl Ord for SmallestHolder {
     }
 }
 
-/// Struct returned by [`dijkstra_reach`].
-pub struct DijkstraReachable<FN, E>
+/// The working buffers of one bounded reachability search — the open set, the
+/// visited set, and the parent/cost table.
+///
+/// A full 2 km Dijkstra grows these to thousands of entries, and the predicate
+/// cache reruns one per miss. This keeps one set per thread in [`SCRATCH`] and
+/// reuses it, retaining capacity across searches — the buffers never escape a
+/// single `reach`, so there is no aliasing. Reuse is a pure allocation
+/// optimisation: the search logic in [`DijkstraReachable::next`] is unchanged,
+/// so results are identical.
+struct Scratch<E>
 where
     E: routers_network::Entry,
 {
     to_see: BinaryHeap<SmallestHolder>,
     seen: FxHashSet<usize>,
     parents: FxIndexMap<E, (usize, Cost)>,
+}
+
+// Manual (not derived) so we don't require `E: Default`.
+impl<E> Default for Scratch<E>
+where
+    E: routers_network::Entry,
+{
+    fn default() -> Self {
+        Self {
+            to_see: BinaryHeap::new(),
+            seen: FxHashSet::default(),
+            parents: FxIndexMap::default(),
+        }
+    }
+}
+
+thread_local! {
+    // One reusable scratch per thread, type-erased so a single `thread_local`
+    // serves any `Entry` type. In practice a process routes over one network
+    // (one `Entry`), so the downcast hits; a miss simply allocates fresh.
+    static SCRATCH: RefCell<Option<Box<dyn Any>>> = const { RefCell::new(None) };
+}
+
+impl<E> Scratch<E>
+where
+    E: routers_network::Entry + 'static,
+{
+    /// Take this thread's scratch (cleared, capacity retained), or a fresh one.
+    fn take() -> Self {
+        SCRATCH.with(|slot| {
+            slot.borrow_mut()
+                .take()
+                .and_then(|any| any.downcast::<Scratch<E>>().ok())
+                .map(|mut boxed| {
+                    boxed.to_see.clear();
+                    boxed.seen.clear();
+                    boxed.parents.clear();
+                    *boxed
+                })
+                .unwrap_or_default()
+        })
+    }
+
+    /// Return this scratch to the thread pool for the next search to reuse.
+    fn give(self) {
+        SCRATCH.with(|slot| *slot.borrow_mut() = Some(Box::new(self) as Box<dyn Any>));
+    }
+}
+
+/// Struct returned by [`dijkstra_reach`].
+pub struct DijkstraReachable<FN, E>
+where
+    E: routers_network::Entry + 'static,
+{
+    scratch: Scratch<E>,
     successors: FN,
+}
+
+impl<FN, E> Drop for DijkstraReachable<FN, E>
+where
+    E: routers_network::Entry + 'static,
+{
+    fn drop(&mut self) {
+        // Hand the buffers back to the thread pool (they are cleared on reuse).
+        mem::take(&mut self.scratch).give();
+    }
 }
 
 /// Information about a node reached by [`dijkstra_reach`].
@@ -71,21 +147,27 @@ impl<FN, IN, E> Iterator for DijkstraReachable<FN, E>
 where
     FN: FnMut(&E) -> IN,
     IN: Iterator<Item = (E, Cost)>,
-    E: routers_network::Entry,
+    E: routers_network::Entry + 'static,
 {
     type Item = DijkstraReachableItem<E>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(SmallestHolder { cost, index }) = self.to_see.pop() {
-            if !self.seen.insert(index) {
+        let Scratch {
+            to_see,
+            seen,
+            parents,
+        } = &mut self.scratch;
+
+        while let Some(SmallestHolder { cost, index }) = to_see.pop() {
+            if !seen.insert(index) {
                 continue;
             }
 
             let (item, successors) = {
-                let (node, (parent_index, cost)) = self.parents.get_index(index).unwrap();
+                let (node, (parent_index, cost)) = parents.get_index(index).unwrap();
                 let item = Some(DijkstraReachableItem {
                     node: *node,
-                    parent: self.parents.get_index(*parent_index).map(|x| *x.0),
+                    parent: parents.get_index(*parent_index).map(|x| *x.0),
                     total_cost: *cost,
                 });
 
@@ -95,7 +177,7 @@ where
             for (successor, move_cost) in successors {
                 let new_cost = cost + move_cost;
 
-                let index = match self.parents.entry(successor) {
+                let index = match parents.entry(successor) {
                     Entry::Vacant(e) => {
                         let n = e.index();
                         e.insert((index, new_cost));
@@ -111,7 +193,7 @@ where
                     }
                 };
 
-                self.to_see.push(SmallestHolder {
+                to_see.push(SmallestHolder {
                     cost: new_cost,
                     index,
                 });
@@ -134,27 +216,17 @@ impl Dijkstra {
     /// an iterator of successors associated with their move cost.
     pub fn reach<FN, IN, E>(&self, start: &E, successors: FN) -> DijkstraReachable<FN, E>
     where
-        E: routers_network::Entry,
+        E: routers_network::Entry + 'static,
         FN: FnMut(&E) -> IN,
         IN: Iterator<Item = (E, Cost)>,
     {
-        let mut to_see: BinaryHeap<SmallestHolder> = BinaryHeap::with_capacity(256);
-        to_see.push(SmallestHolder {
+        let mut scratch = Scratch::<E>::take();
+        scratch.to_see.push(SmallestHolder {
             cost: Zero::zero(),
             index: 0,
         });
+        scratch.parents.insert(*start, (usize::MAX, Zero::zero()));
 
-        let mut parents: FxIndexMap<E, (usize, Cost)> =
-            FxIndexMap::with_capacity_and_hasher(64, BuildHasherDefault::<FxHasher>::default());
-
-        parents.insert(*start, (usize::MAX, Zero::zero()));
-        let seen = FxHashSet::default();
-
-        DijkstraReachable {
-            to_see,
-            seen,
-            parents,
-            successors,
-        }
+        DijkstraReachable { scratch, successors }
     }
 }


### PR DESCRIPTION
Rejected experiment, kept as a draft for the record.

Same-session A/B (warm Sydney generous replay, 19,343 trips): pooling the Dijkstra open/visited/parent buffers per thread measured **~60% slower** (277.9s vs 173.3s) with identical results. The bounded search's working set varies enormously, so retaining max-size buffers makes every later small search pay O(capacity) clears and thrash the CPU cache on a sparse map — the allocator's per-call right-sizing wins. Not merging.