### PR TITLE
Remove historian from auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -99,8 +99,6 @@ jobs:
             file: infrastructure/orchestrator/Dockerfile
           - name: matcher
             file: infrastructure/matcher/Dockerfile
-          - name: historian
-            file: infrastructure/historian/Dockerfile
           - name: timezone
             file: infrastructure/timezone/Dockerfile
       fail-fast: true


### PR DESCRIPTION
Removes the historian service from the auto-release workflow matrix.

The historian service no longer needs to participate in the automated release process. This change simplifies the auto-release configuration by removing the corresponding Dockerfile entry from the build matrix.