### PR TITLE
feat: Configurable Dijkstra Upper Bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6603,7 +6603,6 @@ dependencies = [
  "routers_transition",
  "scc",
  "serde",
- "stream-partition",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -6638,6 +6637,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "uom",
  "wkt",
 ]
 
@@ -6739,6 +6739,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "uom",
  "wkt",
 ]
 
@@ -7675,16 +7676,6 @@ checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
 dependencies = [
  "approx 0.5.1",
  "num-traits",
-]
-
-[[package]]
-name = "stream-partition"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4707315829201ca2d8d6a7c6c888b217ab222a644b5c06bef15af3ab93ace7e"
-dependencies = [
- "futures",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -8648,6 +8639,16 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uom"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a739f83872836c82a4f2527d4e54b37007b3de68cafe7edde95fd695968bf4b9"
+dependencies = [
+ "num-traits",
+ "typenum",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,14 @@ tokio = { version = "1.47.1", features = [
     "fs",
 ] }
 
+# Units of measure. `autoconvert` is off: everything here is SI, and it only
+# costs compile time once there is a single system.
+uom = { version = "0.38.0", default-features = false, features = [
+    "si",
+    "f64",
+    "std",
+] }
+
 # GeoRust
 geo = { version = "0.31.0", features = ["use-serde"] }
 geo-index = { version = "0.3.1" }

--- a/libs/routers_rpc/Cargo.toml
+++ b/libs/routers_rpc/Cargo.toml
@@ -26,6 +26,9 @@ connectrpc = { workspace = true }
 # GeoRust
 geo = { workspace = true }
 
+# Units of measure
+uom = { workspace = true }
+
 log = { workspace = true }
 tokio = { workspace = true }
 

--- a/libs/routers_rpc/src/services/matcher.rs
+++ b/libs/routers_rpc/src/services/matcher.rs
@@ -14,10 +14,14 @@ use schema::proto::routers::model::v1::{
     Edge, EdgeIdentifier, MatchedRoute, NodeIdentifier, RouteEdge, RouteElement,
 };
 
+use alloc::sync::Arc;
 use routers_network::{Entry, Metadata};
+use routers_transition::primitives::{DEFAULT_REACH_DISTANCE, PredicateCache};
 use routers_transition::{Match, MatchOptions};
 #[cfg(feature = "telemetry")]
 use tracing::Level;
+use uom::si::f64::Length;
+use uom::si::length::meter;
 
 use crate::sdk::r#match::{MatchSdk, as_linestring, coordinate};
 use crate::sdk::optimise::optimise_for;
@@ -118,10 +122,18 @@ where
         );
         let runtime = <T::Meta>::runtime(context);
 
+        // The reach is carried by the predicate cache, so a per-request reach
+        // means a per-request cache. No sharing is lost: each request builds
+        // its own either way.
+        let reach = owned
+            .reach_distance
+            .map_or(DEFAULT_REACH_DISTANCE, Length::new::<meter>);
+
         let opts = MatchOptions::new()
             .with_runtime(runtime.clone())
             .with_solver(solver)
-            .with_search_distance(owned.search_distance);
+            .with_search_distance(owned.search_distance)
+            .with_cache(Arc::new(PredicateCache::with_reach_distance(reach)));
 
         let result = self
             .inner

--- a/libs/routers_transition/Cargo.toml
+++ b/libs/routers_transition/Cargo.toml
@@ -28,6 +28,9 @@ log = { workspace = true }
 geo = { workspace = true }
 wkt = { workspace = true }
 
+# Units of measure
+uom = { workspace = true }
+
 # Tracing [Optional-"tracing"]
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }

--- a/libs/routers_transition/src/lib.rs
+++ b/libs/routers_transition/src/lib.rs
@@ -23,7 +23,9 @@
 //!
 //! If you want to dive a little deeper, you can tune the candidate search
 //! radius, weighing strategy, and caching through [`MatchOptions`], instead
-//! of supplying the defaults.
+//! of supplying the defaults. How far the router reaches between consecutive
+//! positions is carried by the cache — see
+//! [`PredicateCache::with_reach_distance`](primitives::PredicateCache).
 //!
 //! ### Going deeper
 //!
@@ -56,3 +58,8 @@ mod r#match;
 
 // Re-exports from routers_trellis
 pub use routers_trellis::{LayerId, NodeId, Path as TrellisPath, Solved, Trellis};
+
+/// Units of measure, re-exported because distances cross this crate's public
+/// API as [`uom`] quantities. Name them through here rather than adding your
+/// own `uom` dependency: a version skew would make `Length` a different type.
+pub use uom;

--- a/libs/routers_transition/src/match/definition.rs
+++ b/libs/routers_transition/src/match/definition.rs
@@ -61,6 +61,13 @@ pub struct MatchOptions<N: Network> {
     /// Any given value of the enumeration is accepted,
     pub solver: SolverVariant,
 
+    /// A [`PredicateCache`] to answer reachability queries from, shared across
+    /// matches to keep it warm. `None` builds a fresh one at
+    /// [`DEFAULT_REACH_DISTANCE`](crate::primitives::DEFAULT_REACH_DISTANCE).
+    ///
+    /// The cache also carries how far the solver reaches between consecutive
+    /// positions, so `PredicateCache::with_reach_distance` is how you change
+    /// it.
     pub cache: Option<Arc<PredicateCache<N>>>,
 }
 

--- a/libs/routers_transition/src/match/implementation.rs
+++ b/libs/routers_transition/src/match/implementation.rs
@@ -28,10 +28,7 @@ where
         let generator = StandardGenerator::new(self, &costing.emission)
             .with_search_distance(opts.search_distance);
 
-        let weigher = match opts.cache {
-            Some(cache) => opts.solver.instance(cache),
-            None => opts.solver.without_cache(),
-        };
+        let weigher = opts.solver.instance(opts.cache.unwrap_or_default());
 
         Matcher::new(self, &costing, generator, weigher, &opts.runtime)
             .r#match(linestring)

--- a/libs/routers_transition/src/primitives/cache.rs
+++ b/libs/routers_transition/src/primitives/cache.rs
@@ -4,7 +4,6 @@ use geo::Distance;
 use routers_network::{DataPlane, Metadata, Network};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use scc::HashCache;
-use scc::hash_cache::Entry;
 
 /// Entries retained before the cache starts evicting.
 ///
@@ -31,6 +30,9 @@ const _: () = assert!(
 /// recently used entry of a bucket once that bucket is full. Eviction is
 /// therefore O(1) and bucket-local: the cache can evict a little before it is
 /// globally full, which is the price of not scanning.
+///
+/// Anything the value varies with beyond its key belongs in `Meta`, and caches
+/// whose metadata disagrees must stay separate maps.
 pub struct CacheMap<V, N, Meta>
 where
     V: Debug,
@@ -181,6 +183,8 @@ mod successor {
 
     use geo::Haversine;
     use routers_network::DirectionAwareEdgeId;
+    use uom::si::f64::Length;
+    use uom::si::length::meter;
 
     /// The weights, given as output from the [`SuccessorsCache::calculate`] function.
     type SuccessorWeights<E> = Vec<(E, DirectionAwareEdgeId<E>, WeightAndDistance)>;
@@ -201,17 +205,15 @@ mod successor {
             ctx.map
                 .edges_outof(key)
                 .map(|(_, next, (w, edge))| {
-                    const METER_TO_CM: f64 = 100.0;
-
                     #[allow(unsafe_code)]
                     let position = unsafe { ctx.map.point(&next).unwrap_unchecked() };
 
-                    // In centimeters (1m = 100cm)
-                    let distance = Haversine.distance(source, position);
-                    (next, (distance * METER_TO_CM) as u32, w, edge)
+                    // `Haversine` answers in metres; the unit goes on here so
+                    // nothing downstream has to remember that.
+                    let distance = Length::new::<meter>(Haversine.distance(source, position));
+                    (next, distance, w, edge)
                 })
                 .map(|(next, distance, weight, edge)| {
-                    // Stores the weight and distance (in cm) to the candidate
                     let cost = WeightAndDistance::new(weight, distance);
 
                     (next, edge, cost)
@@ -223,11 +225,23 @@ mod successor {
 
 mod predicate {
     use crate::primitives::{Dijkstra, algorithms::DijkstraReachableItem};
+    use core::marker::PhantomData;
     use routers_network::Network;
+    use uom::si::f64::Length;
 
     use super::*;
 
-    const DEFAULT_THRESHOLD: f64 = 200_000f64; // 2km in cm
+    /// How far the bounded Dijkstra reaches from its root — two kilometres of
+    /// network distance, not straight-line.
+    ///
+    /// Spelled as a literal because [`Length::new`] is not `const`; a
+    /// quantity's field holds its value in the SI base unit, so this is
+    /// metres.
+    pub const DEFAULT_REACH_DISTANCE: Length = Length {
+        dimension: PhantomData,
+        units: PhantomData,
+        value: 2_000.0,
+    };
 
     #[derive(Debug)]
     pub struct PredicateMetadata<N>
@@ -238,8 +252,8 @@ mod predicate {
         /// prevent repeated calculations.
         successors: SuccessorsCache<N>,
 
-        /// The threshold by which the solver is bounded, in centimeters.
-        threshold_distance: f64,
+        /// How far the solver reaches.
+        reach: Length,
     }
 
     impl<N> Default for PredicateMetadata<N>
@@ -249,7 +263,7 @@ mod predicate {
         fn default() -> Self {
             Self {
                 successors: SuccessorsCache::default(),
-                threshold_distance: DEFAULT_THRESHOLD,
+                reach: DEFAULT_REACH_DISTANCE,
             }
         }
     }
@@ -266,30 +280,42 @@ mod predicate {
     ///
     /// Keyed by a root node, it holds the parent-pointer map of an
     /// upper-bounded Dijkstra rooted there: every node reachable within the
-    /// threshold, mapped to the node it was reached from. Computed once on
-    /// first query and read thereafter — and deterministic, which is what
-    /// lets collapse re-derive hop geometry rather than store it.
+    /// cache's `reach_distance`, mapped to the node it was reached from.
+    /// Computed once on first query and read thereafter — and deterministic,
+    /// which is what lets collapse re-derive hop geometry rather than store
+    /// it.
     ///
-    /// Matching many trajectories over the same map? Share one cache across
-    /// matches (see
-    /// [`MatchOptions::with_cache`](crate::MatchOptions::with_cache)) so
-    /// later matches run warm.
+    /// Every entry is computed at the cache's reach, so the reach is fixed at
+    /// construction. Build one with `with_reach_distance` to match at anything
+    /// other than [`DEFAULT_REACH_DISTANCE`], and pass it to
+    /// [`MatchOptions::with_cache`](crate::MatchOptions::with_cache) — which
+    /// also keeps it warm across matches.
     pub type PredicateCache<N> =
         LockedMap<Predicates<<N as DataPlane>::Entry>, N, PredicateMetadata<N>>;
 
     impl<N: Network> PredicateCache<N> {
-        pub fn with_threshold(threshold_cm: f64) -> Self {
+        /// An empty cache whose entries reach `reach_distance`.
+        ///
+        /// Raise it for sparse traces — long gaps between positions, or
+        /// motorway driving. The cost is superlinear: a Dijkstra reaching
+        /// twice as far settles far more than twice the nodes.
+        pub fn with_reach_distance(reach_distance: Length) -> Self {
             LockedMap(Arc::new(CacheMap::with_metadata(PredicateMetadata {
                 successors: SuccessorsCache::default(),
-                threshold_distance: threshold_cm,
+                reach: reach_distance,
             })))
+        }
+
+        /// How far this cache's entries reach.
+        pub fn reach_distance(&self) -> Length {
+            self.0.metadata.reach
         }
     }
 
     impl<N: Network> Calculable<N, Predicates<N::Entry>> for PredicateCache<N> {
         #[inline]
         fn calculate(&self, ctx: &RoutingContext<N>, key: N::Entry) -> Predicates<N::Entry> {
-            let threshold = self.0.metadata.threshold_distance;
+            let reach = self.0.metadata.reach;
 
             Dijkstra
                 .reach(&key, move |node| {
@@ -315,10 +341,7 @@ mod predicate {
                         })
                         .map(|(a, _, b)| (a, b))
                 })
-                .take_while(|p| {
-                    // Bounded by the threshold distance (centimeters)
-                    (p.total_cost.distance_cm() as f64) < threshold
-                })
+                .take_while(|p| p.total_cost.distance() < reach)
                 .map(|DijkstraReachableItem { node, parent, .. }| {
                     (node, parent.unwrap_or_default())
                 })
@@ -354,15 +377,17 @@ where
     }
 }
 
-pub use predicate::PredicateCache;
+pub use predicate::{DEFAULT_REACH_DISTANCE, PredicateCache};
 pub use successor::SuccessorsCache;
 
 use crate::primitives::RoutingContext;
 
 #[cfg(test)]
 mod tests {
-    use super::{Arc, DEFAULT_CACHE_CAPACITY, PredicateCache};
+    use super::{Arc, DEFAULT_CACHE_CAPACITY, DEFAULT_REACH_DISTANCE, PredicateCache};
     use routers_network::mock::{MockEntryId, MockNetwork};
+    use uom::si::f64::Length;
+    use uom::si::length::{centimeter, meter};
 
     /// Got caught out by nodes exceeding their memory limit,
     /// so we must ensure the cache size stays bounded.
@@ -385,5 +410,24 @@ mod tests {
         // than it advertises; `DEFAULT_CACHE_CAPACITY` has a const assert for
         // that, and this confirms the constructor honours it.
         assert_eq!(cache.0.map.capacity(), DEFAULT_CACHE_CAPACITY);
+    }
+
+    /// A cache reports the reach it was built at, whichever unit named it —
+    /// and an unconfigured one reaches the documented default.
+    #[test]
+    fn a_cache_reports_the_reach_it_was_built_at() {
+        let default = PredicateCache::<MockNetwork>::default();
+        assert_eq!(default.reach_distance(), DEFAULT_REACH_DISTANCE);
+        assert_eq!(default.reach_distance().get::<meter>(), 2_000.0);
+
+        let wide =
+            PredicateCache::<MockNetwork>::with_reach_distance(Length::new::<meter>(8_000.0));
+        assert_eq!(wide.reach_distance().get::<centimeter>(), 800_000.0);
+
+        // The unit is carried, not assumed: 800,000cm names the same reach.
+        let same = PredicateCache::<MockNetwork>::with_reach_distance(Length::new::<centimeter>(
+            800_000.0,
+        ));
+        assert_eq!(same.reach_distance(), wide.reach_distance());
     }
 }

--- a/libs/routers_transition/src/primitives/mod.rs
+++ b/libs/routers_transition/src/primitives/mod.rs
@@ -20,7 +20,7 @@ mod resolve;
 mod routing;
 mod weight_and_distance;
 
-pub use cache::{PredicateCache, SuccessorsCache};
+pub use cache::{DEFAULT_REACH_DISTANCE, PredicateCache, SuccessorsCache};
 pub use error::{Disconnected, DisconnectedError, MatchError, Unanchored, UnanchoredError};
 pub use resolve::{Reachable, ResolutionMethod};
 pub use routing::RoutingContext;

--- a/libs/routers_transition/src/primitives/weight_and_distance.rs
+++ b/libs/routers_transition/src/primitives/weight_and_distance.rs
@@ -2,19 +2,26 @@ use core::cmp::Ordering;
 use core::ops::Add;
 use pathfinding::num_traits::Zero;
 use routers_network::edge::Weight;
+use uom::si::f64::Length;
+use uom::si::length::centimeter;
 
 /// The accumulated routing cost of a candidate path.
 ///
 /// It carries a running average road-class weight — held as a separate
 /// `numerator` (sum of weights) and `denominator` (number of edges) so the
-/// average stays exact under addition — alongside the cumulative `distance`
-/// travelled, in centimeters.
+/// average stays exact under addition — alongside the cumulative distance
+/// travelled.
+///
+/// Distance crosses the API as a [`Length`], but is held in whole centimetres
+/// so accumulation over a long path stays exact where repeated
+/// floating-point addition would drift. The field names its unit because
+/// nothing in the type does.
 #[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Copy, Clone, Hash, Debug)]
 pub struct WeightAndDistance {
     numerator: Weight,
     denominator: u32,
-    distance: u32,
+    distance_cm: u32,
 }
 
 impl WeightAndDistance {
@@ -33,7 +40,7 @@ impl WeightAndDistance {
     /// one quarter of the motorway path length.
     #[inline]
     pub fn repr(&self) -> u32 {
-        (self.squared_weight() * self.distance()) as u32
+        (self.squared_weight() * f64::from(self.distance_cm)) as u32
     }
 
     /// The running average road-class weight (numerator / denominator).
@@ -51,25 +58,20 @@ impl WeightAndDistance {
         (self.weight() as f64).powi(2)
     }
 
+    /// The cumulative distance travelled.
     #[inline]
-    const fn distance(&self) -> f64 {
-        self.distance as f64
-    }
-
-    /// The cumulative distance travelled, in centimeters.
-    #[inline]
-    pub const fn distance_cm(&self) -> u32 {
-        self.distance
+    pub fn distance(&self) -> Length {
+        Length::new::<centimeter>(f64::from(self.distance_cm))
     }
 
     /// Constructs the cost of a single edge of the given road-class `weight`
-    /// and `distance` (in centimeters).
+    /// and `distance`.
     #[inline]
-    pub const fn new(weight: Weight, distance: u32) -> Self {
+    pub fn new(weight: Weight, distance: Length) -> Self {
         Self {
             numerator: weight,
             denominator: 1,
-            distance,
+            distance_cm: distance.get::<centimeter>() as u32,
         }
     }
 }
@@ -101,7 +103,7 @@ impl Add<Self> for WeightAndDistance {
         WeightAndDistance {
             numerator: self.numerator + rhs.numerator,
             denominator: self.denominator + rhs.denominator,
-            distance: self.distance + rhs.distance,
+            distance_cm: self.distance_cm + rhs.distance_cm,
         }
     }
 }
@@ -111,7 +113,7 @@ impl Zero for WeightAndDistance {
         WeightAndDistance {
             numerator: 0,
             denominator: 0,
-            distance: 0,
+            distance_cm: 0,
         }
     }
 

--- a/libs/routers_transition/src/weigh/all_compute.rs
+++ b/libs/routers_transition/src/weigh/all_compute.rs
@@ -36,6 +36,9 @@ impl<N> AllCompute<N>
 where
     N: Network,
 {
+    /// Weigh against `cache`, adopting its `reach_distance`. To weigh at a
+    /// different reach, pass a cache built by
+    /// `PredicateCache::with_reach_distance`.
     pub fn use_cache(self, cache: Arc<PredicateCache<N>>) -> Self {
         Self {
             predicate: cache,

--- a/libs/routers_transition/src/weigh/mod.rs
+++ b/libs/routers_transition/src/weigh/mod.rs
@@ -36,7 +36,9 @@ pub trait Weigher<N>
 where
     N: Network,
 {
-    /// The predicate cache backing this weigher's reachability queries.
+    /// The predicate cache backing this weigher's reachability queries. Its
+    /// `reach_distance` is how far a query searches from a candidate before
+    /// giving up.
     fn cache(&self) -> &PredicateCache<N>;
 
     /// Which next-layer candidates to weigh for `source`, as positions within

--- a/libs/routers_transition/src/weigh/selective.rs
+++ b/libs/routers_transition/src/weigh/selective.rs
@@ -45,6 +45,9 @@ impl<N> Selective<N>
 where
     N: Network,
 {
+    /// Weigh against `cache`, adopting its `reach_distance`. To weigh at a
+    /// different reach, pass a cache built by
+    /// `PredicateCache::with_reach_distance`.
     pub fn use_cache(self, cache: Arc<PredicateCache<N>>) -> Self {
         Self {
             predicate: cache,

--- a/libs/routers_transition/src/weigh/variant.rs
+++ b/libs/routers_transition/src/weigh/variant.rs
@@ -30,13 +30,11 @@ pub enum SolverVariant {
 }
 
 impl SolverVariant {
-    pub(crate) fn without_cache<N: Network>(self) -> WeigherImpl<N> {
-        match self {
-            SolverVariant::Selective => WeigherImpl::Selective(Selective::default()),
-            _ => WeigherImpl::AllCompute(AllCompute::default()),
-        }
-    }
-
+    /// The chosen weigher over `cache`, adopting its `reach_distance`.
+    ///
+    /// Every variant takes a cache — a weigher always has one, so there is no
+    /// cacheless form to pick between. Callers with none of their own pass a
+    /// fresh [`PredicateCache`] aimed at the reach they want.
     pub(crate) fn instance<N: Network>(self, cache: Arc<PredicateCache<N>>) -> WeigherImpl<N> {
         match self {
             SolverVariant::Selective => {

--- a/libs/routers_transition/tests/matching.rs
+++ b/libs/routers_transition/tests/matching.rs
@@ -1,11 +1,17 @@
 //! End-to-end map-matching tests over the `routers_network` `MockNetwork`
 //! harness (enabled via its `testing` feature).
 
+extern crate alloc;
+
+use alloc::sync::Arc;
 use geo::{LineString, point, wkt};
 use routers_network::mock::{MockMetadata, MockNetwork, MockNetworkBuilder};
 use routers_network::{DataPlane, Direction, Metadata};
+use routers_transition::primitives::PredicateCache;
 use routers_transition::weigh::SolverVariant;
 use routers_transition::{Match, MatchOptions, MatchSimpleExt};
+use uom::si::f64::Length;
+use uom::si::length::meter;
 
 /// Tiny straight road: 1 -> 2 -> 3 along lat = 34.15.
 fn straight_road() -> MockNetwork {
@@ -403,4 +409,102 @@ fn mock_metadata_accessible() {
     let meta = MockMetadata;
     assert!(meta.accessible(&(), Direction::Outgoing));
     assert!(meta.accessible(&(), Direction::Incoming));
+}
+
+// ── Reach distance ────────────────────────────────────────────────────────────
+
+/// A straight road of six ~920 m edges, so consecutive nodes are far enough
+/// apart that the reach distance decides whether the ends can be linked.
+fn long_road() -> MockNetwork {
+    MockNetworkBuilder::new()
+        .node(1, point!(x: -118.10, y: 34.15))
+        .node(2, point!(x: -118.11, y: 34.15))
+        .node(3, point!(x: -118.12, y: 34.15))
+        .node(4, point!(x: -118.13, y: 34.15))
+        .node(5, point!(x: -118.14, y: 34.15))
+        .node(6, point!(x: -118.15, y: 34.15))
+        .node(7, point!(x: -118.16, y: 34.15))
+        .edge(1, 2)
+        .edge(2, 3)
+        .edge(3, 4)
+        .edge(4, 5)
+        .edge(5, 6)
+        .edge(6, 7)
+        .build()
+}
+
+/// The two ends of [`long_road`], ~5.5 km apart along the road.
+fn long_road_ends() -> LineString {
+    wkt! { LINESTRING(-118.101 34.1503, -118.159 34.1503) }
+}
+
+/// The nodes of the interpolated path, or `None` if the match did not resolve.
+fn interpolated_nodes(net: &MockNetwork, opts: MatchOptions<MockNetwork>) -> Option<Vec<i64>> {
+    net.r#match(long_road_ends(), opts).ok().map(|result| {
+        result
+            .interpolated
+            .elements
+            .iter()
+            .flat_map(|e| [e.edge.source.id.0, e.edge.target.id.0])
+            .collect()
+    })
+}
+
+/// Options matching against a cache built at `reach`.
+fn reaching(reach: Length) -> MatchOptions<MockNetwork> {
+    MatchOptions::new().with_cache(Arc::new(PredicateCache::with_reach_distance(reach)))
+}
+
+/// `metres` as a [`Length`], for brevity at the call sites below.
+fn m(metres: f64) -> Length {
+    Length::new::<meter>(metres)
+}
+
+/// The reach must actually bound the search: a span the reach does not cover
+/// cannot be linked, and the same span becomes linkable once it does.
+#[test]
+fn reach_distance_bounds_the_search() {
+    let net = long_road();
+
+    assert!(
+        interpolated_nodes(&net, reaching(m(1_000.0))).is_none(),
+        "a 1km reach must not bridge a 5.5km span"
+    );
+
+    let far = interpolated_nodes(&net, reaching(m(8_000.0)))
+        .expect("an 8km reach must bridge a 5.5km span");
+    for node in 1..=7 {
+        assert!(
+            far.contains(&node),
+            "node {node} must appear in the interpolated path once the reach covers the span"
+        );
+    }
+}
+
+/// No cache means a fresh one at the 2km default — not enough for a 5.5km span.
+#[test]
+fn no_cache_matches_at_the_default_reach() {
+    let net = long_road();
+
+    assert_eq!(
+        interpolated_nodes(&net, MatchOptions::new()),
+        interpolated_nodes(&net, reaching(m(2_000.0))),
+        "an absent cache must behave as one built at the default reach"
+    );
+}
+
+/// A shared cache must stay warm and give the same answer on every match, so
+/// long as the reach it was built at is the one being used.
+#[test]
+fn shared_cache_is_reused_across_matches() {
+    let net = long_road();
+    let cache = Arc::new(PredicateCache::<MockNetwork>::with_reach_distance(m(
+        8_000.0,
+    )));
+
+    let first = interpolated_nodes(&net, MatchOptions::new().with_cache(Arc::clone(&cache)));
+    let second = interpolated_nodes(&net, MatchOptions::new().with_cache(Arc::clone(&cache)));
+
+    assert!(first.is_some(), "8km reach must bridge 5.5km");
+    assert_eq!(first, second, "a warm cache changed the answer");
 }

--- a/schema/proto/routers/api/match/v1/definition.proto
+++ b/schema/proto/routers/api/match/v1/definition.proto
@@ -18,6 +18,12 @@ message MatchRequest {
 
   // Configurable options to dictate the costing functions
   model.v1.CostOptions options = 4;
+
+  // How far (in m of road distance, not straight-line) the router searches out
+  // from one matched position to find the next. Positions at or beyond this
+  // distance along the road cannot be linked, and the match breaks there.
+  // The default value is 2000 meters.
+  optional double reach_distance = 5;
 }
 
 message MatchResponse {


### PR DESCRIPTION
The bounded Dijkstra's reach was a private const, `DEFAULT_THRESHOLD`, set to 200,000cm (2km), so callers could not widen it for sparse traces or narrow it for speed. This unlocks that use-case.